### PR TITLE
Use angle brackets to include WinUI headers

### DIFF
--- a/hub/apps/winui/winui2/getting-started.md
+++ b/hub/apps/winui/winui2/getting-started.md
@@ -97,10 +97,10 @@ When you add a NuGet package to a C++/WinRT project, the tooling generates a set
 ```cppwinrt
 // pch.h
 ...
-#include "winrt/Microsoft.UI.Xaml.Automation.Peers.h"
-#include "winrt/Microsoft.UI.Xaml.Controls.Primitives.h"
-#include "winrt/Microsoft.UI.Xaml.Media.h"
-#include "winrt/Microsoft.UI.Xaml.XamlTypeInfo.h"
+#include <winrt/Microsoft.UI.Xaml.Automation.Peers.h>
+#include <winrt/Microsoft.UI.Xaml.Controls.Primitives.h>
+#include <winrt/Microsoft.UI.Xaml.Media.h>
+#include <winrt/Microsoft.UI.Xaml.XamlTypeInfo.h>
 ...
 ```
 


### PR DESCRIPTION
While Visual C++ allows both double quotes and angle brackets to specify the name of a header file without relative path, it's common practice to use double quotes for local files and angle brackets for headers in configured include path.