### PR TITLE
Use a PostBuildEvent target instead of a AfterBuild target

### DIFF
--- a/windows-apps-src/porting/desktop-to-uwp-packaging-dot-net.md
+++ b/windows-apps-src/porting/desktop-to-uwp-packaging-dot-net.md
@@ -55,7 +55,7 @@ If you want to debug your app in the context of the Windows app package applicat
 
 Let's start with Step 1 in the journey.
 
-### Step 1: Package
+ ### Step 1: Package
 
 This step shows how to create a Desktop Bridge app from an existing Win32 project. In this example, we'll use a basic WinForms Project that performs read and write operations on the registry.
 
@@ -73,10 +73,10 @@ To create the Desktop Bridge package, add a JavaScript UWP project to the same s
 
 All the Win32 binaries will be stored in your UWP project in a folder called win32 (though this exact name is not required; you can use any name you like).
 
-If you are using Visual Studio, you can automate the project to copy the files after each build, improving your development workflow. Edit your project file (.csproj in this example) to include an AfterBuild target that will copy all the Win32 output files to the win32 folder in the UWP project as follows:
+If you are using Visual Studio, you can automate the project to copy the files after each successful build, improving your development workflow. Edit your project file (.csproj in this example) to include an AfterBuild target that will copy all the Win32 output files to the win32 folder in the UWP project as follows:
 
 ```xml
-  <Target Name="AfterBuild">
+  <Target Name="PostBuildEvent">
     <PropertyGroup>
       <TargetUWP>..\MyDesktopApp.Package\win32\</TargetUWP>
     </PropertyGroup>

--- a/windows-apps-src/porting/desktop-to-uwp-packaging-dot-net.md
+++ b/windows-apps-src/porting/desktop-to-uwp-packaging-dot-net.md
@@ -21,7 +21,6 @@ To get started, fill out the form at [Bring your existing apps and games to the 
 > Have feedback our encounter issues as you journey along the Desktop Bridge? The best place to make feature suggestions is on the [Windows Developer UserVoice](https://wpdev.uservoice.com/forums/110705-universal-windows-platform/category/161895-desktop-bridge-centennial). For questions and bug reports, please head over to the [Developing Universal Windows apps forums](https://social.msdn.microsoft.com/Forums/home?forum=wpdevelop).
 
 ## Default Universal Windows Platform packages
-
 Visual Studio allows you to generate the debug and release packages that can be distributed using the Windows Store or app sideloading. To facilitate the package creation, Visual Studio helps you creating an. appxupload file ready to be submitted to the store. For more info, see [Packaging UWP Apps](..\packaging\packaging-uwp-apps.md).
 
 ## Desktop Bridge Packages

--- a/windows-apps-src/porting/desktop-to-uwp-packaging-dot-net.md
+++ b/windows-apps-src/porting/desktop-to-uwp-packaging-dot-net.md
@@ -21,6 +21,7 @@ To get started, fill out the form at [Bring your existing apps and games to the 
 > Have feedback our encounter issues as you journey along the Desktop Bridge? The best place to make feature suggestions is on the [Windows Developer UserVoice](https://wpdev.uservoice.com/forums/110705-universal-windows-platform/category/161895-desktop-bridge-centennial). For questions and bug reports, please head over to the [Developing Universal Windows apps forums](https://social.msdn.microsoft.com/Forums/home?forum=wpdevelop).
 
 ## Default Universal Windows Platform packages
+
 Visual Studio allows you to generate the debug and release packages that can be distributed using the Windows Store or app sideloading. To facilitate the package creation, Visual Studio helps you creating an. appxupload file ready to be submitted to the store. For more info, see [Packaging UWP Apps](..\packaging\packaging-uwp-apps.md).
 
 ## Desktop Bridge Packages
@@ -54,7 +55,7 @@ If you want to debug your app in the context of the Windows app package applicat
 
 Let's start with Step 1 in the journey.
 
- ### Step 1: Package
+### Step 1: Package
 
 This step shows how to create a Desktop Bridge app from an existing Win32 project. In this example, we'll use a basic WinForms Project that performs read and write operations on the registry.
 

--- a/windows-apps-src/porting/desktop-to-uwp-packaging-dot-net.md
+++ b/windows-apps-src/porting/desktop-to-uwp-packaging-dot-net.md
@@ -73,7 +73,7 @@ To create the Desktop Bridge package, add a JavaScript UWP project to the same s
 
 All the Win32 binaries will be stored in your UWP project in a folder called win32 (though this exact name is not required; you can use any name you like).
 
-If you are using Visual Studio, you can automate the project to copy the files after each successful build, improving your development workflow. Edit your project file (.csproj in this example) to include an AfterBuild target that will copy all the Win32 output files to the win32 folder in the UWP project as follows:
+If you are using Visual Studio, you can automate the project to copy the files after each successful build, improving your development workflow. Edit your project file (.csproj in this example) to include an PostBuildEvent target that will copy all the Win32 output files to the win32 folder in the UWP project as follows:
 
 ```xml
   <Target Name="PostBuildEvent">


### PR DESCRIPTION
This will make msbuild copy the files only if the build succeeds. (After all you don't want to either copy your old build or a failed/partial build to your converter package)