### PR TITLE
Fix bug of using a private isCtrlKeyPressed

### DIFF
--- a/windows-apps-src/input-and-devices/keyboard-events.md
+++ b/windows-apps-src/input-and-devices/keyboard-events.md
@@ -176,6 +176,12 @@ void KeyboardSupport::MainPage::MediaButton_Click(Platform::Object^ sender, Wind
 }
 
 
+bool KeyboardSupport::MainPage::IsCtrlKeyPressed()
+{
+    var ctrlState = CoreWindow::GetForCurrentThread().GetKeyState(VirtualKey::Control);
+    return (ctrlState & CoreVirtualKeyStates::Down) == CoreVirtualKeyStates::Down;
+}
+
 void KeyboardSupport::MainPage::Grid_KeyDown(Platform::Object^ sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs^ e)
 {
     if (e->Key == VirtualKey::Control) isCtrlKeyPressed = true;
@@ -184,13 +190,10 @@ void KeyboardSupport::MainPage::Grid_KeyDown(Platform::Object^ sender, Windows::
 
 void KeyboardSupport::MainPage::Grid_KeyUp(Platform::Object^ sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs^ e)
 {
-    if (e->Key == VirtualKey::Control) isCtrlKeyPressed = false;
-    else if (isCtrlKeyPressed) {
-        if (e->Key==VirtualKey::P) {
-            DemoMovie->Play();
-        }
-        if (e->Key==VirtualKey::A) {DemoMovie->Pause();}
-        if (e->Key==VirtualKey::S) {DemoMovie->Stop();}
+    if (IsCtrlKeyPressed()) {
+        if (e->Key==VirtualKey::P) { DemoMovie->Play(); }
+        if (e->Key==VirtualKey::A) { DemoMovie->Pause(); }
+        if (e->Key==VirtualKey::S) { DemoMovie->Stop(); }
     }
 }
 ```
@@ -212,15 +215,15 @@ private void MediaButton_Click(object sender, RoutedEventArgs e)
     }
 }
 
-private void Grid_KeyUp(object sender, KeyRoutedEventArgs e)
+private static bool IsCtrlKeyPressed()
 {
-    if (e.Key == VirtualKey.Control) isCtrlKeyPressed = false;
+    var ctrlState = CoreWindow.GetForCurrentThread().GetKeyState(VirtualKey.Control);
+    return (ctrlState & CoreVirtualKeyStates.Down) == CoreVirtualKeyStates.Down;
 }
 
 private void Grid_KeyDown(object sender, KeyRoutedEventArgs e)
 {
-    if (e.Key == VirtualKey.Control) isCtrlKeyPressed = true;
-    else if (isCtrlKeyPressed)
+    if (IsCtrlKeyPressed())
     {
         switch (e.Key)
         {
@@ -238,15 +241,13 @@ Protected Overrides Sub OnNavigatedTo(e As Navigation.NavigationEventArgs)
 
 End Sub
 
-Private Sub Grid_KeyUp(sender As Object, e As KeyRoutedEventArgs)
-    If e.Key = Windows.System.VirtualKey.Control Then
-        isCtrlKeyPressed = False
-    End If
-End Sub
+Private Function IsCtrlKeyPressed As Boolean
+    Dim ctrlState As CoreVirtualKeyStates = CoreWindow.GetForCurrentThread().GetKeyState(VirtualKey.Control);
+    Return (ctrlState & CoreVirtualKeyStates.Down) == CoreVirtualKeyStates.Down;
+End Function
 
 Private Sub Grid_KeyDown(sender As Object, e As KeyRoutedEventArgs)
-    If e.Key = Windows.System.VirtualKey.Control Then isCtrlKeyPressed = True
-    If isCtrlKeyPressed Then
+    If IsCtrlKeyPressed() Then
         Select Case e.Key
             Case Windows.System.VirtualKey.P
                 DemoMovie.Play()


### PR DESCRIPTION
Using isCtrlKeyPressed and KeyUp/Down events to track CTRL key state is wrong since it does nto cover case when user presses CTRL and without releasing it switches to another app, then releases CTRL and then returns back to our app. In this case with isCtrlKeyPressed will wrongly contain true and pressing A, P, S without any modifiers will trigger actions. Also, KeyUp is not wired in the example so CTRL will be forever stuck once pressed. The correct solution is to determine modifier key being pressed when a target key (A, S, P) is pressed by using CoreWindow.GetForCurrentThread().GetKeyState.

C# code is correct in my change. However C++ and especially VB.NET parts may be not compilable - please check and correct if needed.