### PR TITLE
Update ARM64 SDK announce link

### DIFF
--- a/landing/arm-docs/index.yml
+++ b/landing/arm-docs/index.yml
@@ -8,8 +8,8 @@ metadata:
   description: This page provides the information for you to get started developing ARM64 win32 and UWP apps. # Required; article description that is displayed in search results. < 160 chars.
   ms.service: guidance #Required; service per approved list. service slug assigned to your service by ACOM.
   ms.topic: landing-page # Required
-  author: msatranjr #Required; your GitHub user alias, with correct capitalization.
-  ms.author: misatran #Required; microsoft alias of author; optional team alias.
+  author: hickeys #Required; your GitHub user alias, with correct capitalization.
+  ms.author: hickeys #Required; microsoft alias of author; optional team alias.
   ms.date: 05/08/2018 #Required; mm/dd/yyyy format.
   ms.localizationpriority: medium
 

--- a/landing/arm-docs/index.yml
+++ b/landing/arm-docs/index.yml
@@ -44,7 +44,7 @@ landingContent:
       - linkListType: how-to-guide
         links:
           - text: Build ARM64 apps with the SDK
-            url: https://blogs.windows.com/buildingapps/?p=52087
+            url: https://blogs.windows.com/windowsdeveloper/2018/11/15/official-support-for-windows-10-on-arm-development/
           - text: UWP apps on ARM
             url: /windows/uwp/porting/apps-on-arm-troubleshooting-arm32
           - text: Debug on ARM


### PR DESCRIPTION
The link for Build ARM64 apps with the SDK should point to the blogpost announcing the actual release rather than the blogpost announcing the preview.