### PR TITLE
Stated dimensions

### DIFF
--- a/windows-apps-src/monetize/supported-ad-sizes-for-banner-ads.md
+++ b/windows-apps-src/monetize/supported-ad-sizes-for-banner-ads.md
@@ -9,9 +9,9 @@ ms.localizationpriority: medium
 ---
 # Supported banner ad sizes
 
-The following banner ad sizes are supported for Universal Windows Platform (UWP) apps. When you instantiate your **AdControl** object in your app, make sure you set the height and width properties to match one of these supported sizes.
+The following banner ad sizes are supported for Universal Windows Platform (UWP) apps. When you instantiate your **AdControl** object in your app, make sure you set the width and height properties to match one of these supported sizes.
 
-Sizes are Width x Height.
+Sizes are width x height.
 
 * 160x600
 * 300x50

--- a/windows-apps-src/monetize/supported-ad-sizes-for-banner-ads.md
+++ b/windows-apps-src/monetize/supported-ad-sizes-for-banner-ads.md
@@ -11,6 +11,8 @@ ms.localizationpriority: medium
 
 The following banner ad sizes are supported for Universal Windows Platform (UWP) apps. When you instantiate your **AdControl** object in your app, make sure you set the height and width properties to match one of these supported sizes.
 
+Sizes are Width x Height.
+
 * 160x600
 * 300x50
 * 300x250


### PR DESCRIPTION
I added 1 line to explicitly state that the listed dimensions are width x height.

The included images are confusing and do not sufficiently communicate dimensions.  For example, the first image states 100 x 600 and shows a landscape-oriented screen. That implies that the dimensions are height x width (as the image is wider than it is high), however a bright blue box inside the image is portrait-oriented. The listed dimensions in fact refer only to that section. That's too many hurdles for the reader to jump. Explicitly stating width x height avoids possible confusion.