### PR TITLE
Fix typo in c# example

### DIFF
--- a/windows-apps-src/porting/desktop-to-uwp-enhance.md
+++ b/windows-apps-src/porting/desktop-to-uwp-enhance.md
@@ -107,7 +107,7 @@ Here's the code that you'd use to show the notification window that we looked at
 using Windows.Foundation;
 using Windows.System;
 using Windows.UI.Notifications;
-using Windows.Data.Xml::Dom;
+using Windows.Data.Xml.Dom;
 ...
 
 private void ShowToast()


### PR DESCRIPTION
should be Windows.Data.Xml.Dom not using Windows.Data.Xml::Dom