### PR TITLE
docs: Better promote required components link

### DIFF
--- a/hub/apps/windows-app-sdk/system-requirements.md
+++ b/hub/apps/windows-app-sdk/system-requirements.md
@@ -5,7 +5,7 @@ ms.topic: article
 ms.date: 06/24/2022
 keywords: windows win32, windows app development, Windows App SDK
 ms.author: stwhi
-author: whims
+author: stevewhims
 ms.localizationpriority: medium
 ---
 

--- a/hub/apps/windows-app-sdk/system-requirements.md
+++ b/hub/apps/windows-app-sdk/system-requirements.md
@@ -2,7 +2,7 @@
 title: System requirements for Windows app development
 description: This article provides information about minimum system requirements for tools required for developing Windows apps.
 ms.topic: article
-ms.date: 07/26/2021
+ms.date: 06/24/2022
 keywords: windows win32, windows app development, Windows App SDK
 ms.author: stwhi
 author: whims
@@ -39,16 +39,13 @@ The [Windows App SDK](index.md) is a set of developer tools that represent the n
 
 The Windows App SDK has these system requirements:
 
-- Windows 10, version 1809 (build 17763) and later.
+- Windows 10, version 1809 (build 17763) or later
 
-- Visual Studio 2019 version 16.9 and later with the following workloads and components:
-  - **Universal Windows Platform development**
-  - **.NET Desktop Development** (needed even if you're only building C++ Win32 apps)
-  - **Desktop development with C++** (needed even if you're only building .NET apps)
+- Visual Studio 2019 version 16.9 or later with the required components (see [Required workloads and components](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=vs-2022-17-1-a%2Cvs-2022-17-1-b#required-workloads-and-components))
 
-- Windows SDK version 2004 (build 19041) and later. This is installed with Visual Studio 2019 and Visual Studio 2022 by default.
+- Windows SDK version 2004 (build 19041) or later, as included with Visual Studio 2019 and Visual Studio 2022 by default
 
-- Building .NET apps also requires .NET 6 or later (see [Download .NET](https://dotnet.microsoft.com/download) and [.NET 5 will reach End of Support on May 10, 2022](https://devblogs.microsoft.com/dotnet/dotnet-5-end-of-support-update/)).
+- Building .NET apps also requires .NET 6 or later (see [Download .NET](https://dotnet.microsoft.com/download) and [.NET 5 will reach End of Support on May 10, 2022](https://devblogs.microsoft.com/dotnet/dotnet-5-end-of-support-update/))
 
 ### Visual Studio support for WinUI 3 tools
 

--- a/hub/apps/windows-app-sdk/system-requirements.md
+++ b/hub/apps/windows-app-sdk/system-requirements.md
@@ -45,7 +45,7 @@ The Windows App SDK has these system requirements:
 
 - Windows SDK version 2004 (build 19041) or later, as included with Visual Studio 2019 and Visual Studio 2022 by default
 
-- Building .NET apps also requires .NET 6 or later (see [Download .NET](https://dotnet.microsoft.com/download) and [.NET 5 will reach End of Support on May 10, 2022](https://devblogs.microsoft.com/dotnet/dotnet-5-end-of-support-update/))
+- Building .NET apps also requires .NET 6 or later (see [Download .NET](https://dotnet.microsoft.com/download)
 
 ### Visual Studio support for WinUI 3 tools
 


### PR DESCRIPTION
We shouldn't assume new developers need to install the UWP workload anymore when building Windows App SDK apps. The current wording heavily implies that the UWP workload is somehow required to build Windows App SDK applications. This is also inconsistent with the other Windows App SDK documentation.

We now link to that documentation instead and tidy up bullet point punctuation 