### PR TITLE
Add extract parameter to file upload

### DIFF
--- a/windows-apps-src/debug-test-perf/device-portal-api-core.md
+++ b/windows-apps-src/debug-test-perf/device-portal-api-core.md
@@ -4431,7 +4431,7 @@ Upload a file to a folder.  This will overwrite an existing file with the same n
 | :------     | :----- |
 | knownfolderid | (**required**) The top-level directory where you want to upload files. Use **LocalAppData** for access to sideloaded apps. |
 | packagefullname | (**required if *knownfolderid* == LocalAppData**) The package full name of the app you are interested in. |
-| extract | (**required**) Can be `"true"` or `"false"`. This indicates if the file should be extracted after upload.|
+| extract | (**required**) True or false. This indicates whether the file should be extracted after upload.|
 | path | (**optional**) The sub-directory within the folder or package specified above. |
 
 **Request headers**

--- a/windows-apps-src/debug-test-perf/device-portal-api-core.md
+++ b/windows-apps-src/debug-test-perf/device-portal-api-core.md
@@ -3450,7 +3450,7 @@ The WER reports in the following format.
                 "Name": string, (not base64 encoded)
                 "Type": string ("Queue" or "Archive")
             },
-    },...
+    ]},...
 ]}
 ```
 

--- a/windows-apps-src/debug-test-perf/device-portal-api-core.md
+++ b/windows-apps-src/debug-test-perf/device-portal-api-core.md
@@ -4431,6 +4431,7 @@ Upload a file to a folder.  This will overwrite an existing file with the same n
 | :------     | :----- |
 | knownfolderid | (**required**) The top-level directory where you want to upload files. Use **LocalAppData** for access to sideloaded apps. |
 | packagefullname | (**required if *knownfolderid* == LocalAppData**) The package full name of the app you are interested in. |
+| extract | (**required**) Can be `"true"` or `"false"`. This indicates if the file should be extracted after upload.|
 | path | (**optional**) The sub-directory within the folder or package specified above. |
 
 **Request headers**


### PR DESCRIPTION
The extract parameter is missing in the documentation although it is required.