### PR TITLE
Request Example for posting to Review: Example error IsPublic should …

### DIFF
--- a/windows-apps-src/monetize/submit-responses-to-app-reviews.md
+++ b/windows-apps-src/monetize/submit-responses-to-app-reviews.md
@@ -81,14 +81,14 @@ Content-Type: application/json
       "ReviewId": "6be543ff-1c9c-4534-aced-af8b4fbe0316",
       "ResponseText": "Thank you for pointing out this bug. I fixed it and published an update, you should have the fix soon",
       "SupportEmail": "support@contoso.com",
-      "IsPublic": "true"
+      "IsPublic": true
     },
     {
       "ApplicationId": "9NBLGGH1RP08",
       "ReviewId": "80c9671a-96c2-4278-bcbc-be0ce5a32a7c",
       "ResponseText": "Thank you for submitting your review. Can you tell more about what you were doing in the app when it froze? Thanks very much for your help.",
       "SupportEmail": "support@contoso.com",
-      "IsPublic": "false"
+      "IsPublic": false
     }
   ]
 }


### PR DESCRIPTION
…be bool not string.

I've had someone submit an issue with this Example below

```json
POST https://manage.devcenter.microsoft.com/v1.0/my/reviews/responses HTTP/1.1
Authorization: Bearer <your access token>
Content-Type: application/json
{
  "Responses": [
    {
      "ApplicationId": "9WZDNCRFJ3Q8",
      "ReviewId": "6be543ff-1c9c-4534-aced-af8b4fbe0316",
      "ResponseText": "Thank you for pointing out this bug. I fixed it and published an update, you should have the fix soon",
      "SupportEmail": "support@contoso.com",
      "IsPublic": "true"
    },
    {
      "ApplicationId": "9NBLGGH1RP08",
      "ReviewId": "80c9671a-96c2-4278-bcbc-be0ce5a32a7c",
      "ResponseText": "Thank you for submitting your review. Can you tell more about what you were doing in the app when it froze? Thanks very much for your help.",
      "SupportEmail": "support@contoso.com",
      "IsPublic": "false"
    }
  ]
}
```
It seems that this IsPublic value should be a bool, and the backend system fails to convert the String to a bool. The customer changed this from "true" to true and he was then able to submit his reviews.  The system did not return any errors and in fact returned a response of Successful = true.

I was not able to verify this on my own, as setting up a review process requires enterprise setup beyond my abilities. Is it possible the doc is wrong and requires a fix, or should be backend be more robust to handle strings as well as bools in the IsPublic field.