### PR TITLE
Update navigate-between-two-pages.md

### DIFF
--- a/windows-apps-src/layout/navigate-between-two-pages.md
+++ b/windows-apps-src/layout/navigate-between-two-pages.md
@@ -301,7 +301,7 @@ In the Page2.xaml code-behind file, override the `OnNavigatedTo` method with the
 ```csharp
 protected override void OnNavigatedTo(NavigationEventArgs e)
 {
-    if (e.Parameter is string)
+    if (e.Parameter is string && !string.IsNullOrWhiteSpace((string)e.Parameter))
     {
         greeting.Text = "Hi, " + e.Parameter.ToString();
     }


### PR DESCRIPTION
I updated the example showing a name being printed: I think missing this check makes the example strange if someone clicks the HyperlinkButton without entering a string.
If the example is to be used to demonstrate additional checking is needed I think attention should be drawn to that case?