### PR TITLE
Change all usaged of PropertyChanged to use Invoke pattern

### DIFF
--- a/windows-apps-src/data-access/sql-server-databases.md
+++ b/windows-apps-src/data-access/sql-server-databases.md
@@ -89,10 +89,7 @@ public class Product : INotifyPropertyChanged
     public event PropertyChangedEventHandler PropertyChanged;
     private void NotifyPropertyChanged(string propertyName)
     {
-        if (PropertyChanged != null)
-        {
-            PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
-        }
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
 
 }

--- a/windows-apps-src/data-binding/data-binding-in-depth.md
+++ b/windows-apps-src/data-binding/data-binding-in-depth.md
@@ -141,7 +141,7 @@ public class HostViewModel : INotifyPropertyChanged
     public void OnPropertyChanged([CallerMemberName] string propertyName = null)
     {
         // Raise the PropertyChanged event, passing the name of the property whose value has changed.
-        this.PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
 }
 ```


### PR DESCRIPTION
The Data Binding in Depth one crashes if a property is updated before binding has been added, and the SQL Database one is not thread safe.