### PR TITLE
Add Tip to use ShowAddAccountAsync

### DIFF
--- a/windows-apps-src/security/web-account-manager.md
+++ b/windows-apps-src/security/web-account-manager.md
@@ -69,6 +69,9 @@ If you run your app and click the "Log in" button, it should display an empty wi
 
 The pane is empty because the system only provides a UI shell - it's up to the developer to programatically populate the pane with the identity providers. 
 
+> [!TIP]
+> Optionally, you can use [ShowAddAccountAsync](https://docs.microsoft.com/en-us/uwp/api/windows.ui.applicationsettings.accountssettingspane.showaddaccountasync) instead of [Show](https://docs.microsoft.com/en-us/uwp/api/windows.ui.applicationsettings.accountssettingspane.show#Windows_UI_ApplicationSettings_AccountsSettingsPane_Show), which will return an [IAsyncAction](https://docs.microsoft.com/en-us/uwp/api/Windows.Foundation.IAsyncAction) to your app, and query for the status of the operation. 
+
 ## Register for AccountCommandsRequested
 
 To add commands to the pane, we start by registering for the AccountCommandsRequested event handler. This tells the system to run our build logic when the user asks to see the pane (e.g., clicks our XAML button). 

--- a/windows-apps-src/security/web-account-manager.md
+++ b/windows-apps-src/security/web-account-manager.md
@@ -70,7 +70,7 @@ If you run your app and click the "Log in" button, it should display an empty wi
 The pane is empty because the system only provides a UI shell - it's up to the developer to programatically populate the pane with the identity providers. 
 
 > [!TIP]
-> Optionally, you can use [ShowAddAccountAsync](https://docs.microsoft.com/en-us/uwp/api/windows.ui.applicationsettings.accountssettingspane.showaddaccountasync) instead of [Show](https://docs.microsoft.com/en-us/uwp/api/windows.ui.applicationsettings.accountssettingspane.show#Windows_UI_ApplicationSettings_AccountsSettingsPane_Show), which will return an [IAsyncAction](https://docs.microsoft.com/en-us/uwp/api/Windows.Foundation.IAsyncAction) to your app, and query for the status of the operation. 
+> Optionally, you can use **[ShowAddAccountAsync](https://docs.microsoft.com/uwp/api/windows.ui.applicationsettings.accountssettingspane.showaddaccountasync)** instead of **[Show](https://docs.microsoft.com/uwp/api/windows.ui.applicationsettings.accountssettingspane.show#Windows_UI_ApplicationSettings_AccountsSettingsPane_Show)**, which will return an **[IAsyncAction](https://docs.microsoft.com/uwp/api/Windows.Foundation.IAsyncAction)**, to query for the status of the operation. 
 
 ## Register for AccountCommandsRequested
 


### PR DESCRIPTION
Add a tip for callers to use ShowAddAccountAsync() instead of Show() if they want to query the status of the operation