### PR TITLE
Replace WinDeployAppCmd with WinAppDeployCmd

### DIFF
--- a/windows-apps-src/debug-test-perf/loose-file-registration.md
+++ b/windows-apps-src/debug-test-perf/loose-file-registration.md
@@ -25,7 +25,7 @@ Loose file layout is simply the act of placing app contents in a folder instead 
 
 ## How to register a loose file layout
 
-Windows provides multiple developer tools to register loose file layouts on local and remote devices. You can choose from `WinDeployAppCmd` (Windows SDK Tool), Windows Device Portal, PowerShell, and [Visual Studio](./deploying-and-debugging-uwp-apps.md#register-layout-from-network). Below we will go over how to register loose files using these tools. But first, ensure that you have following setup:
+Windows provides multiple developer tools to register loose file layouts on local and remote devices. You can choose from `WinAppDeployCmd` (Windows SDK Tool), Windows Device Portal, PowerShell, and [Visual Studio](./deploying-and-debugging-uwp-apps.md#register-layout-from-network). Below we will go over how to register loose files using these tools. But first, ensure that you have following setup:
 
 - Your devices must be on the Windows 10 Creators Update (Build 14965) or later.
 - You will need to enable [developer mode](/windows/apps/get-started/enable-your-device-for-development) and [device discovery](/windows/apps/get-started/enable-your-device-for-development#device-discovery) on all devices.
@@ -33,9 +33,9 @@ Windows provides multiple developer tools to register loose file layouts on loca
 > [!IMPORTANT]
 > Loose file registration is only available on devices that support the Network Share (SMB) Protocol: Desktop and Xbox. 
 
-### Register with WinDeployAppCmd
+### Register with WinAppDeployCmd
 
-If you are using the SDK tools corresponding to the Windows 10 Creators Update (Build 14965) or later, you can use the `WinDeployAppCmd` command in a Command Prompt.
+If you are using the SDK tools corresponding to the Windows 10 Creators Update (Build 14965) or later, you can use the `WinAppDeployCmd` command in a Command Prompt.
 
 ```cmd
 WinAppDeployCmd.exe registerfiles -remotedeploydir <Network Path> -ip <IP Address> -pin <target machine PIN>


### PR DESCRIPTION
This pull request replaces a wrong command name `WinDeployAppCmd` with the correct one `WinAppDeployCmd`.