### PR TITLE
Update set-up-your-development-environment.md

### DIFF
--- a/hub/apps/windows-app-sdk/set-up-your-development-environment.md
+++ b/hub/apps/windows-app-sdk/set-up-your-development-environment.md
@@ -34,13 +34,13 @@ While installing Visual Studio, select these workloads and components.
 
 * On the **Workloads** tab of the installation dialog, select:
   * **Universal Windows Platform development**
+    * Then in the **Installation details** pane of the installation dialog, select **C++ (v143) Universal Windows Platform tools**.
   * **.NET Desktop Development** for C# app development
     * Then in the **Installation details** pane of the installation dialog, select **Windows App SDK C# Templates** (at the bottom of the list).
   * **Desktop development with C++** for C++ app development
     * Then in the **Installation details** pane of the installation dialog,  select **Windows App SDK C++ Templates** (at the bottom of the list).
 
 * On the **Individual components** tab of the installation dialog, in the **SDKs, libraries, and frameworks** section, make sure **Windows 10 SDK (10.0.19041.0)** is selected.
-* In the **Installation details** pane of the installation dialog, in the **Universal Windows Platform development** section, make sure either **C++ (v143) Universal Windows Platform tools** (for Visual Studio 2022) or **C++ (v142) Universal Windows Platform tools** (for Visual Studio 2019) is selected.
 
 ##### [Other Visual Studio versions](#tab/vs-other)
 


### PR DESCRIPTION
Minor stylistic change:
Updating the required workloads instructions structure for VS2022 17.1 and above a bit. Accounts for the fact that we know C++ (v143) needs to be installed and moves those instructions as a sub-point to match UWP installation details to those of .NET and C++