### PR TITLE
Make the path bold work

### DIFF
--- a/windows-apps-src/porting/desktop-to-uwp-test-windows-s.md
+++ b/windows-apps-src/porting/desktop-to-uwp-test-windows-s.md
@@ -74,7 +74,7 @@ We recommend that you apply these policies to a virtual machine because these po
 
 If you want to apply these policies to your local machine, it's best to start with the Audit mode policy. With this policy, you can review the Code Integrity Event Logs to ensure that nothing critical would be blocked in an enforced policy.
 
-When you're ready to apply a policy, find the .P7B file for the policy that you chose, rename it to **SIPolicy.P7B**, and then save that file to this location on your system: **C:\Windows\System32\CodeIntegrity\**.
+When you're ready to apply a policy, find the .P7B file for the policy that you chose, rename it to **SIPolicy.P7B**, and then save that file to this location on your system: **C:\Windows\System32\CodeIntegrity\\**.
 
 Then, restart your system.
 


### PR DESCRIPTION
\*\*C:\\Windows\\System32\\CodeIntegrity\\\*\*, 
the * follows the "\\" will be escaped, the final "\\" should be "\\\\".