### PR TITLE
Added Applies To section

### DIFF
--- a/windows-apps-src/controls-and-patterns/tiles-and-notifications-adaptive-tiles-schema.md
+++ b/windows-apps-src/controls-and-patterns/tiles-and-notifications-adaptive-tiles-schema.md
@@ -135,6 +135,11 @@ textStyle values: caption captionSubtle body bodySubtle base baseSubtle subtitle
 </subgroup>
 ```
 
+## Applies to
+
+Windows 10
+Windows 10 Mobile
+
 ## Related topics
 
 


### PR DESCRIPTION
Along this entire series of articles, the person who wrote them failed to mention that 99% of these so-called "windows universal" features are **valid only for Windows 10, not Windows Phone 8.1**. The W10 universe is definitely separated from the WP8.1 one, like the Marvel multiverses.