### PR TITLE
Don’t imply that winui 3 is open source

### DIFF
--- a/hub/apps/winui/winui3/index.md
+++ b/hub/apps/winui/winui3/index.md
@@ -29,7 +29,7 @@ WinUI 3 is the native UI platform component that ships with the [Windows App SDK
 :::row:::
    :::column:::
 
-        **Github**: WinUI is an open-source project hosted on Github. Use the [WinUI repo](https://github.com/microsoft/microsoft-ui-xaml), to file feature requests or bugs, interact with the WinUI team, and view the team's plans for WinUI 3 and beyond on their [roadmap](https://github.com/microsoft/microsoft-ui-xaml/blob/master/docs/roadmap.md).
+        **Github**: WinUI is hosted on Github. Use the [WinUI repo](https://github.com/microsoft/microsoft-ui-xaml), to file feature requests or bugs, interact with the WinUI team, and view the team's plans for WinUI 3 and beyond on their [roadmap](https://github.com/microsoft/microsoft-ui-xaml/blob/master/docs/roadmap.md).
 
    :::column-end:::
    :::column:::


### PR DESCRIPTION
No source is available for winui 3; winui 2 is open source, but open sourcing winui 3 is still “planned” but has been delayed for over a year at this point, and isn’t on the current roadmap.