### PR TITLE
Fix Typo in "Windows app silhouettes" Section

### DIFF
--- a/hub/apps/design/basics/app-silhouette.md
+++ b/hub/apps/design/basics/app-silhouette.md
@@ -10,7 +10,7 @@ ms.localizationpriority: medium
 
 # Windows app silhouettes
 
-Silhouettes indicate a common pattern of relationships between elements such app layering, menus, navigation, commanding and content areas. This article focuses on the common silhouettes as used in several Windows in-box apps.
+Silhouettes indicate a common pattern of relationships between elements such as app layering, menus, navigation, commanding and content areas. This article focuses on the common silhouettes as used in several Windows in-box apps.
 
 Also refer to [Content Basics](content-basics.md) for common arrangements of content and controls.
 


### PR DESCRIPTION
Fixed the following Typo: 

From: 
"...elements such app layering..."
To:
"...elements such as app layering..."