### PR TITLE
Add note about the icon size ramp

### DIFF
--- a/hub/apps/design/style/segoe-fluent-icons-font.md
+++ b/hub/apps/design/style/segoe-fluent-icons-font.md
@@ -62,7 +62,7 @@ You can also use the static resource `SymbolThemeFontFamily` to access **Segoe F
 ```
 
 > [!NOTE]
-For optimal appearance, use these specific sizes: 16, 20, 24, 32, 40, 48, and 64. Deviating from these font sizes could lead to less crisp or blurry outcomes.
+> For optimal appearance, use these specific sizes: 16, 20, 24, 32, 40, 48, and 64. Deviating from these font sizes could lead to less crisp or blurry outcomes.
 
 ## How do I get this font?
 

--- a/hub/apps/design/style/segoe-fluent-icons-font.md
+++ b/hub/apps/design/style/segoe-fluent-icons-font.md
@@ -61,6 +61,9 @@ You can also use the static resource `SymbolThemeFontFamily` to access **Segoe F
 <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE700;"/>
 ```
 
+> [!NOTE]
+For optimal appearance, use these specific sizes: 16, 20, 24, 32, 40, 48, and 64. Deviating from these font sizes could lead to less crisp or blurry outcomes.
+
 ## How do I get this font?
 
 * On Windows 11: There's nothing you need to do, the font comes with Windows.


### PR DESCRIPTION
As pointed out by the Windows Design team, this is the ramp recommended when using icons in UWP/WinUI.