### PR TITLE
PowerToys Run: Add new system plugin command to docs

### DIFF
--- a/hub/powertoys/run.md
+++ b/hub/powertoys/run.md
@@ -83,7 +83,7 @@ PowerToys Run enables a set of system level actions that can be executed.
 | `Sleep` | Sleeps the computer | |
 | `Hibernate` | Hibernates the computer | |
 | `Empty Recycle Bin` | Empties the recycle bin | |
-| `UEFI Firmware Settings` | Reboot computer into UEFI Firmware Settings | Only available on systems with UEFI firmware.<br>(Requires administrative permissions.) |
+| `UEFI Firmware Settings` | Reboot computer into UEFI Firmware Settings | Only available on systems with UEFI firmware.<br />(Requires administrative permissions.) |
 
 ## Plugin manager
 

--- a/hub/powertoys/run.md
+++ b/hub/powertoys/run.md
@@ -74,15 +74,16 @@ These default activation phrases will force PowerToys Run into only targeted plu
 
 PowerToys Run enables a set of system level actions that can be executed.
 
-| Action command | Action |
-| :--- | :--- |
-| `Shutdown` | Shuts down the computer |
-| `Restart` | Restarts the computer |
-| `Sign Out` | Signs current user out |
-| `Lock` | Locks the computer |
-| `Sleep` | Sleeps the computer |
-| `Hibernate` | Hibernates the computer |
-| `Empty Recycle Bin` | Empties the recycle bin |
+| Action command | Action | Note |
+| :--- | :--- | :--- |
+| `Shutdown` | Shuts down the computer | |
+| `Restart` | Restarts the computer | |
+| `Sign Out` | Signs current user out | |
+| `Lock` | Locks the computer | |
+| `Sleep` | Sleeps the computer | |
+| `Hibernate` | Hibernates the computer | |
+| `Empty Recycle Bin` | Empties the recycle bin | |
+| `UEFI Firmware Settings` | Reboot computer into UEFI Firmware Settings | Only available on systems with UEFI firmware.<br>(Requires administrative permissions.) |
 
 ## Plugin manager
 


### PR DESCRIPTION
This PR adds the new command in System plugin of PT Run to the docs page.
The new command will be included in version 0.55.0 and the PR can be merged after the release of the new PT version.

@crutkas can you please review the docs update. Thank you.