### PR TITLE
Fix self-contained deployment code block

### DIFF
--- a/hub/apps/windows-app-sdk/preview-channel.md
+++ b/hub/apps/windows-app-sdk/preview-channel.md
@@ -44,18 +44,20 @@ Windows App SDK 1.1 will introduce support for self-contained deployment. Our [D
 
 **Known issues:**
 - A C++ app that is MSIX-packaged needs to add the below to the bottom of their project file to workaround a bug in the self-contained `.targets` file that removes framework references to VCLibs:
-    ```xml
-      <PropertyGroup>
-        <IncludeGetResolvedSDKReferences>true</IncludeGetResolvedSDKReferences>
-      </PropertyGroup>
 
-      <Target Name="_RemoveFrameworkReferences"
+    ```xml
+    <PropertyGroup>
+        <IncludeGetResolvedSDKReferences>true</IncludeGetResolvedSDKReferences>
+    </PropertyGroup>
+
+    <Target Name="_RemoveFrameworkReferences"
         BeforeTargets="_ConvertItems;_CalculateInputsForGenerateCurrentProjectAppxManifest">
         <ItemGroup>
-          <FrameworkSdkReference Remove="@(FrameworkSdkReference)" Condition="'%(FrameworkSdkReference.SDKName)' == 'Microsoft.WindowsAppRuntime.1.1-preview1'" />
+            <FrameworkSdkReference Remove="@(FrameworkSdkReference)" Condition="'%(FrameworkSdkReference.SDKName)' == 'Microsoft.WindowsAppRuntime.1.1-preview1'" />
         </ItemGroup>
     </Target>
-      ```
+     ```
+
 - Supported only on Windows 10, 1903 and above
 
 ### Notifications


### PR DESCRIPTION
Corrects the self-contained deployment code block at https://docs.microsoft.com/windows/apps/windows-app-sdk/preview-channel#self-contained-deployment

Screenshot:
![image](https://user-images.githubusercontent.com/475132/163627467-b8a05c46-8632-4d12-ae21-4783fcc7f054.png)

