### PR TITLE
Corrected related topic link test for Motion in UWP apps

### DIFF
--- a/windows-apps-src/design/motion/page-transitions.md
+++ b/windows-apps-src/design/motion/page-transitions.md
@@ -98,4 +98,4 @@ This can be useful when you modify navigation behavior dynamically based on scre
 ## Related topics
 
 - [Navigate between two pages](../basics/navigate-between-two-pages.md)
-- [Motion in UWindowsWP apps](index.md)
+- [Motion in UWP apps](index.md)


### PR DESCRIPTION
Changes have been made to the text of a related link in the UWP page transitions doc found while reading through.

Previously said:

`Motion in UWindowsWP apps`

Changed to:

`Motion in UWP apps`