### PR TITLE
Update winrt-com-interop-csharp.md

### DIFF
--- a/hub/apps/desktop/modernize/winrt-com-interop-csharp.md
+++ b/hub/apps/desktop/modernize/winrt-com-interop-csharp.md
@@ -61,7 +61,8 @@ To configure your desktop project to access the C# interop classes, follow these
         var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
         var folderPicker = new Windows.Storage.Pickers.FolderPicker();
         WinRT.Interop.InitializeWithWindow.Initialize(folderPicker, hwnd);
-
+        folderPicker.FileTypeFilter.Add("*");
+        
         // Now you can call methods on folderPicker
         var folder = await folderPicker.PickSingleFolderAsync();
         // ...


### PR DESCRIPTION
The example code encounters the following error
`System.Runtime.InteropServices.COMException: 'Error HRESULT E_FAIL has been returned from a call to a COM component.'
`
Adding the following code solves this problem
`folderPicker.FileTypeFilter.Add("*");`