### PR TITLE
Add target sdk for SupportsMultipleInstances

### DIFF
--- a/windows-apps-src/launch-resume/declare-background-tasks-in-the-application-manifest.md
+++ b/windows-apps-src/launch-resume/declare-background-tasks-in-the-application-manifest.md
@@ -208,7 +208,7 @@ Here is example XML that declares a background task that runs in a BackgroundTas
 
 ### Run in a new process each time a trigger fires with the SupportsMultipleInstances attribute
 
-This example declares a background task that runs in a new process that gets its own resource limits (memory and CPU) every time a new trigger is fired. Note the use of `SupportsMultipleInstances` which enables this behavior.
+This example declares a background task that runs in a new process that gets its own resource limits (memory and CPU) every time a new trigger is fired. Note the use of `SupportsMultipleInstances` which enables this behavior. In order to use this attribute you must target SDK version '10.0.15063' (**Windows 10 Creator's Update**) or higher.
 
 ```xml
 <Package

--- a/windows-apps-src/launch-resume/declare-background-tasks-in-the-application-manifest.md
+++ b/windows-apps-src/launch-resume/declare-background-tasks-in-the-application-manifest.md
@@ -208,7 +208,7 @@ Here is example XML that declares a background task that runs in a BackgroundTas
 
 ### Run in a new process each time a trigger fires with the SupportsMultipleInstances attribute
 
-This example declares a background task that runs in a new process that gets its own resource limits (memory and CPU) every time a new trigger is fired. Note the use of `SupportsMultipleInstances` which enables this behavior. In order to use this attribute you must target SDK version '10.0.15063' (**Windows 10 Creator's Update**) or higher.
+This example declares a background task that runs in a new process that gets its own resource limits (memory and CPU) every time a new trigger is fired. Note the use of `SupportsMultipleInstances` which enables this behavior. In order to use this attribute you must target SDK version '10.0.15063' (Windows 10 Creator's Update) or higher.
 
 ```xml
 <Package


### PR DESCRIPTION
Added the correct SDK needed to support SupportsMultipleInstances so people targeting lower don't accidentally try to use it and find it doesn't work.