### PR TITLE
use reverse DNS name for app extension Id

### DIFF
--- a/windows-apps-src/launch-resume/how-to-create-an-extension.md
+++ b/windows-apps-src/launch-resume/how-to-create-an-extension.md
@@ -61,7 +61,7 @@ _Package.appxmanifest in the MathExtensionHost project_
         <Extensions>
             <uap3:Extension Category="windows.appExtensionHost">
                 <uap3:AppExtensionHost>
-                  <uap3:Name>microsoft.com.MathExt</uap3:Name>
+                  <uap3:Name>com.microsoft.mathext</uap3:Name>
                 </uap3:AppExtensionHost>
           </uap3:Extension>
         </Extensions>
@@ -96,7 +96,7 @@ _Package.appxmanifest in the MathExtension project:_
         <Extensions>
           ...
           <uap3:Extension Category="windows.appExtension">
-            <uap3:AppExtension Name="Microsoft.com.MathExt"
+            <uap3:AppExtension Name="com.microsoft.mathext"
                                Id="power"
                                DisplayName="x^y"
                                Description="Exponent"

--- a/windows-apps-src/launch-resume/how-to-create-an-extension.md
+++ b/windows-apps-src/launch-resume/how-to-create-an-extension.md
@@ -363,7 +363,7 @@ _Package.appxmanifest in the MathExtension project:_
      <uap:AppService Name="com.microsoft.sqrtservice" />      <!-- This must match the contents of <Service>...</Service> -->
    </uap:Extension>
    <uap3:Extension Category="windows.appExtension">
-     <uap3:AppExtension Name="Microsoft.com.MathExt" Id="sqrt" DisplayName="Sqrt(x)" Description="Square root" PublicFolder="Public">
+     <uap3:AppExtension Name="com.microsoft.mathext" Id="sqrt" DisplayName="Sqrt(x)" Description="Square root" PublicFolder="Public">
        <uap3:Properties>
          <Service>com.microsoft.powservice</Service>   <!-- this must match <uap:AppService Name=...> -->
        </uap3:Properties>


### PR DESCRIPTION
the build video says, and the [manifest schema](https://docs.microsoft.com/en-us/uwp/schemas/appxpackage/uapmanifestschema/element-uap3-appextension-manual) demonstrates using reverse DNS names for the app extension Id. I've updated this page to match that guidance.