### PR TITLE
Change "1.0.0-stable" to "1.0.0"

### DIFF
--- a/hub/apps/windows-app-sdk/update-existing-projects-to-the-latest-release.md
+++ b/hub/apps/windows-app-sdk/update-existing-projects-to-the-latest-release.md
@@ -45,13 +45,13 @@ If you created a project using version 0.8 Stable (for example, version 0.8.4), 
 6. To add the `WindowsAppSDK` package reference to your `.csproj`/`.vcxproj`:
     
     ```Console
-    install-package Microsoft.WindowsAppSDK -ProjectName {yourProject} -Version 1.0.0-stable
+    install-package Microsoft.WindowsAppSDK -ProjectName {yourProject} -Version 1.0.0
     ```
 
 7. To add the `WindowsAppSDK` package reference to your `.wapproj`:
     
     ```Console
-    install-package Microsoft.WindowsAppSDK -Version 1.0.0-stable 
+    install-package Microsoft.WindowsAppSDK -Version 1.0.0 
     ```   
     
 ## Update from 0.8 Stable or Preview to 1.0 Experimental or Preview 3


### PR DESCRIPTION
The NuGet package for 1.0.0 doesn't have an explicit "stable" suffix, so when I tried upgrading my project with these instructions I saw a warning: 
`Microsoft.WindowsAppSDK 1.0.0-stable was not found. An approximate best match of Microsoft.WindowsAppSDK 1.0.0 was resolved.	`