### PR TITLE
Fixing typos in gaze-interaction sample

### DIFF
--- a/windows-apps-src/design/input/gaze-interactions.md
+++ b/windows-apps-src/design/input/gaze-interactions.md
@@ -225,7 +225,6 @@ A small ellipse is used to show where the gaze point is within the application v
                 // Stop listening for device events on navigation from eye-tracking page.
                 StopGazeDeviceWatcher();
             }
-            ...
         }
     }
     ```
@@ -565,7 +564,7 @@ A small ellipse is used to show where the gaze point is within the application v
     {
         // Ensure the gaze timer restarts on new progress bar location.
         timerGaze.Stop();
-        timersStarted = false;
+        timerStarted = false;
 
         // Get the bounding rectangle of the app window.
         Rect appBounds = Windows.UI.ViewManagement.ApplicationView.GetForCurrentView().VisibleBounds;


### PR DESCRIPTION
Just used this sample at a recruiting event. When copy/pasting into Visual Studio I found two typos. One was a "..." in the first code snippet. Not sure of the purpose of this, it shows as an error in the code editor so I removed it. The second was "timersStarted" which had two s letters in it.