### PR TITLE
Added a link to choose-your-platform

### DIFF
--- a/windows-apps-src/get-started/index.md
+++ b/windows-apps-src/get-started/index.md
@@ -25,6 +25,7 @@ ms.localizationpriority: medium
                         <h3>Learn about Windows 10 Apps</h3>
                         <p>Windows 10 and the Universal Windows Platform let you build apps that work and look great across all Windows device types, or update existing apps with modern features.</p>
                         <ul>
+                          <li><a href="//docs.microsoft.com/windows/apps/desktop/choose-your-platform">What's UWP platform?</a></li>
                           <li><a href="//docs.microsoft.com/windows/uwp/get-started/universal-application-platform-guide">What's a UWP app?</a></li>
                         </ul>
                     </div>


### PR DESCRIPTION
This little link will save me more than two weeks to figure out what is UWP. I think that document is so important, you should put it in all platform's overview part.
When I want to develop a uwp app, I came here as my first stop. But I can't find any description about what is uwp. At first, I think UWP is a library of .NET, and designed for mobile devices. And then, in my mind, I mix Windows Runtime and .NET together. Later, when I choose project type, I selected WPF for my project. And later, I think language projection of C++/WinRT is the right way to access .Net from C++. etc.
But if I saw that link first. All of these will not happen. That document tell me that, in Windows there're four platforms to choose, and UWP is one of them. So clear! But I spend so long to find it out. Because I just want to try UWP, so I click UWP link, not desktop.