### PR TITLE
  Fix an ApiInformation.IsTypePresent check in Acrylic material doc

### DIFF
--- a/windows-apps-src/design/style/acrylic.md
+++ b/windows-apps-src/design/style/acrylic.md
@@ -231,7 +231,7 @@ To add an acrylic brush, define the three resources for dark, light and high con
 The following sample shows how to declare AcrylicBrush in code. If your app supports multiple OS targets, be sure to check that this API is available on the user’s machine.
 
 ```csharp
-if (Windows.Foundation.Metadata.ApiInformation.IsTypePresent("Windows.UI.Xaml.Media.XamlCompositionBrushBase"))
+if (Windows.Foundation.Metadata.ApiInformation.IsTypePresent("Windows.UI.Xaml.Media.AcrylicBrush"))
 {
     Windows.UI.Xaml.Media.AcrylicBrush myBrush = new Windows.UI.Xaml.Media.AcrylicBrush();
     myBrush.BackgroundSource = Windows.UI.Xaml.Media.AcrylicBackgroundSource.HostBackdrop;


### PR DESCRIPTION
Checking if the `Windows.UI.Xaml.Media.XamlCompositionBrushBase` type is present and using `Windows.UI.Xaml.Media.AcrylicBrush` will cause application crash on W10 Creators Update; as `XamlCompositionBrushBase` was introduced with Creators Update and `AcrylicBrush` with Fall Creators Update.