### PR TITLE
Fix credential locker example

### DIFF
--- a/windows-apps-src/security/credential-locker.md
+++ b/windows-apps-src/security/credential-locker.md
@@ -86,7 +86,7 @@ private Windows.Security.Credentials.PasswordCredential GetCredentialFromLocker(
     {
         credentialList = vault.FindAllByResource("bunq");
     }
-    catch(Exception ex)
+    catch(Exception)
     {
         return null;
     }

--- a/windows-apps-src/security/credential-locker.md
+++ b/windows-apps-src/security/credential-locker.md
@@ -79,7 +79,18 @@ private Windows.Security.Credentials.PasswordCredential GetCredentialFromLocker(
     Windows.Security.Credentials.PasswordCredential credential = null;
 
     var vault = new Windows.Security.Credentials.PasswordVault();
-    var credentialList = vault.FindAllByResource(resourceName);
+
+    IReadOnlyList<PasswordCredential> credentialList = null;
+
+    try
+    {
+        credentialList = vault.FindAllByResource("bunq");
+    }
+    catch(Exception ex)
+    {
+        return null;
+    }
+
     if (credentialList.Count > 0)
     {
         if (credentialList.Count == 1)

--- a/windows-apps-src/security/credential-locker.md
+++ b/windows-apps-src/security/credential-locker.md
@@ -84,9 +84,9 @@ private Windows.Security.Credentials.PasswordCredential GetCredentialFromLocker(
 
     try
     {
-        credentialList = vault.FindAllByResource("bunq");
+        credentialList = vault.FindAllByResource(resourceName);
     }
-    catch(Exception)
+    catch(Exception) when (ex.Message.EndsWith("Cannot find credential in Vault"))
     {
         return null;
     }

--- a/windows-apps-src/security/credential-locker.md
+++ b/windows-apps-src/security/credential-locker.md
@@ -86,7 +86,7 @@ private Windows.Security.Credentials.PasswordCredential GetCredentialFromLocker(
     {
         credentialList = vault.FindAllByResource(resourceName);
     }
-    catch(Exception) when (ex.Message.EndsWith("Cannot find credential in Vault"))
+    catch(Exception)
     {
         return null;
     }

--- a/windows-apps-src/security/intro-to-secure-windows-app-development.md
+++ b/windows-apps-src/security/intro-to-secure-windows-app-development.md
@@ -341,7 +341,7 @@ private PasswordCredential GetCredentialFromLocker()
     {
         credentialList = vault.FindAllByResource("bunq");
     }
-    catch(Exception ex)
+    catch(Exception)
     {
         return null;
     }

--- a/windows-apps-src/security/intro-to-secure-windows-app-development.md
+++ b/windows-apps-src/security/intro-to-secure-windows-app-development.md
@@ -341,7 +341,7 @@ private PasswordCredential GetCredentialFromLocker()
     {
         credentialList = vault.FindAllByResource(resourceName);
     }
-    catch(Exception) when (ex.Message.EndsWith("Cannot find credential in Vault"))
+    catch(Exception)
     {
         return null;
     }

--- a/windows-apps-src/security/intro-to-secure-windows-app-development.md
+++ b/windows-apps-src/security/intro-to-secure-windows-app-development.md
@@ -334,7 +334,17 @@ private PasswordCredential GetCredentialFromLocker()
     PasswordCredential credential = null;
 
     var vault = new PasswordVault();
-    var credentialList = vault.FindAllByResource(resourceName);
+
+    IReadOnlyList<PasswordCredential> credentialList = null;
+
+    try
+    {
+        credentialList = vault.FindAllByResource("bunq");
+    }
+    catch(Exception ex)
+    {
+        return null;
+    }
 
     if (credentialList.Count == 1)
     {

--- a/windows-apps-src/security/intro-to-secure-windows-app-development.md
+++ b/windows-apps-src/security/intro-to-secure-windows-app-development.md
@@ -339,9 +339,9 @@ private PasswordCredential GetCredentialFromLocker()
 
     try
     {
-        credentialList = vault.FindAllByResource("bunq");
+        credentialList = vault.FindAllByResource(resourceName);
     }
-    catch(Exception)
+    catch(Exception) when (ex.Message.EndsWith("Cannot find credential in Vault"))
     {
         return null;
     }


### PR DESCRIPTION
Hi,

this PR addresses the issue #3045. It implements the proposed solution by catching the exception thrown by `vault.FindAllByResource` and returns null.