### PR TITLE
Changing  DateTime to DateTimeOffset for clarity

### DIFF
--- a/windows-apps-src/design/app-settings/store-and-retrieve-app-data.md
+++ b/windows-apps-src/design/app-settings/store-and-retrieve-app-data.md
@@ -28,7 +28,7 @@ Here are data types you can use for app settings:
 - **UInt8**, **Int16**, **UInt16**, **Int32**, **UInt32**, **Int64**, **UInt64**, **Single**, **Double**
 - **Boolean**
 - **Char16**, **String**
-- [**DateTimeOffset**](https://docs.microsoft.com/en-us/dotnet/api/system.datetimeoffset?redirectedfrom=MSDN&view=dotnet-uwp-10.0), [**TimeSpan**](https://docs.microsoft.com/en-us/dotnet/api/system.timespan?redirectedfrom=MSDN&view=dotnet-uwp-10.0)
+- [**DateTimeOffset**](https://docs.microsoft.com/dotnet/api/system.datetimeoffset?view=dotnet-uwp-10.0), [**TimeSpan**](https://docs.microsoft.com/dotnet/api/system.timespan?view=dotnet-uwp-10.0)
 - **GUID**, [**Point**](https://docs.microsoft.com/uwp/api/Windows.Foundation.Point), [**Size**](https://docs.microsoft.com/uwp/api/Windows.Foundation.Size), [**Rect**](https://docs.microsoft.com/uwp/api/Windows.Foundation.Rect)
 - [**ApplicationDataCompositeValue**](https://docs.microsoft.com/uwp/api/Windows.Storage.ApplicationDataCompositeValue): A set of related app settings that must be serialized and deserialized atomically. Use composite settings to easily handle atomic updates of interdependent settings. The system ensures the integrity of composite settings during concurrent access and roaming. Composite settings are optimized for small amounts of data, and performance can be poor if you use them for large data sets.
 

--- a/windows-apps-src/design/app-settings/store-and-retrieve-app-data.md
+++ b/windows-apps-src/design/app-settings/store-and-retrieve-app-data.md
@@ -28,7 +28,7 @@ Here are data types you can use for app settings:
 - **UInt8**, **Int16**, **UInt16**, **Int32**, **UInt32**, **Int64**, **UInt64**, **Single**, **Double**
 - **Boolean**
 - **Char16**, **String**
-- [**DateTime**](https://docs.microsoft.com/uwp/api/Windows.Foundation.DateTime), [**TimeSpan**](https://docs.microsoft.com/uwp/api/Windows.Foundation.TimeSpan)
+- [**DateTimeOffset**](https://docs.microsoft.com/en-us/dotnet/api/system.datetimeoffset?redirectedfrom=MSDN&view=dotnet-uwp-10.0), [**TimeSpan**](https://docs.microsoft.com/en-us/dotnet/api/system.timespan?redirectedfrom=MSDN&view=dotnet-uwp-10.0)
 - **GUID**, [**Point**](https://docs.microsoft.com/uwp/api/Windows.Foundation.Point), [**Size**](https://docs.microsoft.com/uwp/api/Windows.Foundation.Size), [**Rect**](https://docs.microsoft.com/uwp/api/Windows.Foundation.Rect)
 - [**ApplicationDataCompositeValue**](https://docs.microsoft.com/uwp/api/Windows.Storage.ApplicationDataCompositeValue): A set of related app settings that must be serialized and deserialized atomically. Use composite settings to easily handle atomic updates of interdependent settings. The system ensures the integrity of composite settings during concurrent access and roaming. Composite settings are optimized for small amounts of data, and performance can be poor if you use them for large data sets.
 


### PR DESCRIPTION
Developers reading this document thought that DateTime was referring to System.DateTime. However, it was actually referring to Windows.Foundation.DateTime which is equivalent to System.DateTimeOffset. Updating the word and its links to improve clarity.