### PR TITLE
Fix typo in the "Writing style" guidelines

### DIFF
--- a/windows-apps-src/design/style/writing-style.md
+++ b/windows-apps-src/design/style/writing-style.md
@@ -100,7 +100,7 @@ Abbreviations can be useful when you need to refer to products, places, or techn
 
 * Don't use abbreviations that are too similar to one another.
 
-> The Universal Windows Playform (UWP) design guidance is a resource to help you design and build beautiful, polished apps. With the design features that are included in every UWP app, you can build user interfaces (UI) that scale across a range of devices.
+> The Universal Windows Platform (UWP) design guidance is a resource to help you design and build beautiful, polished apps. With the design features that are included in every UWP app, you can build user interfaces (UI) that scale across a range of devices.
 
 ### Contractions
 


### PR DESCRIPTION
Under the Abbreviations section of the Writing style guidelines, change "Universal Windows Playform (UWP)" to "Universal Windows Platform (UWP)".