### PR TITLE
Removed docs for missing glyph E7B3 (RedEye)

### DIFF
--- a/windows-apps-src/design/style/segoe-ui-symbol-font.md
+++ b/windows-apps-src/design/style/segoe-ui-symbol-font.md
@@ -666,10 +666,6 @@ The following table of glyphs displays unicode points prefixed from E7-  to E9-.
   <td>E7AD</td>
   <td>Rotate</td>
  </tr>
-<tr><td><img src="images/segoe-mdl/E7B3.png" width="32" height="32" alt="RedEye" /></td>
-  <td>E7B3</td>
-  <td>RedEye</td>
- </tr>
 <tr><td><img src="images/segoe-mdl/E7B5.png" width="32" height="32" alt="SetlockScreen" /></td>
   <td>E7B5</td>
   <td>SetlockScreen</td>


### PR DESCRIPTION
The glyph `E7B3` (RedEye) is not present in the font in the latest Window 10 version, nor in the [downlodable font](https://aka.ms/SegoeFonts). Removed the doc's reference to that glyph to avoid confusion.