### PR TITLE
Update tailor-resources-lang-scale-contrast.md

### DIFF
--- a/windows-apps-src/app-resources/tailor-resources-lang-scale-contrast.md
+++ b/windows-apps-src/app-resources/tailor-resources-lang-scale-contrast.md
@@ -43,7 +43,7 @@ Here is an example of using qualifiers to name folders that contain asset files.
 \Assets\Images\contrast-white\<logo.png, and other image files>
 ```
 
-If you name your folders as in the example above, then your app uses the high contrast setting to load resource files from the folder named for the appropriate qualifier. So, if the setting is High Contrast Black, then the resource files in the `\Assets\Images\contrast-black` folder are loaded. If the setting is None (that is, the computer is not in high contrast mode), then the resource files in the `\Assets\Images\standard` folder are loaded.
+If you name your folders as in the example above, then your app uses the high contrast setting to load resource files from the folder named for the appropriate qualifier. So, if the setting is High Contrast Black, then the resource files in the `\Assets\Images\contrast-black` folder are loaded. If the setting is None (that is, the computer is not in high contrast mode), then the resource files in the `\Assets\Images\contrast-standard` folder are loaded.
 
 ## Use qualifiers in file names
 


### PR DESCRIPTION
Small fix to the instructions; it was missing the 'contrast'-statement in order to make it work in VS. In this edit this has been added.