### PR TITLE
Fixed typo in CleanUp method (remove/add handler)

### DIFF
--- a/windows-apps-src/audio-video-camera/code/MIDIWin10/cs/MainPage.xaml.cs
+++ b/windows-apps-src/audio-video-camera/code/MIDIWin10/cs/MainPage.xaml.cs
@@ -214,7 +214,7 @@ namespace MIDIWin10
             outputDeviceWatcher.StopWatcher();
             outputDeviceWatcher = null;
 
-            midiInPort.MessageReceived += MidiInPort_MessageReceived;
+            midiInPort.MessageReceived -= MidiInPort_MessageReceived;
             midiInPort.Dispose();
             midiInPort = null;
 


### PR DESCRIPTION
The cleanup method adds an event handler instead of removing it. Fixed this.