### PR TITLE
Update reference instructions for calling Windows APIs

### DIFF
--- a/windows-apps-src/porting/desktop-to-uwp-enhance.md
+++ b/windows-apps-src/porting/desktop-to-uwp-enhance.md
@@ -32,10 +32,9 @@ Then, add a reference to these files.
 
 |File|Location|
 |--|--|
-|System.Runtime.WindowsRuntime|C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\\.NETCore\v4.5|
-|System.Runtime.WindowsRuntime.UI.Xaml|C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\\.NETCore\v4.5|
-|System.Runtime.InteropServices.WindowsRuntime|C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\\.NETCore\v4.5|
-|Windows.winmd|C:\Program Files (x86)\Windows Kits\10\UnionMetadata\Facade|
+|System.Runtime.WindowsRuntime|C:\Windows\Microsoft.NET\Framework\v4.0.30319|
+|System.Runtime.WindowsRuntime.UI.Xaml|C:\Windows\Microsoft.NET\Framework\v4.0.30319|
+|System.Runtime.InteropServices.WindowsRuntime|C:\Windows\Microsoft.NET\Framework\v4.0.30319|
 |Windows.Foundation.UniversalApiContract.winmd|C:\Program Files (x86)\Windows Kits\10\References\<*sdk version*>\Windows.Foundation.UniversalApiContract\<*version*>|
 |Windows.Foundation.FoundationContract.winmd|C:\Program Files (x86)\Windows Kits\10\References\<*sdk version*>\Windows.Foundation.FoundationContract\<*version*>|
 


### PR DESCRIPTION
The old instructions referenced the Win8.x era interop assemblies (netcore v4.5) that had a dependencies on the facade windows.winmd.  This is not necessary, you can reference the .NetFramework 4.x interop assemblies and the contracts.