### PR TITLE
Add warning about ExtendedExecutionForegroundSession

### DIFF
--- a/windows-apps-src/launch-resume/run-minimized-with-extended-execution.md
+++ b/windows-apps-src/launch-resume/run-minimized-with-extended-execution.md
@@ -1,4 +1,4 @@
----
+ ---
 author: TylerMSFT
 description: Learn how to use extended execution to keep your app running while it is minimized
 title: Run while minimized with extended execution
@@ -19,7 +19,7 @@ When the user minimizes or switches away from an app it is put into a suspended 
 
 There are cases where an app may need to keep running, rather than be suspended, while it is minimized. If an app needs to keep running, either the OS can keep it running, or it can request to keep running. For example, when playing audio in the background, the OS can keep an app running longer if you follow these steps for [Background Media Playback](../audio-video-camera/background-audio.md). Otherwise, you must manually request more time.
 
-Create an [ExtendedExecutionSession](https://msdn.microsoft.com/library/windows/apps/windows.applicationmodel.extendedexecution.extendedexecutionsession.aspx) to request more time to complete an operation in the background. The kind of **ExtendedExecutionSession** you create is determined by the  [ExtendedExecutionReason](https://msdn.microsoft.com/library/windows/apps/windows.applicationmodel.extendedexecution.extendedexecutionreason.aspx) that you provide when you create it. There are three **ExtendedExecutionReason** enum values: **Unspecified, LocationTracking** and **SavingData**.
+Create an [ExtendedExecutionSession](https://msdn.microsoft.com/library/windows/apps/windows.applicationmodel.extendedexecution.extendedexecutionsession.aspx) to request more time to complete an operation in the background. The kind of **ExtendedExecutionSession** you create is determined by the  [ExtendedExecutionReason](https://msdn.microsoft.com/library/windows/apps/windows.applicationmodel.extendedexecution.extendedexecutionreason.aspx) that you provide when you create it. There are three **ExtendedExecutionReason** enum values: **Unspecified, LocationTracking** and **SavingData**. Do not use [ExtendedExecutionForegroundSession](https://msdn.microsoft.com/library/windows/apps/windows.applicationmodel.extendedexecution.foreground.extendedexecutionforegroundsession.aspx) and [ExtendedExecutionForegroundReason](https://msdn.microsoft.com/library/windows/apps/windows.applicationmodel.extendedexecution.foreground.extendedexecutionforegroundreason.aspx), they require restricted capabilities and are not available for use in Store applications.
 
 ## Run while minimized
 


### PR DESCRIPTION
The ExtendedExecutionForegroundSession and ExtendedExecutionForegroundReason are not available for public consumption. Need to update the documentation to let developers be aware of that.