### PR TITLE
Add lock screen ability to Location Tracking EE

### DIFF
--- a/windows-apps-src/launch-resume/run-minimized-with-extended-execution.md
+++ b/windows-apps-src/launch-resume/run-minimized-with-extended-execution.md
@@ -33,7 +33,7 @@ On all OS editions this kind of extended execution session stops when the device
 
 Specify **ExtendedExecutionReason.LocationTracking** when you create an **ExtendedExecutionSession** if your app needs to regularly log the location from the [GeoLocator](https://msdn.microsoft.com/library/windows/apps/windows.devices.geolocation.geolocator.aspx). Apps for fitness tracking and navigation that need to regularly monitor the user's location and should use this reason.
 
-A location tracking extended execution session can run as long as needed. However, there can only be one such session running per device. A location tracking extended execution session can only be requested in the foreground, and the app must be in the **Running** state. This ensures that the user is aware that the app has initiated an extended location tracking session. It is still possible to use the GeoLocator while the app is in the background by using a background task, or an app service, without requesting a location tracking extended execution session.
+A location tracking extended execution session can run as long as needed, including while the screen is locked on a mobile device. However, there can only be one such session running per device. A location tracking extended execution session can only be requested in the foreground, and the app must be in the **Running** state. This ensures that the user is aware that the app has initiated an extended location tracking session. It is still possible to use the GeoLocator while the app is in the background by using a background task, or an app service, without requesting a location tracking extended execution session.
 
 ## Save Critical Data Locally
 


### PR DESCRIPTION
Location Tracking EE is capable of running indefinitely under the lock screen. This should be identified in the documentation.