### PR TITLE
UWP Community Toolkit is now Windows Community Toolkit

### DIFF
--- a/windows-apps-src/get-started/index.md
+++ b/windows-apps-src/get-started/index.md
@@ -214,7 +214,7 @@ Build apps that work on all Windows 10 devices, or enhance your existing apps wi
                 <div class="card">
                     <div class="cardText">
                         <h3>Developer tools</h3>
-                        <p><a href="//docs.microsoft.com/windows/uwpcommunitytoolkit/">UWP Community Toolkit</a></p>
+                        <p><a href="//docs.microsoft.com/windows/uwpcommunitytoolkit/">Windows Community Toolkit</a></p>
                         <p><a href="//developer.microsoft.com/windows/downloads/virtual-machines">Virtual machines</a></p>
                         <p><a href="//docs.microsoft.com/windows/wsl/about">Bash on Ubuntu on Windows</a></p>
                         </div>

--- a/windows-apps-src/index.md
+++ b/windows-apps-src/index.md
@@ -114,7 +114,7 @@ The Universal Windows Platform (UWP) lets you build apps for any Windows deviceâ
                             <a href="packaging/index.md">Packaging apps</a>
                         </p>
                         <p>
-                            <a href="//docs.microsoft.com/windows/uwpcommunitytoolkit/">UWP Community Toolkit</a>
+                            <a href="//docs.microsoft.com/windows/uwpcommunitytoolkit/">Windows Community Toolkit</a>
                         </p>
                         <p>
                             <a href="porting/index.md">Porting apps to Windows 10</a>


### PR DESCRIPTION
The UWP Community Toolkit has been renamed to Windows Community Toolkit.