### PR TITLE
Removed some dead links from tailoring-for-xbox

### DIFF
--- a/windows-apps-src/xbox-apps/tailoring-for-xbox.md
+++ b/windows-apps-src/xbox-apps/tailoring-for-xbox.md
@@ -41,27 +41,9 @@ TVs don't handle extreme color intensities as well as computer monitors do. Avoi
 
 ### *Remember:* You can disable scaling
 
-UWP apps are automatically scaled to ensure that UI elements such as controls and fonts are legible on all devices. Apps that use XAML are scaled by 200%, while apps that use HTML are scaled by 150%. If you want more control over how your app looks on Xbox, disable the default scale factor to use the actual pixel dimensions of an HDTV (1920x1080). Take a look at [How to turn off scaling](disable-scaling.md) and [Effective pixels and scaling](/windows/apps/design/basics/design-and-ui-intro#effective-pixels-and-scaling) for information about tailoring your app to look great on Xbox.
-
-
-## Channel 9
-
-The following talks on Channel 9 are a great source of information for building amazing apps on Xbox:
-
-- Building Great Universal Windows Platform (UWP) Apps for Xbox
-- Adapt Your App for Xbox One and TV
-- UWP Development 1: Building an Adaptive UI
-- Web Apps Beyond the Browser: Cross-Platform Meets Cross Device
-
-## App Dev on Xbox
-
-The **App Dev on Xbox** event is a great starting point for developers new to building apps on Xbox.
-
-* [Watch the recorded sessions](https://developer.microsoft.com/windows/projects/campaigns/app-dev-on-xbox-event#WatchNow)
-* [Read the blog posts](https://developer.microsoft.com/windows/projects/campaigns/app-dev-on-xbox-event#BlogSeries)
+UWP apps are automatically scaled to ensure that UI elements such as controls and fonts are legible on all devices. Apps that use XAML are scaled by 200%, while apps that use HTML are scaled by 150%. If you want more control over how your app looks on Xbox, disable the default scale factor to use the actual pixel dimensions of an HDTV (1920x1080). Take a look at [How to turn off scaling](disable-scaling.md) for information about tailoring your app to look great on Xbox.
 
 ## See also
 
 - [UWP on Xbox One](index.md)
 - [Designing for Xbox and TV](/windows/apps/design/devices/designing-for-tv)
-- [Progressive Web Apps for Xbox One](/microsoft-edge/progressive-web-apps/xbox-considerations)


### PR DESCRIPTION
I was unable to find new locations of any of the content that I removed. Channel 9 seems to be gone, and I wasn't able to locate the referenced content anywhere on its replacement site either.