### PR TITLE
Mention required nuget.org package source

### DIFF
--- a/hub/apps/winui/winui3/index.md
+++ b/hub/apps/winui/winui3/index.md
@@ -42,7 +42,7 @@ WinUI 3 Preview 2 includes Visual Studio project templates to help get started b
     After you install Visual Studio, make sure you enable .NET previews within the program: 
     - Go to Tools > Options > Preview Features > Select "Use previews of the .NET Core SDK (requires restart)". 
     
-3. Make sure your system has a NuGet package source enabled for **nuget.org**. For more information, see https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior.
+3. Make sure your system has a NuGet package source enabled for **nuget.org**. For more information, see [Common NuGet configurations](/nuget/consume-packages/configuring-nuget-behavior).
 
 4. If you want to create desktop WinUI projects for C#/.NET 5 and C++/Win32 apps, you must install both x64 and x86 versions of .NET 5 Preview 5. **Note that .NET 5 Preview 5 is currently the only supported .NET 5 preview for WinUI 3**:
 

--- a/hub/apps/winui/winui3/index.md
+++ b/hub/apps/winui/winui3/index.md
@@ -22,7 +22,9 @@ Windows UI Library (WinUI) 3 is a native user experience (UX) framework for both
 
 ## Install WinUI 3 Preview 2
 
-WinUI 3 Preview 2 includes Visual Studio project templates to help get started building apps with a WinUI-based user interface, and a NuGet package that contains the WinUI libraries. To install WinUI 3 Preview 2, follow these steps.
+WinUI 3 Preview 2 includes Visual Studio project templates to help get started building apps with a WinUI-based user interface, and a NuGet package that contains the WinUI libraries. Ensure your system has a NuGet Package Source enabled for **nuget.org**. For more information, see https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior.
+
+To install WinUI 3 Preview 2, follow these steps.
 
 > [!NOTE]
 > You can also clone and build the WinUI 3 Preview 2 version of the [XAML Controls Gallery](#xaml-controls-gallery-winui-3-preview-2-branch).

--- a/hub/apps/winui/winui3/index.md
+++ b/hub/apps/winui/winui3/index.md
@@ -22,9 +22,7 @@ Windows UI Library (WinUI) 3 is a native user experience (UX) framework for both
 
 ## Install WinUI 3 Preview 2
 
-WinUI 3 Preview 2 includes Visual Studio project templates to help get started building apps with a WinUI-based user interface, and a NuGet package that contains the WinUI libraries. Ensure your system has a NuGet Package Source enabled for **nuget.org**. For more information, see https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior.
-
-To install WinUI 3 Preview 2, follow these steps.
+WinUI 3 Preview 2 includes Visual Studio project templates to help get started building apps with a WinUI-based user interface, and a NuGet package that contains the WinUI libraries. To install WinUI 3 Preview 2, follow these steps.
 
 > [!NOTE]
 > You can also clone and build the WinUI 3 Preview 2 version of the [XAML Controls Gallery](#xaml-controls-gallery-winui-3-preview-2-branch).
@@ -41,15 +39,17 @@ To install WinUI 3 Preview 2, follow these steps.
     - Desktop development with C++
     - The *C++ (v142) Universal Windows Platform tools* optional component for the Universal Windows Platform workload (see "Installation Details" under the "Universal Windows Platform development" section, on the right pane)
 
-    Once you've downloaded Visual Studio, make sure you enable .NET previews within the program: 
+    After you install Visual Studio, make sure you enable .NET previews within the program: 
     - Go to Tools > Options > Preview Features > Select "Use previews of the .NET Core SDK (requires restart)". 
+    
+3. Make sure your system has a NuGet package source enabled for **nuget.org**. For more information, see https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior.
 
-3. If you want to create desktop WinUI projects for C#/.NET 5 and C++/Win32 apps, you must also install both x64 and x86 versions of .NET 5 Preview 5. **Note that .NET 5 Preview 5 is currently the only supported .NET 5 preview for WinUI 3**:
+4. If you want to create desktop WinUI projects for C#/.NET 5 and C++/Win32 apps, you must install both x64 and x86 versions of .NET 5 Preview 5. **Note that .NET 5 Preview 5 is currently the only supported .NET 5 preview for WinUI 3**:
 
     - [x64 installer for .NET 5 Preview 5](https://dotnet.microsoft.com/download/dotnet/thank-you/sdk-5.0.100-preview.5-windows-x64-installer)
     - [x86 installer for .NET 5 Preview 5](https://dotnet.microsoft.com/download/dotnet/thank-you/sdk-5.0.100-preview.5-windows-x86-installer)
 
-4. Download and install the [WinUI 3 Preview 2 VSIX package](https://aka.ms/winui3/previewdownload). This VSIX package adds the WinUI 3 project templates and NuGet package containing the WinUI 3 libraries to Visual Studio 2019.
+5. Download and install the [WinUI 3 Preview 2 VSIX package](https://aka.ms/winui3/previewdownload). This VSIX package adds the WinUI 3 project templates and NuGet package containing the WinUI 3 libraries to Visual Studio 2019.
 
     For directions on how to add the VSIX package to Visual Studio, see [Finding and Using Visual Studio Extensions](/visualstudio/ide/finding-and-using-visual-studio-extensions#install-without-using-the-manage-extensions-dialog-box).
 


### PR DESCRIPTION
If nuget.org is not an enabled package source on the machine, an error will occur while trying to create the project. 
NuGet does not currently support referencing a package from a VSIX, so the remote source is still necessary: https://github.com/NuGet/Home/issues/4693