### PR TITLE
Broken Link - UWP for TV and Xbox

### DIFF
--- a/windows-apps-src/gaming/e2e.md
+++ b/windows-apps-src/gaming/e2e.md
@@ -1043,7 +1043,7 @@ Separately from UX design, gameplay design such as level design, pacing, world d
     </tr>
     <tr>
         <td>Design your UWP app for Xbox One and television screens</td>
-        <td>[Designing for Xbox and TV](https://docs.microsoft.com/windows/uwp/input/designing-for-tv)</td>
+        <td>[Designing for Xbox and TV](https://docs.microsoft.com/windows/uwp/design/devices/designing-for-tv)</td>
     </tr>
     <tr>
         <td>Targeting multiple device form factors (video)</td>


### PR DESCRIPTION
Corrected UWP for Xbox One and TV link

Old link: https://do​cs.microso​ft.com/win​dows/uwp/i​nput/desig​ning-for-t​v
New link (proposed): https://docs.microsoft.com/windows/uwp/design/devices/designing-for-tv