### PR TITLE
change KeyAccelerators to KeyboardAccelerators

### DIFF
--- a/windows-apps-src/design/input/keyboard-accelerators.md
+++ b/windows-apps-src/design/input/keyboard-accelerators.md
@@ -608,7 +608,7 @@ void AddAccelerator(
       { 
         Modifiers = keyModifiers, Key = key
       };
-    accelerator.Invoked = handler;
+    accelerator.Invoked += handler;
     this.KeyboardAccelerators.Add(accelerator);
   }
 ```

--- a/windows-apps-src/design/input/keyboard-accelerators.md
+++ b/windows-apps-src/design/input/keyboard-accelerators.md
@@ -609,7 +609,7 @@ void AddAccelerator(
         Modifiers = keyModifiers, Key = key
       };
     accelerator.Invoked = handler;
-    this.KeyAccelerators.Add(accelerator);
+    this.KeyboardAccelerators.Add(accelerator);
   }
 ```
 


### PR DESCRIPTION
`KeyAccelerators` property doesn't exist, but `UIElement.KeyboardAccelerators` does