### PR TITLE
Change the Node.js beginners page to recommend the Windows native installation

### DIFF
--- a/hub/nodejs/beginners.md
+++ b/hub/nodejs/beginners.md
@@ -16,16 +16,13 @@ If you're brand new to using Node.js, this guide will help you to get started wi
 
 ## Prerequisites
 
-This guide assumes that you've already completed the steps to [set up your Node.js development environment with WSL 2](./setup-on-wsl2.md), including:
+This guide assumes that you've already completed the steps to [set up your Node.js development environment on native Windows](./setup-on-windows.md), including:
 
-- Install Windows 10 Insider Preview build 18932 or later.
-- Enable the WSL 2 feature on Windows.
-- Install a Linux distribution (Ubuntu 18.04 for our examples). You can check this with: `wsl lsb_release -a`
-- Ensure your Ubuntu 18.04 distribution is running in WSL 2 mode. (WSL can run distributions in both v1 or v2 mode.) You can check this by opening PowerShell and entering: `wsl -l -v`
-- Set Ubuntu 18.04 as your default distribution, using PowerShell, with: `wsl -s ubuntu 18.04`
+- Install a Node.js version manager.
+- Install Visual Studio Code.
 
 > [!NOTE]
-> While there are some additional setup steps for using the Windows Subsystem for Linux, using WSL 2, along with VS Code and the Remote WSL Extension, will provide the smoothest Node.js development workflow, as well as aligning with the majority of tools, how-to articles, tutorials, and [deployment environments](https://docs.microsoft.com/en-us/azure/javascript/tutorial-vscode-azure-app-service-node-01) out there. However, if you're committed to using Node.js on Windows, check out our guide to [set up your Node.js development environment directly on Windows](./setup-on-windows.md). If you are in the (somewhat rare) situation of needing to host a Node.js app on a Windows server, the most common scenario seems to be [using a reverse proxy](https://medium.com/intrinsic/why-should-i-use-a-reverse-proxy-if-node-js-is-production-ready-5a079408b2ca). There are two ways to do this: 1) [using iisnode](https://harveywilliams.net/blog/installing-iisnode) or [directly](https://dev.to/petereysermans/hosting-a-node-js-application-on-windows-with-iis-as-reverse-proxy-397b). We do not maintain these resources and recommend [using Linux servers to host your Node.js apps](https://azure.microsoft.com/en-us/develop/nodejs/).
+> While there are some additional setup steps for using the Windows Subsystem for Linux, using WSL 2, along with VS Code and the Remote WSL Extension, will provide the smoothest Node.js development workflow, as well as aligning with the majority of tools, how-to articles, tutorials, and [deployment environments](https://docs.microsoft.com/en-us/azure/javascript/tutorial-vscode-azure-app-service-node-01) out there. To set up a WSL dev environment, see [Set up your Node.js development environment with WSL 2](./setup-on-wsl2.md).
 
 ## Types of Node.js applications
 
@@ -35,17 +32,17 @@ Node.js is a JavaScript runtime primarily used for creating web applications. Pu
 - **Real-time apps (RTAs)**: These are web apps that enable users to receive information as soon as it's published by an author, rather than requiring that the user (or software) check a source periodically for updates. Some example RTAs include instant messaging apps or chat rooms, online multiplayer games that can be played in the browser, online collaboration docs, community storage, video conference apps, etc.
 - **Data streaming apps**: These are apps (or services) that send data/content as it arrives (or is created) while keeping the connection open to continue downloading further data, content, or components as needed. Some examples include video- and audio-streaming apps.
 - **REST APIs**: These are interfaces that provide data for someone else's web app to interact with. For example, a Calendar API service could provide dates and times for a concert venue that could be used by someone else's local events website.
-- **Server-side rendered apps (SSRs)**: These web apps can run on both the client (in your browser / the front-end) and the server (the back-end) allowing pages that are dynamic to display (generate HTML for) whatever content is known and quickly grab content that is not known as it's available. These are often referred to as “isomorphic” or “universal” applications. SSRs utilize SPA methods in that they don't need to reload every time you use it. SRAs, however, offer a few benefits that may or may not be important to you, like making content on your site appear in Google search results and providing a preview image when links to your app are shared on social media like Twitter or Facebook. The potential drawback being that they require a Node.js server constantly running. In terms of examples, a social networking app that supports events that users will want to appear in search results and social media may benefit from SSR, while an email app may be fine as an SPA. You can also run server-rendered no-SPA apps, which my be something like a WordPress blog. As you can see, things can get complicated, you just need to decide what's important.
+- **Server-side rendered apps (SSRs)**: These web apps can run on both the client (in your browser / the front-end) and the server (the back-end) allowing pages that are dynamic to display (generate HTML for) whatever content is known and quickly grab content that is not known as it's available. These are often referred to as “isomorphic” or “universal” applications. SSRs utilize SPA methods in that they don't need to reload every time you use it. SSRs, however, offer a few benefits that may or may not be important to you, like making content on your site appear in Google search results and providing a preview image when links to your app are shared on social media like Twitter or Facebook. The potential drawback being that they require a Node.js server constantly running. In terms of examples, a social networking app that supports events that users will want to appear in search results and social media may benefit from SSR, while an email app may be fine as an SPA. You can also run server-rendered no-SPA apps, which my be something like a WordPress blog. As you can see, things can get complicated, you just need to decide what's important.
 - **Command line tools**: These allow you to automate repetitive tasks and then distribute your tool across the vast Node.js ecosystem. An example of a command line tool is cURL, which stand for client URL and is used to download content from an internet URL. cURL is often used to install things like Node.js or, in our case, a Node.js version manager.
 - **Hardware programming**: While not quite as popular as web apps, Node.js is growing in popularity for IoT uses, such as collecting data from sensors, beacons, transmitters, motors, or anything that generates large amounts of data. Node.js can enable data collection, analyzing that data, communicating back and forth between a device and server, and taking action based on the analysis. NPM contains more than 80 packages for Arduino controllers, raspberry pi, Intel IoT Edison, various sensors, and Bluetooth devices.
 
 ## Try using Node.js in VS Code
 
-1. Open your Ubuntu terminal and create a new directory: `mkdir HelloNode`, then enter the directory: `cd HelloNode`
+1. Open your terminal and create a new directory: `mkdir HelloNode`, then enter the directory: `cd HelloNode`
 
-2. Create an empty JavaScript file named "app.js": `touch app.js`
+2. Open the directory and empty file in VS Code: : `code .`
 
-3. Open the directory and empty file in VS Code: : `code .`
+3. Create an empty JavaScript file named "app.js" by clicking the **New File** icon in the Explorer.
 
 4. Create a simple string variable in app.js and send the contents of the string to the console by entering this in your 'app.js' file:
 
@@ -54,12 +51,12 @@ Node.js is a JavaScript runtime primarily used for creating web applications. Pu
     console.log(msg);
     ```
 
-5. To run your "app.js" file with Node.js. Open your Ubuntu terminal right inside VS Code by selecting **View** > **Terminal** (or select Ctrl+`, using the backtick character). If you need to change the default terminal, select the dropdown menu and choose **Select Default Shell**. Then select **WSL** as the default terminal shell to use with VS Code.
+5. To run your "app.js" file with Node.js. Open your terminal right inside VS Code by selecting **View** > **Terminal** (or select Ctrl+`, using the backtick character). If you need to change the default terminal, select the dropdown menu and choose **Select Default Shell**.
 
 6. In the terminal, enter: `node app.js`. You should see the output: "Hello World".
 
 > [!NOTE]
-> Notice that because you've already installed the Remote WSL Extension, your directory will open in a remote environment running on the Ubuntu Linux system as indicated by the green tab on the bottom-left of your VS Code window. In addition, notice that when you type `console` in your 'app.js' file, VS Code displays supported options related to the [`console`](https://developer.mozilla.org/docs/Web/API/Console) object for you to choose from using IntelliSense. Try experimenting with Intellisense using other [JavaScript objects](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects).
+> Notice that when you type `console` in your 'app.js' file, VS Code displays supported options related to the [`console`](https://developer.mozilla.org/docs/Web/API/Console) object for you to choose from using IntelliSense. Try experimenting with Intellisense using other [JavaScript objects](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects).
 
 > [!TIP]
 > Consider trying the new [Windows terminal](https://github.com/microsoft/terminal/blob/master/doc/user-docs/index.md) if you plan to use multiple command lines (Ubuntu, PowerShell, Windows Command Prompt, etc) or if you want to [customize your terminal](https://github.com/microsoft/terminal/blob/master/doc/user-docs/UsingJsonSettings.md), including text, background colors, key bindings, etc.
@@ -70,7 +67,7 @@ Express is a minimal, flexible, and streamlined Node.js framework that makes it 
 
 To create a project with Express.js:
 
-1. Open your WSL terminal (Ubuntu 18.04).
+1. Open your terminal.
 2. Create a new project folder: `mkdir ExpressProjects` and enter that directory: `cd ExpressProjects`.
 3. Use Express to create a HelloWorld project template: `npx express-generator HelloWorld --view=pug`.
 
@@ -88,7 +85,7 @@ To create a project with Express.js:
    - `app.js`. The starting point of your app. It loads everything and begins serving user requests. It's basically the glue that holds all the parts together.
    - `package.json`. Contains the project description, scripts manager, and app manifest. Its main purpose is to track your app's dependencies and their respective versions.
 
-5. You now need to install the dependencies that Express uses in order to build and run your HelloWorld Express app (the packages used for tasks like running the server, as defined in the `package.json` file). Inside VS Code, open your WSL terminal by selecting **View** > **Terminal** (or select Ctrl+`, using the backtick character), be sure that you're still in the 'HelloWorld' project directory. Install the Express package dependencies with:
+5. You now need to install the dependencies that Express uses in order to build and run your HelloWorld Express app (the packages used for tasks like running the server, as defined in the `package.json` file). Inside VS Code, open your terminal by selecting **View** > **Terminal** (or select Ctrl+`, using the backtick character), be sure that you're still in the 'HelloWorld' project directory. Install the Express package dependencies with:
 
 ```bash
 npm install
@@ -97,11 +94,11 @@ npm install
 6. At this point you have the framework set up for a multiple-page web app that has access to a large variety of APIs and HTTP utility methods and middleware, making it easier to create a robust API. Start the Express app on a virtual server by entering:
 
 ```bash
-DEBUG=HelloWorld:* npm start
+npx cross-env DEBUG=HelloWorld:* npm start
 ```
 
 > [!TIP]
-> The `DEBUG=myapp:*` part of the command above means you are telling Node.js that you want to turn on logging for debugging purposes. Remember to replace 'myapp' with your app name. You can find your app name in package.json file under "name" property. The `npm start` command is telling npm to run the scripts in your package.json file.
+> The `DEBUG=myapp:*` part of the command above means you are telling Node.js that you want to turn on logging for debugging purposes. Remember to replace 'myapp' with your app name. You can find your app name in package.json file under "name" property. Using `npx cross-env` sets the `DEBUG` environment variable in any terminal, but you can also set it with your terminal specific way. The `npm start` command is telling npm to run the scripts in your package.json file.
 
 7. You can now view the running app by opening a web browser and going to: **localhost:3000**
 
@@ -127,7 +124,7 @@ Node.js has tools to help you develop server-side web apps, some built in and ma
 
 Let's use the built-in OS module to get some information about your computer's operating system:
 
-1) In your WSL (Ubuntu 18.04) terminal, open the Node.js CLI. You'll see the `>` prompt letting you know you're using Node.js after entering: `node`
+1) In your terminal, open the Node.js CLI. You'll see the `>` prompt letting you know you're using Node.js after entering: `node`
 
 2) To identify the operating system you are currently using (which should return a response letting you know that you're on Windows), enter: `os.platform()`
 

--- a/hub/nodejs/setup-on-windows.md
+++ b/hub/nodejs/setup-on-windows.md
@@ -17,6 +17,9 @@ The following is a step-by-step guide to get you started using Node.js in a nati
 > [!NOTE]
 > While using Node.js on Windows is certainly a viable option, we generally recommend using Windows Subsystem for Linux (WSL) for developing Node.js web apps. Many Node.js packages and frameworks are created with a *nix environment in mind and most Node.js apps are deployed on Linux, so developing on WSL ensures consistency between your development and production environments. To set up a WSL dev environment, see [Set up your Node.js development environment with WSL 2](./setup-on-wsl2.md).
 
+> [!NOTE]
+> If you are in the (somewhat rare) situation of needing to host a Node.js app on a Windows server, the most common scenario seems to be [using a reverse proxy](https://medium.com/intrinsic/why-should-i-use-a-reverse-proxy-if-node-js-is-production-ready-5a079408b2ca). There are two ways to do this: 1) [using iisnode](https://harveywilliams.net/blog/installing-iisnode) or [directly](https://dev.to/petereysermans/hosting-a-node-js-application-on-windows-with-iis-as-reverse-proxy-397b). We do not maintain these resources and recommend [using Linux servers to host your Node.js apps](https://azure.microsoft.com/en-us/develop/nodejs/).
+
 ## Install nvm-windows, node.js, and npm
 
 There are multiple ways to install Node.js. We recommend using a version manager as versions change very quickly. You will likely need to switch between multiple versions based on the needs of different projects you're working on. Node Version Manager, more commonly called nvm, is the most popular way to install multiple versions of Node.js, but is only available for Mac/Linux and not supported on Windows. Instead, we will walk through the steps to install nvm-windows and then use it to install Node.js and Node Package Manager (npm). There are [alternative version managers](#alternative-version-managers) to consider as well covered in the next section.
@@ -36,7 +39,7 @@ There are multiple ways to install Node.js. We recommend using a version manager
     ![NVM list showing no Node versions](../images/windows-nvm-powershell-no-node.png)
 
 6. Install the current release of Node.js (for testing the newest feature improvements, but more likely to have issues than the LTS version): `nvm install latest`
-7. Install the latest stable LTS release of Node.js (recommended) by first looking up what the current LTS version number is with: `nvm list available`, then installing the LTS version number with: `nvm install <version>` (replacing `<version>` with the number, ie: `nvm install 10.16.3`).
+7. Install the latest stable LTS release of Node.js (recommended) by first looking up what the current LTS version number is with: `nvm list available`, then installing the LTS version number with: `nvm install <version>` (replacing `<version>` with the number, ie: `nvm install 12.14.0`).
 
     ![NVM list of available versions](../images/windows-nvm-list.png)
 
@@ -53,7 +56,6 @@ There are multiple ways to install Node.js. We recommend using a version manager
 While windows-nvm is currently the most popular version manager for node, there are alternatives to consider:
 
 - [nvs](https://github.com/jasongin/nvs) (Node Version Switcher) is a cross-platform `nvm` alternative with the ability to [integrate with VS Code](https://github.com/jasongin/nvs/blob/master/doc/VSCODE.md).
-- 
 - [Volta](https://github.com/volta-cli/volta#installing-volta) is a new version manager from the LinkedIn team that claims improved speed and cross-platform support.
 
 To install Volta as your version manager (rather than windows-nvm), go to the **Windows Installation** section of their [Getting Started guide](https://docs.volta.sh/guide/getting-started), then download and run their Windows installer, following the setup instructions.


### PR DESCRIPTION
The instructions provided on the beginners page with this change should work in any shell, including WSL.

This also includes a few small fixes, like updating the Node.js LTS version.

cc @mattwojo, let me know if this needs any change or feel free to edit!

Fixes: https://github.com/MicrosoftDocs/windows-uwp/issues/2011
