### PR TITLE
Corrected the wrong return type in gatt-client.md

### DIFF
--- a/windows-apps-src/devices-sensors/gatt-client.md
+++ b/windows-apps-src/devices-sensors/gatt-client.md
@@ -153,11 +153,11 @@ if (result.Status == GattCommunicationStatus.Success)
 Writing to a characteristic follows a similar pattern: 
 ```csharp
 var writer = new DataWriter();
-// WriteByte used for simplicity. Other commmon functions - WriteInt16 and WriteSingle
+// WriteByte used for simplicity. Other common functions - WriteInt16 and WriteSingle
 writer.WriteByte(0x01);
 
-GattReadResult result = await selectedCharacteristic.WriteValueAsync(writer.DetachBuffer());
-if (result.Status == GattCommunicationStatus.Success)
+GattCommunicationStatus result = await selectedCharacteristic.WriteValueAsync(writer.DetachBuffer());
+if (result == GattCommunicationStatus.Success)
 {
     // Successfully wrote to device
 }


### PR DESCRIPTION
`GattCharacteristic.WriteValueAsync` returns `IAsyncOperation<GattCommunicationStatus>` per doc https://docs.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.genericattribu