### PR TITLE
Add extras bucket addition.

### DIFF
--- a/hub/powertoys/install.md
+++ b/hub/powertoys/install.md
@@ -69,6 +69,7 @@ If you have issues when installing/upgrading, visit the [PowerToys package on Ch
 To install PowerToys using [Scoop](https://scoop.sh/), run the following command from the command line / PowerShell:
 
 ```powershell
+scoop bucket add extras
 scoop install powertoys
 ```
 


### PR DESCRIPTION
Powertools is located in `scoop-extras` bucket (https://github.com/lukesampson/scoop-extras).
Installation of scoop needs addition of extras bucket to scoop.
Added extra line that adds `extras` bucket before installation of `powertoys`.