### PR TITLE
Update CI for WinUI 3 instructions to not use solution name for upload

### DIFF
--- a/hub/apps/package-and-deploy/ci-for-winui3.md
+++ b/hub/apps/package-and-deploy/ci-for-winui3.md
@@ -127,7 +127,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: MSIX Package
-        path: ${{ env.Solution_Name }}\\Packages
+        path: ${{ github.workspace }}\\Packages
 
 ```
 
@@ -219,7 +219,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: Upload app
-        path: ${{ env.Solution_Name }}\\bin
+        path: ${{ github.workspace }}\\bin
 ```
 
 ## Step 2: Commit the workflow and watch it run!

--- a/hub/apps/package-and-deploy/ci-for-winui3.md
+++ b/hub/apps/package-and-deploy/ci-for-winui3.md
@@ -52,6 +52,9 @@ Copy/paste the following into your workflow file, and then update...
 1. **Solution_Name** to the name of your solution
 2. **dotnet-version** to either 5.0 or 6.0 depending on your project
 
+> [!NOTE]
+> For the step uploading the artifact (the last step below), if the build output doesn't land in a folder that contains your solution, then replace `env.Solution_Name` with `github.workspace` (the GitHub actions Workspace folder).
+
 ```yml
 # This workflow will build, sign, and package a WinUI 3 MSIX desktop application
 # built on .NET.
@@ -127,7 +130,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: MSIX Package
-        path: ${{ github.workspace }}\\Packages
+        path: ${{ env.Solution_Name }}\\Packages
 
 ```
 
@@ -157,6 +160,9 @@ Copy/paste the following into your workflow file, and then update...
 
 1. **Solution_Name** to the name of your solution
 2. **dotnet-version** to either 5.0 or 6.0 depending on your project
+
+> [!NOTE]
+> For the step uploading the artifact (the last step below), if the build output doesn't land in a folder that contains your solution, then replace `env.Solution_Name` with `github.workspace` (the GitHub actions Workspace folder).
 
 ```yml
 # This workflow will build and publish a WinUI 3 unpackaged desktop application
@@ -219,7 +225,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: Upload app
-        path: ${{ github.workspace }}\\bin
+        path: ${{ env.Solution_Name }}\\bin
 ```
 
 ## Step 2: Commit the workflow and watch it run!


### PR DESCRIPTION
There seems to be an issue with the GitHub Action step uploading the artifact since it uses the solution name as part of the path. In almost all cases, the build output does not land in a folder that contains the solution name including the `.sln`. This PR updates this to the GitHub actions Workspace folder.