### PR TITLE
Update DevHome docs to remove references to deprecated snap feature

### DIFF
--- a/uwp/xbox-apps/dev-home.md
+++ b/uwp/xbox-apps/dev-home.md
@@ -67,22 +67,6 @@ By pressing the **menu** button on your controller, you can access the main menu
 <a id="ID4EUE"></a>
 
    
-
-## Snap Mode UX  
-   
-  
-Several existing and upcoming tools in Dev Home, such as Networking and Multiplayer, are designed to be used snapped to the side while you are running your title, so that you can have easy access to tools while you are testing.   
-   
-  
-To access Snap mode, highlight the title of the appropriate tool, press the **view** button on your controller, and select **snap** from the context menu:  
- ![Screenshot of the DEV HOME page showing the Snap option highlighted.](images/dev_home_4.png)   
-  
-Dev Home will snap right. You can switch context by double tapping the Nexus button as usual.  
- ![Screenshot showing the DEV HOME page snapped to the right showing that you have access to you tools while you're testing.](images/dev_home_5.png)  
-<a id="ID4EKF"></a>
-
-   
-
 ## Customizing Dev Home  
    
   

--- a/uwp/xbox-apps/dev-home.md
+++ b/uwp/xbox-apps/dev-home.md
@@ -79,8 +79,8 @@ Dev Home has been designed to be customizable and personal. You can configure th
 ### Resizing and Reordering Tools  
    
   
-To change the size or position of a tool, use the context menu button (view button on your controller) while the title has focus. From the context menu select **Move** or **Resize**.   
- ![Screenshot of the DEV HOME page snapped to the right showing the Move option highlighted.](images/dev_home_6.png)  
+To change the size or position of a tool, use the context menu button (view button on your controller) while the title has focus. From the context menu select **Move** or **Resize**.
+ ![Screenshot of the DEV HOME page showing the Move option highlighted.](https://user-images.githubusercontent.com/1520739/210461485-393fce51-d495-409c-b5b1-95c014c81c6d.png)
 <a id="ID4EEG"></a>
 
    


### PR DESCRIPTION
Update DevHome docs to remove references to deprecated snap feature.