### PR TITLE
Update docs that canvas model allows overlapping

### DIFF
--- a/hub/powertoys/fancyzones.md
+++ b/hub/powertoys/fancyzones.md
@@ -121,7 +121,7 @@ The **Grid** model starts with a three column grid and allows zones to be create
 
 ![FancyZones Table Editor Mode.](../images/pt-fancyzones-grideditor.png)
 
-The **Canvas** model starts with one zone and supports adding zones that can be dragged and resized similar to windows.
+The **Canvas** model starts with one zone and supports adding zones that can be dragged and resized similar to windows. Zones in the canvas model may be overlapping.
 
 Canvas layout also has keyboard support for zone editing. Use the <kbd>arrow</kbd> keys (up, down, left, right) to move a zone by 10 pixels, or <kbd>Ctrl</kbd>+<kbd>arrow</kbd> to move a zone by 1 pixel. Use the <kbd>Shift</kbd>+<kbd>arrow</kbd> keys to resize a zone by 10 pixels (5 per edge), or <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>arrow</kbd> to resize a zone by 2 pixels (1 per edge). To switch between the editor and dialog, press the <kbd>Ctrl</kbd>+<kbd>Tab</kbd> keys.
 


### PR DESCRIPTION
I had the same issue as microsoft/PowerToys#11552 -- I ctrl+F for "overlap" and didn't think that FancyZones supported it. Add a small breadcrumb so future readers know to use canvas model.