### PR TITLE
Added details on creating custom styles based on WinUI

### DIFF
--- a/windows-apps-src/design/style/rounded-corner.md
+++ b/windows-apps-src/design/style/rounded-corner.md
@@ -181,3 +181,15 @@ You can modify the [CornerRadius](/uwp/api/windows.ui.xaml.controls.control.corn
 |`<CheckBox Content="Checkbox"/>` | `<CheckBox Content="Checkbox" CornerRadius="5"/> ` |
 
 Not all controls' corners will respond to their `CornerRadius` property being modified. To ensure that the control whose corners you wish to round will indeed respond to their `CornerRadius` property the way you expect, first check that the `ControlCornerRadius` or `OverlayCornerRadius` global resources affect the control in question. If they do not, check that the control you wish to round has corners at all. Many of our controls do not render actual edges and therefore cannot make proper use of the `CornerRadius` property.
+
+### Basing custom styles on WinUI
+
+You can base your custom styles on the WinUI rounded corner styles by specifying the correct `BasedOn` attribute in your style. For example to create a custom button style based on WinUI button style, do the following:
+
+```
+<Style x:Key="MyCustomButtonStyle" BasedOn="{StaticResource DefaultButtonStyle}">
+   ...
+</Style>
+```
+
+In general, WinUI control styles follow a consistent naming convention: "DefaultXYZStyle" where "XYZ" is the name of the control. For full reference, you can browse the XAML files in the WinUI repository.

--- a/windows-apps-src/design/style/rounded-corner.md
+++ b/windows-apps-src/design/style/rounded-corner.md
@@ -186,7 +186,7 @@ Not all controls' corners will respond to their `CornerRadius` property being mo
 
 You can base your custom styles on the WinUI rounded corner styles by specifying the correct `BasedOn` attribute in your style. For example to create a custom button style based on WinUI button style, do the following:
 
-```
+```xaml
 <Style x:Key="MyCustomButtonStyle" BasedOn="{StaticResource DefaultButtonStyle}">
    ...
 </Style>


### PR DESCRIPTION
A common task is to create custom controls styles which are based on WinUI's styles. I have updated docs to make the naming convention clear and also show an example of this.