### PR TITLE
Updated "Graphics Tools" install instructions for Windows 10 1703

### DIFF
--- a/windows-apps-src/gaming/use-the-directx-runtime-and-visual-studio-graphics-diagnostic-features.md
+++ b/windows-apps-src/gaming/use-the-directx-runtime-and-visual-studio-graphics-diagnostic-features.md
@@ -18,7 +18,7 @@ localizationpriority: medium
 
 With Windows 10, the graphics diagnostic tools are now available from within Windows as an optional feature. To use the graphics diagnostic features provided in the runtime and Visual Studio to develop DirectX apps or games, install the optional Graphics Tools feature:
 
-1.  Go to **Settings**, select **System**, select **Apps & Features**, and then click **Manage optional features**.
+1.  Go to **Settings**, select **Apps**, and then click **Manage optional features**.
 2.  Click **Add a feature**   
 3.  In the **Optional features** list, select **Graphics Tools** and then click **Install**.
 


### PR DESCRIPTION
It seems these instructions no longer reflect recent versions of Windows. This change updates them to reality for Windows 10 1703.