### PR TITLE
Edit sample code for FillTreeNode on TreeView Class page. 

### DIFF
--- a/windows-apps-src/design/controls-and-patterns/tree-view.md
+++ b/windows-apps-src/design/controls-and-patterns/tree-view.md
@@ -453,7 +453,7 @@ private async void FillTreeNode(TreeViewNode node)
     foreach (var item in itemsList)
     {
         var newNode = new TreeViewNode();
-        newNode.Content = item;
+        newNode.Content = item.Name;
 
         if (item is StorageFolder)
         {


### PR DESCRIPTION
Edited sample code for FillTreeNode so that items in the node will show the StorageFile/Folder's name vs just "Windows.Storage.StorageFile" type. 