### PR TITLE
Add to list of unsupported WinRT APIs in desktop apps

### DIFF
--- a/hub/apps/desktop/modernize/desktop-to-uwp-supported-api.md
+++ b/hub/apps/desktop/modernize/desktop-to-uwp-supported-api.md
@@ -383,6 +383,7 @@ The following WinRT classes require package identity (see [Features that require
 * [**Windows.Services.Store.StoreSendRequestResult**](/uwp/api/Windows.Services.Store.StoreSendRequestResult)
 * [**Windows.Services.Store.StoreSku**](/uwp/api/Windows.Services.Store.StoreSku)
 * [**Windows.Services.Store.StoreVideo**](/uwp/api/Windows.Services.Store.StoreVideo)
+* [**Windows.Storage.AccessCache.StorageApplicationPermissions**](/uwp/api/windows.storage.accesscache.storageapplicationpermissions)
 * [**Windows.Storage.ApplicationData**](/uwp/api/windows.storage.applicationdata)
 * [**Windows.Storage.ApplicationDataSetVersionHandler**](/uwp/api/windows.storage.applicationdatasetversionhandler)
 * [**Windows.Storage.CachedFileManager**](/uwp/api/Windows.Storage.CachedFileManager)


### PR DESCRIPTION
Add `Windows.Storage.AccessCache.StorageApplicationPermissions` as an unsupported WinRT API in desktop apps. Will close https://github.com/microsoft/WindowsAppSDK/issues/2995

(Unsure how line 459/460 got changed, feel free to cleanup) [The last line of files frequently shows up as changed; I'd guess it's to do with different folks' text editors setting different line endings; nothing to worry about AFAIK. :)]