### PR TITLE
move-to-winrt-from-cx.md: Add code for array delay init

### DIFF
--- a/windows-apps-src/cpp-and-winrt-apis/move-to-winrt-from-cx.md
+++ b/windows-apps-src/cpp-and-winrt-apis/move-to-winrt-from-cx.md
@@ -337,7 +337,7 @@ TextBox boxes[3]{ nullptr };
 >         struct result;
 >         template <std::nullptr_t... Nullptrs>
 >         struct result<nullptr_list<Nullptrs...>>
->         { using type = nullptr_list<nullptr, Nullptrs...>; }> ;
+>         { using type = nullptr_list<nullptr, Nullptrs...>; };
 > 
 >         using remainder = typename make_nullptr_list<N - 1>::type;
 >         using type = typename result<remainder>::type;


### PR DESCRIPTION
Currently, /windows-apps-src/cpp-and-winrt-apis/move-to-winrt-from-cx.md states that there is no automated way to construct an array of empty (delayed-initialized) references in C++/WinRT.  This commit provides a TMP-based solution to show that such objective is indeed accomplishable, even if the solution is ad-hoc and verbose.

Because such requirement is arguably rarely encountered in the real world, the updated article puts the code and its surrounding paragraphs inside a `[!NOTE]`.

Problems that this commit may have:
1. The implementation listed in this commit lacks the divide-and-conquer optimization that would reduce the time and space complexity from O(N^2) to O(Nlog N).  Since we do not expect the reader to implement the optimization by themselves, we may want to update this solution to use the optimized algo.
2. On the other hand, the code in this commit is already long and potentially daunting to read, and optimizing it would only make it worse.
3. As mentioned in the added paragraphs, the hand-rolled code in this commit will be superseded in the future when C++ gets a library function that does the equivalent of `std::vector::vector(size_t, const T&)` for `std::array`.

Possible alternatives to merging this commit:
1. Put the code somewhere else on the web and link to that page in this article.
2. Add the proposed code to C++/WinRT instead.