### PR TITLE
winget is not pre-installed on Win11

### DIFF
--- a/hub/package-manager/winget/index.md
+++ b/hub/package-manager/winget/index.md
@@ -12,9 +12,9 @@ The **winget** command line tool enables users to discover, install, upgrade, re
 
 ## Install winget
 
-Windows Package Manager **winget** command-line tool is bundled with Windows 11 and modern versions of Windows 10 by default as the **App Installer**.
+Windows Package Manager **winget** command-line tool is available on Windows 11 and modern versions of Windows 10 as the **App Installer**.
 
-If you are running an earlier version of Windows and the App Installer is not installed, you can [get App Installer from the Microsoft Store](https://www.microsoft.com/p/app-installer/9nblggh4nns1#activetab=pivot:overviewtab). If it's already installed, make sure it is updated with the latest version.
+You can [get App Installer from the Microsoft Store](https://www.microsoft.com/p/app-installer/9nblggh4nns1#activetab=pivot:overviewtab). If it's already installed, make sure it is updated with the latest version.
 
 App Installer includes the production version of the winget tool.
 


### PR DESCRIPTION
Numerous times I've created Virtual Machines in Azure, and on at least two different physical machines with Windows 11 pre-installed, `winget` was not pre-installed. I had to install the App Installer from the Store app in every instance. Therefore, I believe that claiming winget is bundled with Windows is factually incorrect.

fixes: https://github.com/MicrosoftDocs/windows-dev-docs/issues/4212