### PR TITLE
Fix web link to app listing

### DIFF
--- a/windows-apps-src/publish/msiexe/manage-submission-options.md
+++ b/windows-apps-src/publish/msiexe/manage-submission-options.md
@@ -15,7 +15,7 @@ ms.localizationpriority: medium
 
 ## Link to your app's listing
 
-The direct link to your app's page can be shared to help your customers find the app in the Store. This link is in the format `https://www.microsoft.com/store/apps/<your app's Store ID>`. When a customer clicks this link, it opens the web-based listing page for your app. On Windows devices, the Store app will also launch and display your app's listing.
+The direct link to your app's page can be shared to help your customers find the app in the Store. This link is in the format `https://apps.microsoft.com/store/detail/<your app's Store ID>`. When a customer clicks this link, it opens the web-based listing page for your app.
 
 Your app's Store ID is also shown in this section. This Store ID can be used to [generate Store badges](https://developer.microsoft.com/store/badges) or otherwise identify your app.
 


### PR DESCRIPTION
The old link format `https://www.microsoft.com/store/apps/<your app's Store ID>` does not work (I get a page not found error when entering the Store ID of my EXE app). I have fixed the documentation with the new link format, which does link to the expected page.