### PR TITLE
Fix C# code sample typo

### DIFF
--- a/windows-apps-src/launch-resume/handle-file-activation.md
+++ b/windows-apps-src/launch-resume/handle-file-activation.md
@@ -83,7 +83,7 @@ The [**OnFileActivated**](/uwp/api/windows.ui.xaml.application.onfileactivated) 
 protected override void OnFileActivated(FileActivatedEventArgs args)
 {
        // TODO: Handle file activation
-       // The number of files received is args.Files.Size
+       // The number of files received is args.Files.Count
        // The name of the first file is args.Files[0].Name
 }
 ```


### PR DESCRIPTION
In C# the [IReadOnlyList<T> returned for args.Files](https://docs.microsoft.com/en-us/uwp/api/windows.applicationmodel.activation.fileactivatedeventargs.files?view=winrt-20348#Windows_ApplicationModel_Activation_FileActivatedEventArgs_Files) does not have a `.Size` property, but it does have a `.Count`. I am not sure about the other languages though I suspect it may be the same typo than needs verifying and correcting.