### PR TITLE
Change Protocol Activation Parameter from Optional

### DIFF
--- a/windows-apps-src/launch-resume/launch-default-app.md
+++ b/windows-apps-src/launch-resume/launch-default-app.md
@@ -211,7 +211,7 @@ Or to edit a video: `ms-photos:videoedit?InputToken=123abc&Action=Trim&StartTime
 |------------|--------|
 | ms-photos:viewer?fileName={filename} | Launches the Photos app to view the specified image where {filename} is a fully-qualified path name. For example: `c:\users\userName\Pictures\ImageToView.jpg` |
 | ms-photos:videoedit?InputToken={input token} | Launches the Photos app in video editing mode for the file represented by the file token. **InputToken** is required. Use the  [SharedStorageAccessManager](https://docs.microsoft.com/uwp/api/Windows.ApplicationModel.DataTransfer.SharedStorageAccessManager) to get a token for a file. |
-| ms-photos:videoedit?Action={action} | An optional parameter that opens the Photos app in the specified video editing mode where {action} is one of: **SlowMotion**, **FrameExtraction**, **Trim**, **View**, **Ink**. If not specified, defaults to **View** |
+| ms-photos:videoedit?Action={action} | A parameter that indicates which video editing mode to open the Photos app in, where {action} is one of: **SlowMotion**, **FrameExtraction**, **Trim**, **View**, **Ink**. **Action** is required. |
 | ms-photos:videoedit?StartTime={timespan} | An optional parameter that specifies where to start playing the video. `{timespan}` must be in the format `"hh:mm:ss.ffff"`. If not specified, defaults to `00:00:00.0000` |
 
 ### Settings app URI scheme


### PR DESCRIPTION
I work at Microsoft (on the Windows Media Apps team - feel free to ping me on Teams 👍) and recently encountered an issue when trying to launch a video for editing with this URI scheme. I was only specifying the InputToken parameter here, since the others were indicated as optional, and my video would never open, I just get a black screen. 
Feel free to try it with the Windows Store build of Photos and you'll see this same behavior. I dug around in the code and it turns out that you do need to specify this parameter for the videoedit activation to work. As such, it should be changed from an optional parameter to a required one.