### PR TITLE
Proposed removal of unformatted "Important APIs"

### DIFF
--- a/windows-apps-src/devices-sensors/device-information-properties.md
+++ b/windows-apps-src/devices-sensors/device-information-properties.md
@@ -14,11 +14,6 @@ keywords: windows 10, uwp
 
 \[ Updated for UWP apps on Windows 10. For Windows 8.x articles, see the [archive](http://go.microsoft.com/fwlink/p/?linkid=619132) \]
 
-
-** Important APIs **
-
--   [**Windows.Devices.Enumeration**](https://msdn.microsoft.com/library/windows/apps/BR225459)
-
 Each device has associated [**DeviceInformation**](https://msdn.microsoft.com/library/windows/apps/BR225393) properties that you can use when you need specific information or when you are building a device selector. These properties can be specified an AQS filter to limit the devices that you are enumerating over in order to find the devices with the specified traits. You can also use these properties to indicate what information you want returned for each device. That enables you to specify the device information that is returned to your application.
 
 For more information about using [**DeviceInformation**](https://msdn.microsoft.com/library/windows/apps/BR225393) properties in your device selector, see [Build a device selector](build-a-device-selector.md). This topic goes into how to request information properties and also lists some common properties and their purpose.


### PR DESCRIPTION
There's a weak link of what's in this list to the page its on, seems cleaner to just remove it (especially given it's not styled correctly).

Screenshot:
![image](https://cloud.githubusercontent.com/assets/475132/22955194/a64874b0-f2cf-11e6-81c6-b77407a50c80.png)
