### PR TITLE
Updated WebSock_SendMessage to match the C++ snippet

### DIFF
--- a/windows-apps-src/networking/websockets.md
+++ b/windows-apps-src/networking/websockets.md
@@ -223,6 +223,7 @@ The following function sends the given string to a connected WebSocket, and prin
 >    DataWriter messageWriter = new DataWriter(webSock.OutputStream);
 >    messageWriter.WriteString(message);
 >    await messageWriter.StoreAsync();
+>    messageWriter.DetachStream();
 >}
 >```
 


### PR DESCRIPTION
The C# implementation of the method for sending messages was not detaching the stream after sending the message, while the C++ version was doing it.