### PR TITLE
Fix JSON string to actually parse

### DIFF
--- a/windows-apps-src/monetize/send-requests-to-the-store.md
+++ b/windows-apps-src/monetize/send-requests-to-the-store.md
@@ -28,7 +28,7 @@ public async Task<bool> AddUserToFlightGroup()
 {
     StoreSendRequestResult result = await StoreRequestHelper.SendRequestAsync(
         StoreContext.GetDefault(), 8,
-        "{ \"type\": \"AddToFlightGroup\", \"parameters\": \"{ \"flightGroupId\": \"your group ID\" }\" }");
+        "{ \"type\": \"AddToFlightGroup\", \"parameters\": { \"flightGroupId\": \"your group ID\" } }");
 
     if (result.ExtendedError == null)
     {


### PR DESCRIPTION
I copied this example and was getting exceptions from the API. It appears the sub-object was wrapped in "'s when it should not be.