### PR TITLE
Added the correct namespaces in the schema of the alias integration

### DIFF
--- a/hub/apps/desktop/modernize/desktop-to-uwp-extensions.md
+++ b/hub/apps/desktop/modernize/desktop-to-uwp-extensions.md
@@ -1024,14 +1024,14 @@ Users and other processes can use an alias to start your application without hav
 #### Elements and attributes of this extension
 
 ```XML
-<Extension
+<uap3:Extension
     Category="windows.appExecutionAlias"
     Executable="[ExecutableName]"
     EntryPoint="Windows.FullTrustApplication">
-    <AppExecutionAlias>
+    <uap3:AppExecutionAlias>
         <desktop:ExecutionAlias Alias="[AliasName]" />
-    </AppExecutionAlias>
-</Extension>
+    </uap3:AppExecutionAlias>
+</uap3:Extension>
 ```
 
 |Name |Description |


### PR DESCRIPTION
The original schema related to the feature "Start your application by using an alias" was missing the usage of the uap3 namespace, which is required for the manifest to be valid.