### PR TITLE
Fix sub commands in "update" section

### DIFF
--- a/hub/package-manager/winget/source.md
+++ b/hub/package-manager/winget/source.md
@@ -113,11 +113,11 @@ usage: `winget source update [-n, --name] \<name>`
 
 ### update all
 
-The **update** sub command by itself will request and update to each repo. For example: `C:\winget update`
+The **update** sub command by itself will request and update to each repo. For example: `winget source update`
 
 ### update source
 
-The **update** sub command combined with the **--name** option can direct and update to an individual source. For example:  `C:\winget source update --name contoso`
+The **update** sub command combined with the **--name** option can direct and update to an individual source. For example:  `winget source update --name contoso`
 
 ## remove
 


### PR DESCRIPTION
The "update all" section mistakenly left out that "update" is a sub-command of "source", as it does not work on its own as a top level winget command.

Additionally, these two update commands listed "C:\" at the beginning, which naturally only works if winget is located at the root of the C drive, which is not normally the case, nor do the other examples list this - thus, this has been removed.