### PR TITLE
Update sensor-orientation.md

### DIFF
--- a/windows-apps-src/devices-sensors/sensor-orientation.md
+++ b/windows-apps-src/devices-sensors/sensor-orientation.md
@@ -19,7 +19,7 @@ keywords: windows 10, uwp
 -   [**Windows.Devices.Sensors**](https://msdn.microsoft.com/library/windows/apps/BR206408)
 -   [**Windows.Devices.Sensors.Custom**](https://msdn.microsoft.com/library/windows/apps/Dn895032)
 
-Sensor data from the [**Accelerometer**](https://msdn.microsoft.com/library/windows/apps/BR225687), [**Gyrometer**](https://msdn.microsoft.com/library/windows/apps/BR225718), [**Compass**](https://msdn.microsoft.com/library/windows/apps/BR225705), [**Inclinometer**](https://msdn.microsoft.com/library/windows/apps/BR225766), and [**OrientationSensor**](https://msdn.microsoft.com/library/windows/apps/BR206371) classes is defined by their reference axes. These axes are defined by the device's landscape orientation and rotate with the device as the user turns it. If your app supports automatic rotation and reorients itself to accommodate the device as the user rotates it, you must adjust your sensor data for the rotation before using it.
+Sensor data from the [**Accelerometer**](https://msdn.microsoft.com/library/windows/apps/BR225687), [**Gyrometer**](https://msdn.microsoft.com/library/windows/apps/BR225718), [**Compass**](https://msdn.microsoft.com/library/windows/apps/BR225705), [**Inclinometer**](https://msdn.microsoft.com/library/windows/apps/BR225766), and [**OrientationSensor**](https://msdn.microsoft.com/library/windows/apps/BR206371) classes is defined by their reference axes. These axes are defined by the device's reference frame and rotate with the device as the user turns it. If your app supports automatic rotation and reorients itself to accommodate the device as the user rotates it, you must adjust your sensor data for the rotation before using it.
 
 ## Display orientation vs device orientation
 


### PR DESCRIPTION
Fixing a confusing sentence. The sensor axis are not always defined based on landscape orientation of the device. As per explained in our detailed documentation: https://msdn.microsoft.com/en-us/library/windows/hardware/dn642102(v=vs.85).aspx, axis are always related to the device natural orientation. Y will always point up and X to the right when a device is held upstraight in its natural orientation (which typically is landscape for a laptop and portrait for a phone)