### PR TITLE
Fix a few broken or obsolete links (.../desktop-to-uwp-distribute)

### DIFF
--- a/hub/apps/desktop/modernize/desktop-to-uwp-distribute.md
+++ b/hub/apps/desktop/modernize/desktop-to-uwp-distribute.md
@@ -38,7 +38,7 @@ This might make sense if you want greater control over the distribution experien
 
 To distribute your application to other devices without placing it in the Store, you have to obtain a certificate, sign your application by using that certificate, and then sideload your application onto those devices.
 
-You can [create a certificate](/windows/uwp/packaging/create-certificate-package-signing.md) or obtain one from a popular vendor such as [Verisign](https://www.verisign.com/).
+You can [create a certificate](https://docs.microsoft.com/windows/uwp/packaging/create-certificate-package-signing) or obtain one from a popular vendor such as [Verisign](https://www.verisign.com/).
 
 If you plan to distribute your application onto devices that run Windows 10 S, your application has to be signed by the Microsoft Store so you'll have to go through the Store submission process before you can distribute your application onto those devices.
 
@@ -47,9 +47,9 @@ If you create a certificate, you have to install it into the **Trusted Root** or
 > [!IMPORTANT]
 > Make sure that the publisher name on your certificate matches the publisher name of your app.
 
-To sign your application by using a certificate, see [Sign an application package using SignTool](/windows/uwp/packaging/sign-app-package-using-signtool.md).
+To sign your application by using a certificate, see [Sign an application package using SignTool](https://docs.microsoft.com/windows/uwp/packaging/sign-app-package-using-signtool).
 
-To sideload your application onto other devices, see [Sideload LOB apps in Windows 10](https://technet.microsoft.com/itpro/windows/deploy/sideload-apps-in-windows-10).
+To sideload your application onto other devices, see [Sideload LOB apps in Windows 10](https://docs.microsoft.com/windows/application-management/sideload-apps-in-windows-10).
 
 **Videos**
 

--- a/hub/apps/desktop/modernize/desktop-to-uwp-distribute.md
+++ b/hub/apps/desktop/modernize/desktop-to-uwp-distribute.md
@@ -10,7 +10,7 @@ ms.localizationpriority: medium
 
 # Distribute your packaged desktop app
 
-If you decide to [package your desktop app in an MSIX package](https://docs.microsoft.com/windows/msix/desktop/desktop-to-uwp-root), you can publish your packaged application to the Microsoft Store or sideload it onto one or more devices.
+If you decide to [package your desktop app in an MSIX package](/windows/msix/desktop/desktop-to-uwp-root), you can publish your packaged application to the Microsoft Store or sideload it onto one or more devices.
 
 > [!NOTE]
 > Do you have a plan for how you might transition users to your packaged application? Before you distribute your app, see the [Transition users to your packaged app](#transition-users) section of this guide to get some ideas.
@@ -21,12 +21,12 @@ The [Microsoft Store](https://www.microsoft.com/store/apps) is a convenient way 
 
 Publish your application to the Microsoft Store to reach the broadest audience. Also, organizational customers can acquire your application to distribute internally to their organizations through the [Microsoft Store for Business](https://www.microsoft.com/business-store).
 
-If you plan to publish to the Microsoft Store, you'll be asked a few extra questions as part of the submission process. That's because your package manifest declares a restricted capability named **runFullTrust**, and we need to approve your application's use of that capability. You can read more about this requirement here: [Restricted capabilities](https://docs.microsoft.com/windows/uwp/packaging/app-capability-declarations#restricted-capabilities).
+If you plan to publish to the Microsoft Store, you'll be asked a few extra questions as part of the submission process. That's because your package manifest declares a restricted capability named **runFullTrust**, and we need to approve your application's use of that capability. You can read more about this requirement here: [Restricted capabilities](/windows/uwp/packaging/app-capability-declarations#restricted-capabilities).
 
 You don't have to sign your application before you submit it to the Store.
 
 >[!IMPORTANT]
-> If you plan to publish your application to the Microsoft Store, make sure that your application operates correctly on devices that run Windows 10 S. This is a Store requirement. See [Test your Windows app for Windows 10  S](https://docs.microsoft.com/windows/msix/desktop/desktop-to-uwp-test-windows-s).
+> If you plan to publish your application to the Microsoft Store, make sure that your application operates correctly on devices that run Windows 10 S. This is a Store requirement. See [Test your Windows app for Windows 10  S](/windows/msix/desktop/desktop-to-uwp-test-windows-s).
 
 <a id="side-load" />
 
@@ -38,7 +38,7 @@ This might make sense if you want greater control over the distribution experien
 
 To distribute your application to other devices without placing it in the Store, you have to obtain a certificate, sign your application by using that certificate, and then sideload your application onto those devices.
 
-You can [create a certificate](https://docs.microsoft.com/windows/uwp/packaging/create-certificate-package-signing) or obtain one from a popular vendor such as [Verisign](https://www.verisign.com/).
+You can [create a certificate](/windows/uwp/packaging/create-certificate-package-signing) or obtain one from a popular vendor such as [Verisign](https://www.verisign.com/).
 
 If you plan to distribute your application onto devices that run Windows 10 S, your application has to be signed by the Microsoft Store so you'll have to go through the Store submission process before you can distribute your application onto those devices.
 
@@ -47,9 +47,9 @@ If you create a certificate, you have to install it into the **Trusted Root** or
 > [!IMPORTANT]
 > Make sure that the publisher name on your certificate matches the publisher name of your app.
 
-To sign your application by using a certificate, see [Sign an application package using SignTool](https://docs.microsoft.com/windows/uwp/packaging/sign-app-package-using-signtool).
+To sign your application by using a certificate, see [Sign an application package using SignTool](/windows/uwp/packaging/sign-app-package-using-signtool).
 
-To sideload your application onto other devices, see [Sideload LOB apps in Windows 10](https://docs.microsoft.com/windows/application-management/sideload-apps-in-windows-10).
+To sideload your application onto other devices, see [Sideload LOB apps in Windows 10](/windows/application-management/sideload-apps-in-windows-10).
 
 **Videos**
 


### PR DESCRIPTION
It seems the docs.microsoft.com publishing process is somewhat inconsistent in whether or not it auto-removes the .md extensions from linked page URLs when turning the markdown files into HTML webpages. This PR fixes a couple broken links resulting from that inconsistency.

I also updated a link that still works, but redirects.