### PR TITLE
Update DimissExtendedSplash method

### DIFF
--- a/windows-apps-src/launch-resume/create-a-customized-splash-screen.md
+++ b/windows-apps-src/launch-resume/create-a-customized-splash-screen.md
@@ -187,14 +187,14 @@ Use these steps to define methods to correctly display your extended splash scre
     After app setup is complete, navigate away from your extended splash screen. The following code defines a method called `DismissExtendedSplash` that navigates to the `MainPage` defined in your app's MainPage.xaml file.
 
     ```cs
-    void DismissExtendedSplash()
-    {
-        // Navigate to mainpage
-        rootFrame.Navigate(typeof(MainPage));
-        // Place the frame in the current Window
-        Window.Current.Content = rootFrame;
-    }
-    ```
+    async void DismissExtendedSplash()
+      {
+         await Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal,() =>            {
+              rootFrame = new Frame();
+              rootFrame.Content = new MainPage(); Window.Current.Content = rootFrame;
+            });
+      }
+      ```
 
 7.  **Inside the class, define a handler for Window.SizeChanged events**
 


### PR DESCRIPTION
Currently, an error will occur in that method saying that the code is running on a thread it's not supposed to run on. This error occurs when calling the method inside DismissedEventHandler. Using the core dispatcher eliminates the issue.