### PR TITLE
Fix confusing typo

### DIFF
--- a/windows-apps-src/get-started/universal-application-platform-guide.md
+++ b/windows-apps-src/get-started/universal-application-platform-guide.md
@@ -202,7 +202,7 @@ The API documentation also tells you which device family an API is part of. If y
 
 **Calling an API that's NOT implemented by your target device family**
 
-There will be cases when you want to call an API in an extension SDK that you've referenced, but that API is not part of the device family you are targeting. For example, you may be targeting the universal device family, but have a desktop API that you'd like to use if the app happens to be running on a mobile device. In that case, you can opt to write adaptive code in order to call that API.
+There will be cases when you want to call an API in an extension SDK that you've referenced, but that API is not part of the device family you are targeting. For example, you may be targeting the universal device family, but have a desktop API that you'd like to use if the app happens to be running on a desktop device. In that case, you can opt to write adaptive code in order to call that API.
 
 **Writing adaptive code with the ApiInformation class**
 


### PR DESCRIPTION
It makes no sense to call a desktop-only API when running on a mobile device. Should be "... running on a desktop device."