### PR TITLE
Fix 404 link to rust docs on microsoft.github.io

### DIFF
--- a/hub/dev-environment/rust/index.yml
+++ b/hub/dev-environment/rust/index.yml
@@ -54,6 +54,6 @@ landingContent:
           - text: The Rust website
             url: https://www.rust-lang.org/
           - text: Rust documentation for the Windows API
-            url: https://microsoft.github.io/windows-docs-rs/doc/bindings/windows/
+            url: https://microsoft.github.io/windows-docs-rs/doc/bindings/Windows/
           - text: Minesweeper sample app
             url: https://github.com/robmikh/minesweeper-rs


### PR DESCRIPTION
Possibly the most windows appropriate fix there is.