### PR TITLE
Add links to overall data binding documentation

### DIFF
--- a/windows-apps-src/cpp-and-winrt-apis/binding-collection.md
+++ b/windows-apps-src/cpp-and-winrt-apis/binding-collection.md
@@ -9,7 +9,7 @@ ms.localizationpriority: medium
 
 # XAML items controls; bind to a C++/WinRT collection
 
-A collection that can be effectively bound to a XAML items control is known as an *observable* collection. This idea is based on the software design pattern known as the *observer pattern*. This topic shows how to implement observable collections in [C++/WinRT](/windows/uwp/cpp-and-winrt-apis/intro-to-using-cpp-with-winrt), and how to [bind](/windows/uwp/data-binding/) XAML items controls to them.
+A collection that can be effectively bound to a XAML items control is known as an *observable* collection. This idea is based on the software design pattern known as the *observer pattern*. This topic shows how to implement observable collections in [C++/WinRT](/windows/uwp/cpp-and-winrt-apis/intro-to-using-cpp-with-winrt), and how to bind XAML items controls to them (for background info, see [Data binding](/windows/uwp/data-binding)).
 
 If you want to follow along with this topic, then we recommend that you first create the project that's described in [XAML controls; bind to a C++/WinRT property](binding-property.md). This topic adds more code to that project, and it adds to the concepts explained in that topic.
 

--- a/windows-apps-src/cpp-and-winrt-apis/binding-collection.md
+++ b/windows-apps-src/cpp-and-winrt-apis/binding-collection.md
@@ -9,7 +9,7 @@ ms.localizationpriority: medium
 
 # XAML items controls; bind to a C++/WinRT collection
 
-A collection that can be effectively bound to a XAML items control is known as an *observable* collection. This idea is based on the software design pattern known as the *observer pattern*. This topic shows how to implement observable collections in [C++/WinRT](/windows/uwp/cpp-and-winrt-apis/intro-to-using-cpp-with-winrt), and how to bind XAML items controls to them.
+A collection that can be effectively bound to a XAML items control is known as an *observable* collection. This idea is based on the software design pattern known as the *observer pattern*. This topic shows how to implement observable collections in [C++/WinRT](/windows/uwp/cpp-and-winrt-apis/intro-to-using-cpp-with-winrt), and how to [bind](/windows/uwp/data-binding/) XAML items controls to them.
 
 If you want to follow along with this topic, then we recommend that you first create the project that's described in [XAML controls; bind to a C++/WinRT property](binding-property.md). This topic adds more code to that project, and it adds to the concepts explained in that topic.
 

--- a/windows-apps-src/cpp-and-winrt-apis/binding-property.md
+++ b/windows-apps-src/cpp-and-winrt-apis/binding-property.md
@@ -8,7 +8,7 @@ ms.localizationpriority: medium
 ---
 
 # XAML controls; bind to a C++/WinRT property
-A property that can be effectively bound to a XAML control is known as an *observable* property. This idea is based on the software design pattern known as the *observer pattern*. This topic shows how to implement observable properties in [C++/WinRT](/windows/uwp/cpp-and-winrt-apis/intro-to-using-cpp-with-winrt), and how to bind XAML items controls to them (for background info, see [Data binding](/windows/uwp/data-binding)).
+A property that can be effectively bound to a XAML control is known as an *observable* property. This idea is based on the software design pattern known as the *observer pattern*. This topic shows how to implement observable properties in [C++/WinRT](/windows/uwp/cpp-and-winrt-apis/intro-to-using-cpp-with-winrt), and how to bind XAML controls to them (for background info, see [Data binding](/windows/uwp/data-binding)).
 
 > [!IMPORTANT]
 > For essential concepts and terms that support your understanding of how to consume and author runtime classes with C++/WinRT, see [Consume APIs with C++/WinRT](consume-apis.md) and [Author APIs with C++/WinRT](author-apis.md).

--- a/windows-apps-src/cpp-and-winrt-apis/binding-property.md
+++ b/windows-apps-src/cpp-and-winrt-apis/binding-property.md
@@ -8,7 +8,7 @@ ms.localizationpriority: medium
 ---
 
 # XAML controls; bind to a C++/WinRT property
-A property that can be effectively bound to a XAML control is known as an *observable* property. This idea is based on the software design pattern known as the *observer pattern*. This topic shows how to implement observable properties in [C++/WinRT](/windows/uwp/cpp-and-winrt-apis/intro-to-using-cpp-with-winrt), and how to bind XAML controls to them.
+A property that can be effectively bound to a XAML control is known as an *observable* property. This idea is based on the software design pattern known as the *observer pattern*. This topic shows how to implement observable properties in [C++/WinRT](/windows/uwp/cpp-and-winrt-apis/intro-to-using-cpp-with-winrt), and how to [bind](/windows/uwp/data-binding/) XAML controls to them.
 
 > [!IMPORTANT]
 > For essential concepts and terms that support your understanding of how to consume and author runtime classes with C++/WinRT, see [Consume APIs with C++/WinRT](consume-apis.md) and [Author APIs with C++/WinRT](author-apis.md).

--- a/windows-apps-src/cpp-and-winrt-apis/binding-property.md
+++ b/windows-apps-src/cpp-and-winrt-apis/binding-property.md
@@ -8,7 +8,7 @@ ms.localizationpriority: medium
 ---
 
 # XAML controls; bind to a C++/WinRT property
-A property that can be effectively bound to a XAML control is known as an *observable* property. This idea is based on the software design pattern known as the *observer pattern*. This topic shows how to implement observable properties in [C++/WinRT](/windows/uwp/cpp-and-winrt-apis/intro-to-using-cpp-with-winrt), and how to [bind](/windows/uwp/data-binding/) XAML controls to them.
+A property that can be effectively bound to a XAML control is known as an *observable* property. This idea is based on the software design pattern known as the *observer pattern*. This topic shows how to implement observable properties in [C++/WinRT](/windows/uwp/cpp-and-winrt-apis/intro-to-using-cpp-with-winrt), and how to bind XAML items controls to them (for background info, see [Data binding](/windows/uwp/data-binding)).
 
 > [!IMPORTANT]
 > For essential concepts and terms that support your understanding of how to consume and author runtime classes with C++/WinRT, see [Consume APIs with C++/WinRT](consume-apis.md) and [Author APIs with C++/WinRT](author-apis.md).


### PR DESCRIPTION
The C++/WinRT docs mention XAML binding; link to the overall documentation in the first mentions of the term for those who might not be familiar with it.