### PR TITLE
ASLR test listed as only being performed on apps written in managed code

### DIFF
--- a/windows-apps-src/debug-test-perf/windows-app-certification-kit-tests.md
+++ b/windows-apps-src/debug-test-perf/windows-app-certification-kit-tests.md
@@ -216,7 +216,7 @@ Enable the /DYNAMICBASE option in the linker command when you build your app. Ve
 
 Normally, ASLR doesn't affect performance. But in some scenarios there is a slight performance improvement on 32-bit systems. It is possible that performance could degrade in a highly congested system that have many images loaded in many different memory locations.
 
-This test is performed on only apps written in managed code, such as by using C# or .NET Framework.
+This test is performed only on apps written in unmanaged languages, such as by using C or C++.
 
 ### <span id="binscope-5"></span>Read/Write Shared PE Section
 


### PR DESCRIPTION
...which makes no sense. This PR changes the text to say that it's performed only on apps written in unmanaged languages, which seems to be what was initially meant, given that the /DYNAMICBASE linker option is referred to.