### PR TITLE
Added quotes around the Package namespace

### DIFF
--- a/windows-apps-src/porting/desktop-to-uwp-packaging-dot-net.md
+++ b/windows-apps-src/porting/desktop-to-uwp-packaging-dot-net.md
@@ -209,7 +209,7 @@ To execute the Win32 process, use the [**FullTrustProcessLauncher**](https://msd
 
 ```xml
 ..
-xmlns:desktop=http://schemas.microsoft.com/appx/manifest/desktop/windows10
+xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
 ..
 <desktop:Extension Category="windows.fullTrustProcess"
                     Executable="win32\MyDesktopApp.exe" />


### PR DESCRIPTION
Tiny change to fix the namespace declaration so you can just copy and paste.