### PR TITLE
Fix CS1002 in TrySetSystemBackdrop method

### DIFF
--- a/hub/apps/windows-app-sdk/system-backdrop-controller.md
+++ b/hub/apps/windows-app-sdk/system-backdrop-controller.md
@@ -214,7 +214,7 @@ public sealed partial class MainWindow : Window
             m_configurationSource.IsInputActive = true;
             SetConfigurationSourceTheme();
 
-            m_backdropController = new Microsoft.UI.Composition.SystemBackdrops.MicaController()
+            m_backdropController = new Microsoft.UI.Composition.SystemBackdrops.MicaController();
 
             // Enable the system backdrop.
             // Note: Be sure to have "using WinRT;" to support the Window.As<...>() call.


### PR DESCRIPTION
A semicolon was added at the end of the backdropController creation statement.