### PR TITLE
Update xmlns namespace

### DIFF
--- a/hub/apps/winui/winui2/getting-started.md
+++ b/hub/apps/winui/winui2/getting-started.md
@@ -69,7 +69,7 @@ You can optionally check "Include prerelease" to see the latest prerelease versi
     * In your XAML page, add a reference at the top of your page
 
         ```xaml
-        xmlns:controls="using:Microsoft.UI.Xaml.Controls"
+        xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
         ```
 
     * In your code (if you want to use the type names without qualifying them), you can add a using directive.


### PR DESCRIPTION
This aligns it with code example and the rest of the samples that usually use `muxc` as the prefix elsewhere in the docs.