### PR TITLE
Update send-local-toast-desktop-cpp-wrl.md

### DIFF
--- a/windows-apps-src/design/shell/tiles-and-notifications/send-local-toast-desktop-cpp-wrl.md
+++ b/windows-apps-src/design/shell/tiles-and-notifications/send-local-toast-desktop-cpp-wrl.md
@@ -212,7 +212,7 @@ if (SUCCEEDED(hr))
     {
         // Create the notification itself (using helper method from compat library)
         ComPtr<IToastNotification> toast;
-        hr = DesktopNotificationManagerCompat::CreateToastNotification(doc, &toast);
+        hr = DesktopNotificationManagerCompat::CreateToastNotification(doc.Get(), &toast);
         if (SUCCEEDED(hr))
         {
             // And show it!


### PR DESCRIPTION
doc.Get() is to be used. else getting the following compilation error.

Severity	Code	Description	Project	File	Line	Suppression State
Error	C2664	'HRESULT DesktopNotificationManagerCompat::CreateToastNotification(ABI::Windows::Data::Xml::Dom::IXmlDocument *,ABI::Windows::UI::Notifications::IToastNotification **)': cannot convert argument 1 from 'Microsoft::WRL::ComPtr<ABI::Windows::Data::Xml::Dom::IXmlDocument>' to 'ABI::Windows::Data::Xml::Dom::IXmlDocument *'	Toast	c:\users\sahils\documents\visual studio 2017\projects\gokhalesirclasspunewin32dotnetcomwinrt\toast\toast.cpp	51