### PR TITLE
Update auto-build-package-uwp-apps.md

### DIFF
--- a/windows-apps-src/packaging/auto-build-package-uwp-apps.md
+++ b/windows-apps-src/packaging/auto-build-package-uwp-apps.md
@@ -165,10 +165,16 @@ To execute a unit test, use the Visual Studio Test build step.
 
 ![add unit tests](images/building-screen8.png)
 
-UWP unit tests are executed in the context of a given appx file so you can’t use the generated bundle. Also, you’ll have to specify the path to a concrete platform appx file. For example:
+UWP unit tests are executed in the context of a given appxrecipe file so you can’t use the generated bundle. Also, you’ll have to specify the path to a concrete platform appxrecipe file. For example:
 
 ```
-$(Build.ArtifactStagingDirectory)\AppxPackages\MyUWPApp.UnitTest\x86\MyUWPApp.UnitTest_$(AppxVersion)_x86.appx
+$(Build.ArtifactStagingDirectory)\AppxPackages\MyUWPApp.UnitTest\x86\MyUWPApp.UnitTest_$(AppxVersion)_x86.appxrecipe
+```
+
+In order for the tests to run a console parameter will have to be added to vstest.console.exe. This parameter can be provide through: **Execution Options => Other console options**. Please add following parameter: 
+
+```
+/framework:FrameworkUap10
 ```
 
 >Note: Use the following command to execute the unit tests locally from the command line:


### PR DESCRIPTION
Recently I used VSTS for setting up CI for an UWP app, according to the docs an appx file has to be used for setting up automated testing on the build but from my recent experience an .appxrecipe is required. Also in the "other console options" the parameter /framework:FrameworkUap10 had to be added to make the tests run. If you'd like build logs from this configuration, I'd be happy to provide.