### PR TITLE
fix typo

### DIFF
--- a/windows-apps-src/xaml-platform/x-defaultbindmode-attribute.md
+++ b/windows-apps-src/xaml-platform/x-defaultbindmode-attribute.md
@@ -25,7 +25,7 @@ In XAML markup, specifies a default mode for x:Bind.
 
 ## Remarks
 
-x:Bind has a default mode of OneTime, and this was chosen for performance reasons as using OneTime will cause more code to be generated to hookup and handle the change detection. **x:DefaultBindMode** can be used to change the default mode for x:Bind for a specific segment of the markup tree. The mode selected will apply any x:Bind expressions on that element and its children, that do not explicitly specify a mode as part of the binding.
+x:Bind has a default mode of OneTime, and this was chosen for performance reasons as using OneWay will cause more code to be generated to hookup and handle the change detection. **x:DefaultBindMode** can be used to change the default mode for x:Bind for a specific segment of the markup tree. The mode selected will apply any x:Bind expressions on that element and its children, that do not explicitly specify a mode as part of the binding.
 
 ## Related topics
 


### PR DESCRIPTION
this should've been OneWay instead of OneTime. The default is OneTime *because* it generates less code and OneWay causes more to be generated