### PR TITLE
Enable contributor display for VSTS

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -69,4 +69,5 @@
       "branch": "master"
     }    
   ]
+    "resolve_user_profile_using_github": true
 }


### PR DESCRIPTION
Based on Ted Hudek email re: resolution with VS China on representing profiles for contributions made through VS Git