### PR TITLE
missing '.' in outfile example

### DIFF
--- a/hub/package-manager/winget/index.md
+++ b/hub/package-manager/winget/index.md
@@ -39,7 +39,7 @@ To install winget on Windows Sandbox, follow these steps from a Windows PowerShe
 
 ```powershell
 $ProgressPreference='Silent'
-Invoke-WebRequest -Uri https://github.com/microsoft/winget-cli/releases/download/v1.3.2691/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle -OutFile .\MicrosoftDesktopAppInstaller_8wekyb3d8bbwe.msixbundle
+Invoke-WebRequest -Uri https://github.com/microsoft/winget-cli/releases/download/v1.3.2691/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle -OutFile .\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle
 Invoke-WebRequest -Uri https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx -OutFile Microsoft.VCLibs.x64.14.00.Desktop.appx
 Add-AppxPackage Microsoft.VCLibs.x64.14.00.Desktop.appx
 Add-AppxPackage Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle


### PR DESCRIPTION
Caught this when running the code on a local project and received a file not found error. 

Correcting the outfile name to reflect what the Add-AppxPackage is looking for resolves the issue.