### PR TITLE
Update index.md

### DIFF
--- a/hub/apps/get-started/index.md
+++ b/hub/apps/get-started/index.md
@@ -41,6 +41,24 @@ For more information about WinUI 3 apps, see see the following articles:
 - [Samples](https://github.com/microsoft/Xaml-Controls-Gallery/tree/winui3preview)
 
 
+#### [UWP](#tab/uwp)
+
+The Universal Windows Platform (UWP) provides a common type system, APIs, and application model for all devices that run Windows 10 and later versions. Not only can you use UWP to create desktop applications for Windows PCs, but UWP is also the only supported platform for Xbox, HoloLens, and Surface Hub applications. UWP apps can be native or managed.
+
+UWP is a highly customizable platform and can use XAML markup to separate UI (presentation) from code (business logic). UWP is suitable for desktop apps that require a sophisticated UI, styles customization, and graphics-intensive scenarios. UWP also has built-in support for the [Fluent Design System](/windows/uwp/design/fluent-design-system/) via XAML for the default UX experience and provides access to the [Windows Runtime (WinRT) APIs](/windows/uwp/get-started/universal-application-platform-guide#how-the-universal-windows-platform-relates-to-windows-runtime-apis).
+
+For more information about UWP apps, see the following articles:
+
+- [Set up your development environment](../windows-app-sdk/set-up-your-development-environment.md)
+- [Get started](/windows/uwp/get-started/)
+- [Project templates](../desktop/visual-studio-templates.md#uwp-templates)
+- [Design and UI](/windows/uwp/design/)
+- [Technologies and features](/windows/uwp/develop/)
+- [API reference](/uwp/)
+- [Samples](https://github.com/Microsoft/Windows-universal-samples)
+
+---
+
 #### [Native Win32](#tab/cpp-win32)
 
 Native Win32 desktop apps (also sometimes called *classic desktop apps*) are the original app type for native Windows applications that require direct access to Windows and hardware. This makes this the app type of choice for applications that need the highest level of performance and direct access to system hardware.
@@ -120,24 +138,6 @@ For more information about React Native for Windows, see the following links:
 - [API reference](https://microsoft.github.io/react-native-windows/docs/Native-API-Reference)
 - [Community modules directory](https://reactnative.directory)
 - [More resources](https://microsoft.github.io/react-native-windows/resources)
-
-#### [UWP](#tab/uwp)
-
-The Universal Windows Platform (UWP) provides a common type system, APIs, and application model for all devices that run Windows 10 and later versions. Not only can you use UWP to create desktop applications for Windows PCs, but UWP is also the only supported platform for Xbox, HoloLens, and Surface Hub applications. UWP apps can be native or managed.
-
-UWP is a highly customizable platform and can use XAML markup to separate UI (presentation) from code (business logic). UWP is suitable for desktop apps that require a sophisticated UI, styles customization, and graphics-intensive scenarios. UWP also has built-in support for the [Fluent Design System](/windows/uwp/design/fluent-design-system/) via XAML for the default UX experience and provides access to the [Windows Runtime (WinRT) APIs](/windows/uwp/get-started/universal-application-platform-guide#how-the-universal-windows-platform-relates-to-windows-runtime-apis).
-
-For more information about UWP apps, see the following articles:
-
-- [Set up your development environment](../windows-app-sdk/set-up-your-development-environment.md)
-- [Get started](/windows/uwp/get-started/)
-- [Project templates](../desktop/visual-studio-templates.md#uwp-templates)
-- [Design and UI](/windows/uwp/design/)
-- [Technologies and features](/windows/uwp/develop/)
-- [API reference](/uwp/)
-- [Samples](https://github.com/Microsoft/Windows-universal-samples)
-
----
 
 ## Update existing apps
 

--- a/hub/apps/get-started/index.md
+++ b/hub/apps/get-started/index.md
@@ -45,7 +45,7 @@ For more information about WinUI 3 apps, see see the following articles:
 
 Native Win32 desktop apps (also sometimes called *classic desktop apps*) are the original app type for native Windows applications that require direct access to Windows and hardware. This makes this the app type of choice for applications that need the highest level of performance and direct access to system hardware.
 
-Using the Win32 API with C++ makes it possible to achieve the highest levels of performance and efficiency by taking more control of the target platform with unmanaged code than is possible on a managed runtime environment like WinRT and .NET. However, exercising such a level of control over your application's execution requires greater care and attention to get right, and trades development productivity for runtime performance.
+Using the Win32 API with C++ makes it possible to achieve the highest levels of performance and efficiency by taking more control of the target platform with unmanaged code than is possible on a managed runtime environment like WinRT with .NET. However, exercising such a level of control over your application's execution requires greater care and attention to get right, and trades development productivity for runtime performance.
 
 Here are a few highlights of what the Win32 API and C++ offers to enable you to build high-performance applications.
 
@@ -125,7 +125,7 @@ For more information about React Native for Windows, see the following links:
 
 The Universal Windows Platform (UWP) provides a common type system, APIs, and application model for all devices that run Windows 10 and later versions. Not only can you use UWP to create desktop applications for Windows PCs, but UWP is also the only supported platform for Xbox, HoloLens, and Surface Hub applications. UWP apps can be native or managed.
 
-UWP is a highly customizable platform that uses XAML markup to separate UI (presentation) from code (business logic). UWP is suitable for desktop apps that require a sophisticated UI, styles customization, and graphics-intensive scenarios. UWP also has built-in support for the [Fluent Design System](/windows/uwp/design/fluent-design-system/) for the default UX experience and provides access to the [Windows Runtime (WinRT) APIs](/windows/uwp/get-started/universal-application-platform-guide#how-the-universal-windows-platform-relates-to-windows-runtime-apis).
+UWP is a highly customizable platform and can use XAML markup to separate UI (presentation) from code (business logic). UWP is suitable for desktop apps that require a sophisticated UI, styles customization, and graphics-intensive scenarios. UWP also has built-in support for the [Fluent Design System](/windows/uwp/design/fluent-design-system/) via XAML for the default UX experience and provides access to the [Windows Runtime (WinRT) APIs](/windows/uwp/get-started/universal-application-platform-guide#how-the-universal-windows-platform-relates-to-windows-runtime-apis).
 
 For more information about UWP apps, see the following articles:
 


### PR DESCRIPTION
Fixes a few statements that misleads developers.
- WinRT isn't a managed runtime environment.
- UWP XAML != UWP although UWP XAML is the most preferred choice for UWP UI.
- Fluent Design System is only available built-in for UWP apps when using XAML.