### PR TITLE
Removed generated file reference 'app.g.cpp'

### DIFF
--- a/hub/apps/desktop/modernize/host-custom-control-with-xaml-islands-cpp.md
+++ b/hub/apps/desktop/modernize/host-custom-control-with-xaml-islands-cpp.md
@@ -238,7 +238,6 @@ Next, revise the default **App** class in the **MyUWPApp** project to derive fro
         ```cpp
         #include "pch.h"
         #include "App.h"
-        #include "App.g.cpp"
         using namespace winrt;
         using namespace Windows::UI::Xaml;
         namespace winrt::MyUWPApp::implementation


### PR DESCRIPTION
The `app.g.cpp` file is never generated and sample code projects do not include it. 

The sample code provided does not include it

https://github.com/microsoft/Xaml-Islands-Samples/blob/0d84252237132f0e02421c6b7b22edff7dd6a803/Standalone_Samples/CppWinRT_Desktop_Win32App/UWPApplication/App.cpp#L1-L17