### PR TITLE
Fix a link on the UISettings overview

### DIFF
--- a/windows-apps-src/composition/composition-tailoring.md
+++ b/windows-apps-src/composition/composition-tailoring.md
@@ -35,7 +35,7 @@ When turned off, acrylic material will automatically fall back to a solid color 
 ![Calculator with Acrylic](images/tailoring-acrylic.png)
 ![Calculator with Acrylic Responding to Transparency Settings](images/tailoring-acrylic-fallback.png)
 
-However, for any custom effects the application needs to respond to the [UISettings.AdvancedEffectsEnabled](https://docs.microsoft.com/uwp/api/windows.ui.viewmanagement.uisettings.advancedeffectsenabledchanged) property or [AdvancedEffectsEnabledChanged](https://docs.microsoft.com/uwp/api/windows.ui.viewmanagement.uisettings.advancedeffectsenabledchanged) event and switch out the effect/effect graph to use an effect that has no transparency. An example of this is below:
+However, for any custom effects the application needs to respond to the [UISettings.AdvancedEffectsEnabled](https://docs.microsoft.com/uwp/api/windows.ui.viewmanagement.uisettings.advancedeffectsenabled) property or [AdvancedEffectsEnabledChanged](https://docs.microsoft.com/uwp/api/windows.ui.viewmanagement.uisettings.advancedeffectsenabledchanged) event and switch out the effect/effect graph to use an effect that has no transparency. An example of this is below:
 
 ```cs
 public MainPage()


### PR DESCRIPTION
This link meant to go to the property, not the event.