### PR TITLE
Fixes to errors and missing samples on manage-app-submissions page:

### DIFF
--- a/windows-apps-src/monetize/manage-app-submissions.md
+++ b/windows-apps-src/monetize/manage-app-submissions.md
@@ -220,7 +220,7 @@ This resource describes an app submission.
     "marketSpecificPricings": {},
     "sales": [],
     "priceId": "Tier2",
-    "isAdvancedPricingModel": "true"
+    "isAdvancedPricingModel": true
   },
   "visibility": "Public",
   "targetPublishMode": "Manual",
@@ -229,26 +229,37 @@ This resource describes an app submission.
     "en-us": {
       "baseListing": {
         "copyrightAndTrademarkInfo": "",
-        "keywords": [],
+        "keywords": [
+          "epub"
+        ],
         "licenseTerms": "",
         "privacyPolicy": "",
         "supportContact": "",
         "websiteUrl": "",
         "description": "Description",
-        "features": [],
+        "features": [
+          "free ebook reader"
+        ],
         "releaseNotes": "",
         "images": [
           {
             "fileName": "contoso.png",
             "fileStatus": "Uploaded",
             "id": "1152921504672272757",
+            "description": "Main page",
             "imageType": "Screenshot"
           }
         ],
         "recommendedHardware": [],
         "title": "ApiTestApp For Devbox"
       },
-      "platformOverrides": {}
+      "platformOverrides":
+      {
+        "Windows81":
+        {
+          "description": "Ebook reader for Windows 8.1",
+        }
+      }
     }
   },
   "hardwarePreferences": [
@@ -292,7 +303,7 @@ This resource describes an app submission.
   "packageDeliveryOptions": {
     "packageRollout": {
         "isPackageRollout": false,
-        "packageRolloutPercentage": 0,
+        "packageRolloutPercentage": 0.0,
         "packageRolloutStatus": "PackageRolloutNotStarted",
         "fallbackSubmissionId": "0"
     },


### PR DESCRIPTION
These fixes and improvements to the sample data should make it easier to generate proper C# classes for the App submission resource:

```
Pricing resource -> isAdvancedPricingModel
	documentation shows boolean type, but the sample contains string.
Base listing -> keywords and features
	the sample should contain some sample data for these properties
Image resource -> description
	the sample should contain some sample data for this property
Listing resource -> platformOverrides
	the sample should contain some sample data for this property
Package rollout resource -> packageRolloutPercentage
	documentation shows float type, but the sample contains int, should be 0.0
```