### PR TITLE
Add Windows Template Studio to developer tools

### DIFF
--- a/windows-apps-src/get-started/index.md
+++ b/windows-apps-src/get-started/index.md
@@ -203,6 +203,7 @@ ms.localizationpriority: medium
                 <div class="card">
                     <div class="cardText">
                         <h3>Developer tools</h3>
+                        <p><a href="https://github.com/Microsoft/WindowsTemplateStudio/">Windows Template Studio</a></p>
                         <p><a href="//docs.microsoft.com/windows/uwpcommunitytoolkit/">Windows Community Toolkit</a></p>
                         <p><a href="//developer.microsoft.com/windows/downloads/virtual-machines">Virtual machines</a></p>
                         <p><a href="//docs.microsoft.com/windows/wsl/about">Bash on Ubuntu on Windows</a></p>


### PR DESCRIPTION
Windows Template Studio is a Microsoft provided (and community supported) tool to help developers get started when creating a UWP app. In a document about getting started with UWP development, not including it in the developer tools list felt like a big omission.