### PR TITLE
Update instructions for converting a project to use Single-project MSIX Packaging

### DIFF
--- a/hub/apps/windows-app-sdk/single-project-msix.md
+++ b/hub/apps/windows-app-sdk/single-project-msix.md
@@ -143,7 +143,6 @@ Next, edit some configuration settings to use the single-project MSIX feature. T
 
     1. Add `<EnableMsixTooling>true</EnableMsixTooling>` to the main `<PropertyGroup>` element.
     2. Change the value of `<AppxPackage>` to `true`.
-    3. Change the value of the `<AppContainerApplication>` element to `true`.
 
     When you're done, the contents of the **.vcxproj** file should look similar to this.
 
@@ -153,7 +152,7 @@ Next, edit some configuration settings to use the single-project MSIX feature. T
       <PropertyGroup Label="Globals">
         ...
         <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
-        <AppContainerApplication>true</AppContainerApplication>
+        <AppContainerApplication>false</AppContainerApplication>
         <AppxPackage>true</AppxPackage>
         <ApplicationType>Windows Store</ApplicationType>
         <ApplicationTypeRevision>10.0</ApplicationTypeRevision>


### PR DESCRIPTION
It is no longer necessary to set the `AppContainerApplication` property to `true` when converting a C++ WinAppSDK app using Windows Application Packaging to Single-project MSIX Packaging and will in fact lead to incorrect behavior. This PR updates the documentation accordingly.