### PR TITLE
Update broken link

### DIFF
--- a/windows-apps-src/get-started/universal-application-platform-guide.md
+++ b/windows-apps-src/get-started/universal-application-platform-guide.md
@@ -13,7 +13,7 @@ ms.localizationpriority: medium
 
 UWP is one of many ways to create client applications for Windows. UWP apps use WinRT APIs to provide powerful UI and advanced asynchronous features that are ideal for internet-connected devices.
 
-To download the tools you need to start creating UWP apps, see [Get set up](/windows/apps/get-set-up), and then [write your first app](your-first-app.md).
+To download the tools you need to start creating UWP apps, see **Get set up** section in [Get started](/windows/uwp/get-started/), and then [write your first app](your-first-app.md).
 
 
 ## Where does UWP fit in the Microsoft development story?


### PR DESCRIPTION
"Get set up" link is broken. However, there is a "Get set up" section in the /windows/uwp/get-started/ page. I assume the link pointed to a stand-alone page but then moved into a section of the "Get started" page. Thus, this update it changes the link along with the link text to describe the location properly.