### PR TITLE
Update rss-reader-rust-for-windows.md

### DIFF
--- a/hub/dev-environment/rust/rss-reader-rust-for-windows.md
+++ b/hub/dev-environment/rust/rss-reader-rust-for-windows.md
@@ -208,7 +208,7 @@ We did say that Rust for Windows lets you call any Windows API (past, present, a
     fn main() {
         windows::build!(
             ...
-            Windows::Win32::UI::WindowsAndMessaging::MessageBoxA,
+            Windows::Win32::WindowsAndMessaging::MessageBoxA,
         );
     }
     ```
@@ -220,14 +220,14 @@ We did say that Rust for Windows lets you call any Windows API (past, present, a
     use bindings::{ 
         Windows::Foundation::Uri,
         Windows::Web::Syndication::SyndicationClient,
-        Windows::Win32::UI::WindowsAndMessaging::*,
+        Windows::Win32::WindowsAndMessaging::*,
     };
 
     fn main() {
         ...
 
         unsafe {
-            MessageBoxA(None, "Text", "Caption", MB_OK);
+            MessageBoxA(None, "Text", "Caption", MESSAGEBOX_STYLE::MB_OK);
         }
 
         Ok(())


### PR DESCRIPTION
Could not get example code to work. Had to change the MessageBoxA path from (Windows::Win32::UI::WindowsAndMessaging::MessageBoxA) to (Windows::Win32::WindowsAndMessaging::MessageBoxA). Also had to add MESSAGEBOX_STYLE:: before MB_OK in order to compile. These changes also fall in line with the video on the previous page, https://youtu.be/-oZrsCPKsn4.