### PR TITLE
Update display title to match heading

### DIFF
--- a/windows-apps-src/cpp-and-winrt-apis/weak-references.md
+++ b/windows-apps-src/cpp-and-winrt-apis/weak-references.md
@@ -1,6 +1,6 @@
 ---
 description: The Windows Runtime is a reference-counted system; and in such a system it's important for you to know about the significance of, and distinction between, strong and weak references.
-title: Weak references in C++/WinRT
+title: Strong and weak references in C++/WinRT
 ms.date: 05/16/2019
 ms.topic: article
 keywords: windows 10, uwp, standard, c++, cpp, winrt, projection, strong, weak, reference


### PR DESCRIPTION
The display title on this page does not match the heading on the page. I was confused looking through my open tabs to find one that started with "Strong and weak" and didn't find one. Turns out, the header doesn't match the metadata that makes the tab title.

This resolves that minor annoyance by making the metadata match the rest of the page.

I chose to bias toward "strong and weak" (instead of changing the heading to "weak" alone) because the heading says that and so does the TOC link. Two out of three votes used both, so I took that one.