### PR TITLE
Fix typo

### DIFF
--- a/windows-apps-src/style/connected-animation.md
+++ b/windows-apps-src/style/connected-animation.md
@@ -170,7 +170,7 @@ private void ContactsListView_Loaded(object sender, RoutedEventArgs e)
 
 A *coordinated animation* is a special type of entrance animation where an element will appear alongside the connected animation target, animating in tandem with the connected animation element as it moves across the screen. Coordinated animations can add more visual interest to a transition and further draw the user’s attention to the context that is shared between the source and destination views. In these images, the caption UI for the item is animating using a coordinated animation.
 
-Use the two-parameter overload of **TryStart** to add coordinated elements to a connected animation. This example demonstrates a coordinated animation of a Grid layout named “DescriptionRoot” that will enter in tandem with a connected animation element named “ColorImage”.
+Use the two-parameter overload of **TryStart** to add coordinated elements to a connected animation. This example demonstrates a coordinated animation of a Grid layout named “DescriptionRoot” that will enter in tandem with a connected animation element named “CoverImage”.
 
 *DestinationPage.xaml*
 


### PR DESCRIPTION
Just renamed a mispelled variable form 'ColorImage' to 'CoverImage'