### PR TITLE
Include additional installer types from the v0.1 spec

### DIFF
--- a/hub/package-manager/package/manifest.md
+++ b/hub/package-manager/package/manifest.md
@@ -50,7 +50,7 @@ Publisher: string # the name of the publisher
 Name: string # the name of the application
 Version: string # version numbering format
 License: string # the open source license or copyright
-InstallerType: string # enumeration of supported installer types (exe, msi, msix)
+InstallerType: string # enumeration of supported installer types (exe, msi, msix, inno, wix, nullsoft, appx)
 Installers:
   - Arch: string # enumeration of supported architectures
   - URL: string # path to download installation file


### PR DESCRIPTION
Many users are using this page to write manifests manually and are unaware of the additional types [established in the v0.1 spec](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv0.1.md) that are available. This pull request mentions them. I will submit an additional pull request that mentions the generator located in the winget-pkgs Tools folder.