### PR TITLE
Change PowerToys VCM shortcut as 0.53 update

### DIFF
--- a/hub/powertoys/index.md
+++ b/hub/powertoys/index.md
@@ -152,7 +152,7 @@ The currently available utilities include:
         [![Video Conference Mute screenshot](../images/pt-video-conference-mute.png)](video-conference-mute.md)
     :::column-end:::
     :::column span="2":::
-        [Video Conference Mute](video-conference-mute.md) is a quick way to globally "mute" both your microphone and camera using <kbd>⊞ Win</kbd>+<kbd>N</kbd> while on a conference call, regardless of the application that currently has focus. This requires Windows 10 1903 (build 18362) or later.
+        [Video Conference Mute](video-conference-mute.md) is a quick way to globally "mute" both your microphone and camera using <kbd>⊞ Win</kbd>+<kbd>Shift</kbd>+<kbd>Q</kbd> while on a conference call, regardless of the application that currently has focus. This requires Windows 10 1903 (build 18362) or later.
     :::column-end:::
 :::row-end:::
 

--- a/hub/powertoys/video-conference-mute.md
+++ b/hub/powertoys/video-conference-mute.md
@@ -18,7 +18,7 @@ Quickly mute your microphone (audio) and turn off your camera (video) with a sin
 
 The default shortcuts to use Video Conference Mute are:
 
-- <kbd>⊞ Win</kbd>+<kbd>N</kbd> to toggle both audio and video at the same time
+- <kbd>⊞ Win</kbd>+<kbd>Shift</kbd>+<kbd>Q</kbd> to toggle both audio and video at the same time
 - <kbd>⊞ Win</kbd>+<kbd>Shift</kbd>+<kbd>A</kbd> to toggle microphone
 - <kbd>⊞ Win</kbd>+<kbd>Shift</kbd>+<kbd>O</kbd> to toggle camera
 


### PR DESCRIPTION
As of release 0.53 for PowerToys, the default shortcut for VCM is changed. 
 
This resolves #3615 

cc: @crutkas 