### PR TITLE
Updated broken link for "What's a UWP app?"

### DIFF
--- a/windows-apps-src/index.yml
+++ b/windows-apps-src/index.yml
@@ -34,7 +34,7 @@ landingContent:
           - text: Browse Windows courses on Microsoft Learn
             url: https://docs.microsoft.com/learn/browse/?products=windows&resource_type=module
           - text: What's a UWP app?
-            url: /get-started/universal-application-platform-guide.md
+            url: https://docs.microsoft.com/windows/uwp/get-started/universal-application-platform-guide
 
   - title: Latest features
     linkLists:

--- a/windows-apps-src/index.yml
+++ b/windows-apps-src/index.yml
@@ -34,7 +34,7 @@ landingContent:
           - text: Browse Windows courses on Microsoft Learn
             url: https://docs.microsoft.com/learn/browse/?products=windows&resource_type=module
           - text: What's a UWP app?
-            url: https://docs.microsoft.com/windows/uwp/get-started/universal-application-platform-guide
+            url: get-started/universal-application-platform-guide
 
   - title: Latest features
     linkLists:

--- a/windows-apps-src/index.yml
+++ b/windows-apps-src/index.yml
@@ -34,7 +34,7 @@ landingContent:
           - text: Browse Windows courses on Microsoft Learn
             url: https://docs.microsoft.com/learn/browse/?products=windows&resource_type=module
           - text: What's a UWP app?
-            url: get-started/universal-application-platform-guide
+            url: get-started/universal-application-platform-guide.md
 
   - title: Latest features
     linkLists:


### PR DESCRIPTION
I noticed this broken link last week and filed an issue: https://github.com/MicrosoftDocs/feedback/issues/2484

This fix points to the page titled "What's a Universal Windows Platform (UWP) app?"