### PR TITLE
Update sqlite-databases.md

### DIFF
--- a/windows-apps-src/data-access/sqlite-databases.md
+++ b/windows-apps-src/data-access/sqlite-databases.md
@@ -231,8 +231,6 @@ public static void AddData(string inputText)
         insertCommand.Parameters.AddWithValue("@Entry", inputText);
 
         insertCommand.ExecuteReader();
-
-        db.Close();
     }
 
 }
@@ -263,8 +261,6 @@ public static List<String> GetData()
         {
             entries.Add(query.GetString(0));
         }
-
-        db.Close();
     }
 
     return entries;


### PR DESCRIPTION
Removed redundant db.Close() calls in AddData and GetData C# examples.
SqliteConnection class implements IDisposable and executes SqliteConnection.Close() as part of its IDisposable.Dispose() call, example contains redundant line as instance is disposed implicitly at the end of the using block.
InitializeDatabase example on line 175 already demonstrates this.