### PR TITLE
Added notes for how to enable the Lifecycle Events toolbar in Visual Studio

### DIFF
--- a/windows-apps-src/launch-resume/debug-a-background-task.md
+++ b/windows-apps-src/launch-resume/debug-a-background-task.md
@@ -36,6 +36,10 @@ Background tasks can be triggered manually through Microsoft Visual Studio. Then
 
 2.  Run your application in the debugger and then trigger the background task using the **Lifecycle Events** toolbar. This drop down shows the names of the background tasks that can be activated by Visual Studio.
 
+> [!NOTE]
+> The Lifecycle Events toolbar options are not shown by default in Visual Studio. 
+> To show these options, right-click on the current toolbar in Visual Studio and ensure the option **Debug Location** is enabled.
+
     For this to work, the background task must already be registered and it must still be waiting for the trigger. For example, if a background task was registered with a one-shot TimeTrigger and that trigger has already fired, launching the task through Visual Studio will have no effect.
 
 > [!Note]


### PR DESCRIPTION
As #1830 describes, the description in the documentation for debugging background tasks refers to using toolbar options for lifecycle events which aren't available by default in Visual Studio.

This change adds a new note which describes how a user can enable the option using the `Debug Location` options in the toolbar right-click menu.