### PR TITLE
Update rss-reader-rust-for-windows.md

### DIFF
--- a/hub/dev-environment/rust/rss-reader-rust-for-windows.md
+++ b/hub/dev-environment/rust/rss-reader-rust-for-windows.md
@@ -109,7 +109,7 @@ Now let's try out Rust for Windows by writing a simple console app that download
     fn main() -> windows::core::Result<()> {
         let uri = Uri::CreateUri(h!("https://blogs.windows.com/feed"))?;
         let client = SyndicationClient::new()?;
-        let feed = client.RetrieveFeedAsync(uri)?.get()?;
+        let feed = client.RetrieveFeedAsync(&uri)?.get()?;
 
         Ok(())
     }


### PR DESCRIPTION
Add missing ampersand before "uri" argument in step 8 code. This omission makes the sample fail to compile. It is correct in step 9, but for students following along and adding code step-by-step, this is easy to miss.