### PR TITLE
vmImage from vs2017  to windows-latest in sample

### DIFF
--- a/windows-apps-src/packaging/auto-build-package-uwp-apps.md
+++ b/windows-apps-src/packaging/auto-build-package-uwp-apps.md
@@ -32,7 +32,7 @@ trigger:
 - master
 
 pool:
-  vmImage: 'VS2017-Win2016'
+  vmImage: 'windows-latest'
 
 variables:
   solution: '**/*.sln'


### PR DESCRIPTION
Changing `vmImage` from `vs2017` to windows-latest. Source: https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops