### PR TITLE
Fixed XAML compilation error

### DIFF
--- a/windows-apps-src/debug-test-perf/optimize-xaml-loading.md
+++ b/windows-apps-src/debug-test-perf/optimize-xaml-loading.md
@@ -244,7 +244,7 @@ The XAML platform tries to cache commonly-used objects so that they can be reuse
             <TextBlock.Foreground>
                 <SolidColorBrush Color="#FFFFA500"/>
             </TextBlock.Foreground>
-        </TextBox>
+        </TextBlock>
         <Button Content="Submit">
             <Button.Foreground>
                 <SolidColorBrush Color="#FFFFA500"/>


### PR DESCRIPTION
There was a XAML markup error in ending tag of TextBlock in "Inefficient" emphasis of "Consolidate multiple brushes that look the same into one resource" header. It was written as </TextBox> instead of </TextBlock>