### PR TITLE
Update dsc yaml exmaple in create.md to fix failure when using it.

### DIFF
--- a/hub/package-manager/configuration/create.md
+++ b/hub/package-manager/configuration/create.md
@@ -62,7 +62,7 @@ properties:
         module: Microsoft.Windows.Developer
         allowPrerelease: true
       settings:
-        MinVersion: 10.0.19041
+        MinVersion: "10.0.19041"
   resources:
     - resource: DeveloperMode
       directives:


### PR DESCRIPTION
Using the example as is results in the ff error message: '10' is not a valid Version string.
