### PR TITLE
Fix typo pointing to BC1 instead of BC4

### DIFF
--- a/uwp/graphics-concepts/block-compression.md
+++ b/uwp/graphics-concepts/block-compression.md
@@ -41,9 +41,9 @@ The uncompressed data is laid out in memory sequentially and requires 16 bytes, 
 
 ### <span id="Storing_Compressed_Data"></span><span id="storing_compressed_data"></span><span id="STORING_COMPRESSED_DATA"></span><span id="storing-compressed-data"></span>Storing compressed data
 
-Now that you've seen how much memory an uncompressed image uses, take a look at how much memory a compressed image saves. The [BC1](#bc1) compression format stores 2 colors (1 byte each) and 16 3-bit indices (48 bits, or 6 bytes) that are used to interpolate the original colors in the texture, as shown in the following illustration.
+Now that you've seen how much memory an uncompressed image uses, take a look at how much memory a compressed image saves. The [BC4](#bc4) compression format stores 2 colors (1 byte each) and 16 3-bit indices (48 bits, or 6 bytes) that are used to interpolate the original colors in the texture, as shown in the following illustration.
 
-![the bc1 compression format](images/d3d10-block-compress-3.png)
+![the bc4 compression format](images/d3d10-block-compress-3.png)
 
 The total space required to store the compressed data is 8 bytes which is a 50-percent memory savings over the uncompressed example. The savings are even larger when more than one color component is used.
 


### PR DESCRIPTION
BC4 is the format which uses 1-byte per each of the two endpoints along with 16 x 3-bit interpolation indices, not BC1 (which uses 5:6:5).