### PR TITLE
fix spelling of "desktop" (from "desktop")

### DIFF
--- a/windows-apps-src/design/shell/tiles-and-notifications/toast-desktop-apps.md
+++ b/windows-apps-src/design/shell/tiles-and-notifications/toast-desktop-apps.md
@@ -75,6 +75,6 @@ For classic Win32 apps, set up the AUMID so that you can send toasts, and then a
 
 ## Resources
 
-* [Send a local toast notification from destkop C# apps](send-local-toast-desktop.md)
-* [Send a local toast notification from destkop C++ WRL apps](send-local-toast-desktop-cpp-wrl.md)
+* [Send a local toast notification from desktop C# apps](send-local-toast-desktop.md)
+* [Send a local toast notification from desktop C++ WRL apps](send-local-toast-desktop-cpp-wrl.md)
 * [Toast content documentation](adaptive-interactive-toasts.md)


### PR DESCRIPTION
https://github.com/MicrosoftDocs/windows-uwp/commit/c59769641c70d9a23daa6b99b4322c1175de9a3f did not address all of the instances of the typo called out in #1926. This change fixes the rest.