### PR TITLE
Add Proper Winget Version

### DIFF
--- a/hub/package-manager/winget/configure.md
+++ b/hub/package-manager/winget/configure.md
@@ -19,7 +19,7 @@ The **configure** command of the [winget](./index.md) tool uses a [WinGet Config
 ## Prerequisites
 
 - Windows 10 RS5 or later, and Windows 11.
-- Winget version v1.4.11071 or later.
+- Winget version v1.5.1572 or later.
 
 ## Usage
 

--- a/hub/package-manager/winget/configure.md
+++ b/hub/package-manager/winget/configure.md
@@ -19,7 +19,7 @@ The **configure** command of the [winget](./index.md) tool uses a [WinGet Config
 ## Prerequisites
 
 - Windows 10 RS5 or later, and Windows 11.
-- Winget version xxx or later?
+- Winget version v1.4.11071 or later.
 
 ## Usage
 


### PR DESCRIPTION
Problem:

Current document has an underspecified requirement for Winget. It says: "xxx or later?"
That is super confusing for any user.

Fix:

Add a specific working version