### PR TITLE
Update CameraRotationHelper to new spec

### DIFF
--- a/windows-apps-src/audio-video-camera/code/SimpleCameraPreview_Win10/cs/CameraRotationHelper.cs
+++ b/windows-apps-src/audio-video-camera/code/SimpleCameraPreview_Win10/cs/CameraRotationHelper.cs
@@ -67,17 +67,7 @@ namespace SimpleCameraPreview_Win10
         private SimpleOrientation GetCameraOrientationRelativeToNativeOrientation()
         {
             // Get the rotation angle of the camera enclosure
-            var enclosureAngle = ConvertClockwiseDegreesToSimpleOrientation((int)_cameraEnclosureLocation.RotationAngleInDegreesClockwise);
-
-            // Account for the fact that, on portrait-first devices, the built in camera sensor is read at a 90 degree offset to the native orientation
-            if (_displayInformation.NativeOrientation == DisplayOrientations.Portrait && !IsEnclosureLocationExternal(_cameraEnclosureLocation))
-            {
-                return AddOrientations(SimpleOrientation.Rotated90DegreesCounterclockwise, enclosureAngle);
-            }
-            else
-            {
-                return AddOrientations(SimpleOrientation.NotRotated, enclosureAngle);
-            }
+            return ConvertClockwiseDegreesToSimpleOrientation((int)_cameraEnclosureLocation.RotationAngleInDegreesClockwise);
         }
 
         // Gets the rotation to rotate ui elements


### PR DESCRIPTION
Update GetCameraOrientationRelativeToNativeOrientation() to match new camera device orientation spec, which requires drivers to publish device orientation as relative to native orientation, as opposed to landscape orientation as before. This causes the 90 degree offset to be unnecessary/incorrect.

See: https://review.docs.microsoft.com/en-us/windows-hardware/drivers/stream/camera-device-orientation