### PR TITLE
Fix for #840

### DIFF
--- a/windows-apps-src/app-to-app/share-data.md
+++ b/windows-apps-src/app-to-app/share-data.md
@@ -82,7 +82,7 @@ async void OnDeferredImageRequestedHandler(DataProviderRequest request)
 
         // Re-encode the image at 50% width and height.
         BitmapEncoder imageEncoder = await BitmapEncoder.CreateForTranscodingAsync(inMemoryStream, imageDecoder);
-        imageEncoder.BitmapTransform.ScaledWidth = (uint)(imageDecoder.OrientedPixelHeight * 0.5);
+        imageEncoder.BitmapTransform.ScaledWidth = (uint)(imageDecoder.OrientedPixelWidth * 0.5);
         imageEncoder.BitmapTransform.ScaledHeight = (uint)(imageDecoder.OrientedPixelHeight * 0.5);
         await imageEncoder.FlushAsync();
 


### PR DESCRIPTION
Fix scaling the image in the example code - was using half of height as a new width instead of half of original width (Fix #840)