### PR TITLE
Reflect latest changes to json config files

### DIFF
--- a/hub/powertoys/fancyzones.md
+++ b/hub/powertoys/fancyzones.md
@@ -102,8 +102,7 @@ In the demo below, we start with a default template applied to the screen and tw
 ![FancyZones Quick-Swap Layouts settings and usage.](../images/pt-fancyzones-quickswap.gif)
 
 > [!TIP]
-> The settings for the zone layouts and monitors are saved in file `%LocalAppData%\Microsoft\PowerToys\FancyZones\zones-settings.json`. This can be manually changed to tweak zones, and exported to share layouts across devices.
-
+> The settings for your custom zone layouts are saved in the file %LocalAppData%\Microsoft\PowerToys\FancyZones\custom-layouts.json. This file can be manually changed to tweak zones, and exported to share layouts across devices.  Other json files in the same directory can be modified to alter settings for monitors, layout hotkeys, etc.
 
 ## Settings
 

--- a/hub/powertoys/fancyzones.md
+++ b/hub/powertoys/fancyzones.md
@@ -102,7 +102,7 @@ In the demo below, we start with a default template applied to the screen and tw
 ![FancyZones Quick-Swap Layouts settings and usage.](../images/pt-fancyzones-quickswap.gif)
 
 > [!TIP]
-> The settings for your custom zone layouts are saved in the file %LocalAppData%\Microsoft\PowerToys\FancyZones\custom-layouts.json. This file can be manually changed to tweak zones, and exported to share layouts across devices.  Other json files in the same directory can be modified to alter settings for monitors, layout hotkeys, etc.
+> The settings for your custom zone layouts are saved in the file `%LocalAppData%\Microsoft\PowerToys\FancyZones\custom-layouts.json`. This file can be manually changed to tweak zones, and exported to share layouts across devices. Other json files in the same directory can be modified to alter settings for monitors, layout hotkeys, etc. Be warned that editing these files is not recommended as it may cause other issues with FancyZones functionality. 
 
 ## Settings
 


### PR DESCRIPTION
The `zones-settings.json` file was removed and split into different files in https://github.com/microsoft/PowerToys/pull/15642.  However, the current documentation still references the removed `zones-settings.json` file.   This update fixes the file location and also mentions the other newly available configuration files.