### PR TITLE
Nothing mentioned about how to use Redirect Visual

### DIFF
--- a/windows-apps-src/composition/composition-visual-tree.md
+++ b/windows-apps-src/composition/composition-visual-tree.md
@@ -493,3 +493,7 @@ namespace compositionvisual
     }
 }
 ```
+<improvement suggestion>
+This article does not mention how to use Redirect Visual nor do we seem to have any other published content on such.
+Please create and add a description and sample code how to use Redirect Visual in  CompositionVisual Doc.
+</improvement suggestion>


### PR DESCRIPTION
This article does not mention how to use Redirect Visual nor do we seem to have any other published content on such.
Please create and add a description and sample code how to use Redirect Visual in  CompositionVisual Doc.

Doc Issue Regarding Composition API.
Redirect Visual(https://docs.microsoft.com/en-us/uwp/api/windows.ui.composition.redirectvisual  ) 
has recently been (introduced v10.0.17763.0) added to Composition API.

But in the CompositionVisual Doc (https://docs.microsoft.com/en-us/windows/uwp/composition/composition-visual-tree ) there is no mention of Redirect Visual.
And there is no other doc that we can find talking about how to use Redirect Visual. 

I think we have two options to fix this issue:

  1. Add Description about how to use Redirect Visual in  CompositionVisual Doc.
  2. Add Sample Codes to the Doc or Add an additional Sample of Redirect Visual.
It would be perfect, if the above two options could be done.