### PR TITLE
missing URIs

### DIFF
--- a/windows-apps-src/launch-resume/launch-settings-app.md
+++ b/windows-apps-src/launch-resume/launch-settings-app.md
@@ -339,7 +339,7 @@ The following sections describe different categories of ms-settings URIs used to
 | Storage | ms-settings:storagesense |
 | Storage Sense | ms-settings:storagepolicies |
 | Storage recommendations | ms-settings:storagerecommendations |
-
+ 
 ### Time and language
 
 |Settings page| URI |


### PR DESCRIPTION
Cannot contribute to the content, but this doc seems to miss URIs from Windows 10/11 21H2, aswell as 22H2. 
Example: in the System > Storage > Advanced Storage Settings menus.

sidenote: Strange that the URI for Storage Sense is actually not Storage Sense :)