### PR TITLE
Fixing a missing `#endif`

### DIFF
--- a/hub/apps/winui/winui3/xaml-templated-controls-cppwinrt-winui-3.md
+++ b/hub/apps/winui/winui3/xaml-templated-controls-cppwinrt-winui-3.md
@@ -102,6 +102,7 @@ Next, replace the contents of BgLabelControl.cpp with the following code.
 #include "BgLabelControl.h"
 #if __has_include("BgLabelControl.g.cpp")
 #include "BgLabelControl.g.cpp"
+#endif
 
 namespace winrt::BgLabelControlApp::implementation
 {


### PR DESCRIPTION
The application doesn't compile after copying and pasting the provided source code.
This change adds the missing `#endif` that allows the code to compile.