### PR TITLE
Update use-a-maintenance-trigger.md

### DIFF
--- a/windows-apps-src/launch-resume/use-a-maintenance-trigger.md
+++ b/windows-apps-src/launch-resume/use-a-maintenance-trigger.md
@@ -32,7 +32,7 @@ This example assumes that you have lightweight code you can run in the backgroun
 
 More information on writing a background task class is available in [Create and register an in-process background task](create-and-register-an-inproc-background-task.md) or [Create and register an out-of-process background task](create-and-register-a-background-task.md).
 
-Create a new [**MaintenanceTrigger**](https://msdn.microsoft.com/library/windows/apps/br224843) object. The second parameter, *OneShot*, specifies whether the maintenance task will run only once or continue to run periodically. If *OneShot* is set to true, the first parameter (*FreshnessTime*) specifies the number of minutes to wait before scheduling the background task. If *OneShot* is set to false, *FreshnessTime* specifies how often the background task will run.
+Create a new [**MaintenanceTrigger**](https://msdn.microsoft.com/library/windows/apps/hh700517) object. The second parameter, *OneShot*, specifies whether the maintenance task will run only once or continue to run periodically. If *OneShot* is set to true, the first parameter (*FreshnessTime*) specifies the number of minutes to wait before scheduling the background task. If *OneShot* is set to false, *FreshnessTime* specifies how often the background task will run.
 
 > [!NOTE]
 > If *FreshnessTime* is set to less than 15 minutes, an exception is thrown when attempting to register the background task.


### PR DESCRIPTION
A "MaintenanceTrigger" link actually pointed to the TimeTrigger Class rather than the MaintenanceTrigger Class.