### PR TITLE
Update index.md - need to enable a VS option to use .NET Core previews

### DIFF
--- a/hub/apps/winui/winui3/index.md
+++ b/hub/apps/winui/winui3/index.md
@@ -43,6 +43,7 @@ WinUI 3 Preview 2 includes Visual Studio project templates to help get started b
 
     - x64: [https://aka.ms/dotnet/net5/preview5/Sdk/dotnet-sdk-win-x64.exe](https://aka.ms/dotnet/net5/preview5/Sdk/dotnet-sdk-win-x64.exe)
     - x86: [https://aka.ms/dotnet/net5/preview5/Sdk/dotnet-sdk-win-x86.exe](https://aka.ms/dotnet/net5/preview5/Sdk/dotnet-sdk-win-x86.exe)
+    - You must also enable "Use previews of the .NET Core SDK (requires restart) option in Visual Studio. It's under Options -> Environment -> Preview Features.
 
 4. Download and install the [WinUI 3 Preview 2 VSIX package](https://aka.ms/winui3/previewdownload). This VSIX package adds the WinUI 3 project templates and NuGet package containing the WinUI 3 libraries to Visual Studio 2019.
 


### PR DESCRIPTION
Not enabling this "Use previews of the .NET Core SDK" option gives cryptic build errors about missing a developer pack when building desktop WinUI projects:
```
The reference assemblies for .NETFramework,Version=v5.0 were not found. To resolve this, install the Developer Pack (SDK/Targeting Pack) for this framework version or retarget your application. You can download .NET Framework Developer Packs at https://aka.ms/msbuild/developerpacks
```