### PR TITLE
Fix broken link for link to app icons and logos

### DIFF
--- a/windows-apps-src/design/shell/tiles-and-notifications/creating-tiles.md
+++ b/windows-apps-src/design/shell/tiles-and-notifications/creating-tiles.md
@@ -45,7 +45,7 @@ There are a few items you should update:
 -   ShortName: Because there is limited room for your display name to fit on tiles, we recommend that you to specify a ShortName as well, to make sure your app's name doesn’t get truncated.
 -   Logo images:
 
-    You should replace these images with your own. You have the option of supplying images for different visual scales, but you are not required to supply them all. To ensure that you app looks good on a range of devices, we recommend that you provide 100%, 200%, and 400% scale versions of each image. See [Tile and icon assets](app-assets.md) to learn more about generating these assets.
+    You should replace these images with your own. You have the option of supplying images for different visual scales, but you are not required to supply them all. To ensure that you app looks good on a range of devices, we recommend that you provide 100%, 200%, and 400% scale versions of each image. See [App icons and logos](/windows/uwp/design/style/app-icons-and-logos) to learn more about generating these assets.
 
     Scaled images follow this naming convention:
     


### PR DESCRIPTION
Replaces a broken link with an up-to-date link. This link is intended to link to https://docs.microsoft.com/en-us/windows/uwp/design/style/app-icons-and-logos so please let me know if I edited this properly.