### PR TITLE
Fix PowerShell path rendering by using code snippet

### DIFF
--- a/windows-apps-src/get-started/enable-your-device-for-development.md
+++ b/windows-apps-src/get-started/enable-your-device-for-development.md
@@ -188,7 +188,7 @@ You can use gpedit.msc to set the group policies to enable your device, unless y
 
     -   **Allow all trusted apps to install**
 
-    - OR -
+    OR
 
     To enable developer mode, edit the policies to enable both:
 
@@ -204,7 +204,7 @@ You can use gpedit.msc to set the group policies to enable your device, unless y
 
     -   `HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock\\AllowAllTrustedApps`
 
-    - OR -
+    OR
 
     To enable developer mode, set the values of this DWORD to 1:
 
@@ -215,13 +215,17 @@ You can use gpedit.msc to set the group policies to enable your device, unless y
 1.  Run PowerShell with administrator privileges.
 2.  To enable sideloading, run this command:
 
-    -   `PS C:\\WINDOWS\\system32&gt; reg add "HKEY\_LOCAL\_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock" /t REG\_DWORD /f /v "AllowAllTrustedApps" /d "1"`
+    ```powershell
+    PS C:\WINDOWS\system32> reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" /t REG_DWORD /f /v "AllowAllTrustedApps" /d "1"
+    ```
 
-    - OR -
+    OR
 
     To enable developer mode, run this command:
 
-    -   `PS C:\\WINDOWS\\system32&gt; reg add "HKEY\_LOCAL\_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock" /t REG\_DWORD /f /v "AllowDevelopmentWithoutDevLicense" /d "1"`
+    ```powershell
+    PS C:\WINDOWS\system32> reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" /t REG_DWORD /f /v "AllowDevelopmentWithoutDevLicense" /d "1"
+    ```
 
 ## Upgrade your device from Windows 8.1 to Windows 10
 

--- a/windows-apps-src/get-started/enable-your-device-for-development.md
+++ b/windows-apps-src/get-started/enable-your-device-for-development.md
@@ -202,13 +202,13 @@ You can use gpedit.msc to set the group policies to enable your device, unless y
 1.  Run **regedit**.
 2.  To enable sideloading, set the value of this DWORD to 1:
 
-    -   `HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock\\AllowAllTrustedApps`
+    -   `HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock\AllowAllTrustedApps`
 
     OR
 
     To enable developer mode, set the values of this DWORD to 1:
 
-    -   `HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock\\AllowDevelopmentWithoutDevLicense`
+    -   `HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock\AllowDevelopmentWithoutDevLicense`
 
 **Use PowerShell to enable your device**
 


### PR DESCRIPTION
Fixes #2295 

Code snippets should not be HTML escaped. As reference see [.\hub\python\scripting.md](.\hub\python\scripting.md)

Altered the powershell snippets to a real powershell snippet.

Also changed the rendering of the OR statements which felt a bit awkward, now starts at start of line without bullet and -. Old rendering:
![Capture](https://user-images.githubusercontent.com/5115577/77246394-06b0dd00-6c27-11ea-9a55-1f68a9930cc0.PNG)
