### PR TITLE
Incorrect variable type used in screen capture sample.

### DIFF
--- a/windows-apps-src/audio-video-camera/screen-capture.md
+++ b/windows-apps-src/audio-video-camera/screen-capture.md
@@ -289,7 +289,7 @@ namespace CaptureSamples
             }
         } 
  
-        private void ResetFramePool(Vector2 size, bool recreateDevice) 
+        private void ResetFramePool(SizeInt32 size, bool recreateDevice) 
         { 
             do 
             { 


### PR DESCRIPTION
A previous update changed the `_lastSize` variable to a `SizeInt32`, but never updated the `ResetFramePool()` method to make use of the new type. Updated to fix errors.

Not entirely sure why the 'See also' line claims it was updated.

