### PR TITLE
Move `Example` out of `Note` block

### DIFF
--- a/windows-apps-src/launch-resume/run-a-background-task-on-a-timer-.md
+++ b/windows-apps-src/launch-resume/run-a-background-task-on-a-timer-.md
@@ -27,7 +27,7 @@ The built-in timer for Universal Windows Platform (UWP) apps that target the des
 
 > [!NOTE]
 > If *FreshnessTime* is set to less than 15 minutes, an exception is thrown when attempting to register the background task.
- 
+
 For example, this trigger will cause a background task to run once an hour.
 
 ```cs


### PR DESCRIPTION
An extra indentation pulls the `Example` paragraph into a `Note` block, making it confusing.