### PR TITLE
Remove unneeded cast, remove <syntaxhighlight> from .vcxproj snippet

### DIFF
--- a/windows-apps-src/cpp-and-winrt-apis/interop-winrt-cx.md
+++ b/windows-apps-src/cpp-and-winrt-apis/interop-winrt-cx.md
@@ -36,8 +36,7 @@ T from_cx(Platform::Object^ from)
     T to{ nullptr };
 
     winrt::check_hresult(reinterpret_cast<::IUnknown*>(from)
-        ->QueryInterface(winrt::guid_of<T>(),
-            reinterpret_cast<void**>(winrt::put_abi(to))));
+        ->QueryInterface(winrt::guid_of<T>(), winrt::put_abi(to)));
 
     return to;
 }
@@ -96,11 +95,9 @@ If you're porting in one pass, then you don't need to do this. But if you need t
 Alternatively (or, for a XAML project, in addition), you can add C++/CX support by using the C++/WinRT project property page in Visual Studio. In project properties, **Common Properties** \> **C++/WinRT** \> **Project Language** \> **C++/CX**. Doing that will add the following property to your `.vcxproj` file.
 
 ```xml
-<syntaxhighlight lang="xml">
   <PropertyGroup Label="Globals">
     <CppWinRTProjectLanguage>C++/CX</CppWinRTProjectLanguage>
   </PropertyGroup>
-</syntaxhighlight>
 ```
 
 > [!IMPORTANT]


### PR DESCRIPTION
the cast is not needed
`<syntaxhighlight>` looks like it was picked up in the conversion from mediawiki to markdown. it is not valid in the .vcxproj schema