### PR TITLE
Updated runtime installer name to WindowsAppSDKInstall.exe

### DIFF
--- a/hub/apps/windows-app-sdk/tutorial-unpackaged-deployment.md
+++ b/hub/apps/windows-app-sdk/tutorial-unpackaged-deployment.md
@@ -211,7 +211,7 @@ You can choose to follow this tutorial using a C++ project or a C# project that 
                     return MddBootstrapInitialize(majorMinorVersion, versionTag, minVersion);
                 }
         
-                [DllImport("Microsoft.ProjectReunion.Bootstrap.dll", CharSet = CharSet.Unicode)]
+                [DllImport("Microsoft.WindowsAppSDK.Bootstrap.dll", CharSet = CharSet.Unicode)]
                 private static extern int MddBootstrapInitialize(uint majorMinorVersion, string versionTag, PackageVersion packageVersion);
         
                 public static void Shutdown()
@@ -219,7 +219,7 @@ You can choose to follow this tutorial using a C++ project or a C# project that 
                     MddBootstrapShutdown();
                 }
         
-                [DllImport("Microsoft.ProjectReunion.Bootstrap.dll")]
+                [DllImport("Microsoft.WindowsAppSDK.Bootstrap.dll")]
                 private static extern void MddBootstrapShutdown();
             }
         }

--- a/hub/apps/windows-app-sdk/tutorial-unpackaged-deployment.md
+++ b/hub/apps/windows-app-sdk/tutorial-unpackaged-deployment.md
@@ -28,8 +28,8 @@ Before completing this tutorial, we recommend that you review [Runtime architect
     > Although we encourage you to install the Windows App SDK extension for Visual Studio, you do not need to install the extension to perform this tutorial. In this tutorial, you will install the Windows App SDK NuGet package directly in an existing project.
 - Ensure all [dependencies for unpackaged apps](deployment-architecture.md#additional-requirements-for-unpackaged-apps) are installed. The simplest solution is to run the Windows App SDK runtime installer:
 
-  1. Download [ReunionRuntimeInstaller.exe from GitHub](https://aka.ms/windowsappsdk/1.0-experimental).
-  2. From a command prompt, run `ReunionRuntimeInstaller.exe` to install all the dependencies.
+  1. Download [WindowsAppSDKInstall.exe from GitHub](https://aka.ms/windowsappsdk/1.0-experimental).
+  2. From a command prompt, run `WindowsAppSDKInstall.exe` to install all the dependencies.
 
 ## Instructions
 


### PR DESCRIPTION
The documentation still refers to ReunionRuntimeInstaller.exe, but the version currently published on GitHub has already been rebranded to WindowsAppSDKInstall.exe