### PR TITLE
Update arguments and options of WinGet commands

### DIFF
--- a/hub/package-manager/winget/export.md
+++ b/hub/package-manager/winget/export.md
@@ -25,7 +25,7 @@ The **export** command is often used to create a file that you can share with ot
 The following arguments are available.
 
 | Argument    | Description |
-|-------------|-------------|  
+|-------------|-------------|
 | **-o,--output** | Path to the JSON file to be created |
 
 ## Options
@@ -33,11 +33,15 @@ The following arguments are available.
 The options allow you to customize the export experience to meet your needs.
 
 | Option    | Description |
-|----------------|-------------|  
+|----------------|-------------|
 | **-s, --source**  |  [Optional] Specifies a source to export files from. Use this option when you only want files from a specific source.  |
 | **--include-versions** | [Optional] Includes the version of the app currently installed. Use this option if you want a specific version. By default, unless specified, [**import**](./import.md) will use latest. |
 | **--accept-source-agreements** | Used to accept the source license agreement, and avoid the prompt. |
-| **--verbose-logs** | Used to override the logging setting and create a verbose log. |
+| **-?,--help** | Shows help about the selected command. |
+| **--wait** | Prompts the user to press any key before exiting. |
+| **--logs,--open-logs** | Open the default logs location. |
+| **--verbose, --verbose-logs** | Used to override the logging setting and create a verbose log. |
+| **--disable-interactivity** | Disable interactive prompts. |
 
 ## JSON schema
 
@@ -46,7 +50,7 @@ The driving force behind the **export** command is the JSON file. You can find t
 The JSON file includes the following hierarchy.
 
 | Entry      | Description |
-|-------------|-------------|  
+|-------------|-------------|
 | **Sources**  |  The sources application manifests come from.  |
 | **Packages**  |  The collection of packages to install.  |
 | **PackageIdentifier**  |  The Windows Package Manager package identifier used to specify the package.  |

--- a/hub/package-manager/winget/hash.md
+++ b/hub/package-manager/winget/hash.md
@@ -23,9 +23,19 @@ The following arguments are available:
 | Argument  | Description |
 |--------------|-------------|
 | **-f,--file** |  The path to the file to be hashed. |
+
+## Options
+
+The options allow you to customize the hash experience to meet your needs.
+
+| Option  | Description |
+|-------------|-------------|
 | **-m,--msix**  | Specifies that the hash command will also create the SHA-256 SignatureSha256 for use with MSIX installers. |
-| **--verbose-logs** | Used to override the logging setting and create a verbose log. |
 | **-?, --help** |  Gets additional help on this command. |
+| **--wait** | Prompts the user to press any key before exiting. |
+| **--logs,--open-logs** | Open the default logs location. |
+| **--verbose, --verbose-logs** | Used to override the logging setting and create a verbose log. |
+| **--disable-interactivity** | Disable interactive prompts. |
 
 ## Related topics
 

--- a/hub/package-manager/winget/import.md
+++ b/hub/package-manager/winget/import.md
@@ -23,7 +23,7 @@ The **import** command is often used to share your developer environment or buil
 The following arguments are available.
 
 | Argument    | Description |
-|-------------|-------------|  
+|-------------|-------------|
 | **-i,--import-file** | JSON file describing the packages to install. |
 
 ## Options
@@ -31,12 +31,17 @@ The following arguments are available.
 The options allow you to customize the import experience to meet your needs.
 
 | Option      | Description |
-|-------------|-------------|  
+|-------------|-------------|
 | **--ignore-unavailable**  |  Suppresses errors if the app requested is unavailable.  |
 | **--ignore-versions** |  Ignores versions specified in the JSON file and installs the latest available version. |
+| **--no-upgrade** | Skips upgrade if an installed version already exists. |
 | **--accept-package-agreements** | Used to accept the license agreement, and avoid the prompt. |
 | **--accept-source-agreements** | Used to accept the source license agreement, and avoid the prompt. |
-| **--verbose-logs** | Used to override the logging setting and create a verbose log. |
+| **-?,--help** | Shows help about the selected command. |
+| **--wait** | Prompts the user to press any key before exiting. |
+| **--logs,--open-logs** | Open the default logs location. |
+| **--verbose, --verbose-logs** | Used to override the logging setting and create a verbose log. |
+| **--disable-interactivity** | Disable interactive prompts. |
 
 ## JSON Schema
 
@@ -45,7 +50,7 @@ The driving force behind the **import** command is the JSON file. You can find t
 The JSON file includes the following hierarchy.
 
 | Entry      | Description |
-|-------------|-------------|  
+|-------------|-------------|
 | **Sources**  |  The sources application manifests come from.  |
 | **Packages**  |  The collection of packages to install.  |
 | **PackageIdentifier**  |  The Windows Package Manager package identifier used to specify the package.  |

--- a/hub/package-manager/winget/install.md
+++ b/hub/package-manager/winget/install.md
@@ -8,7 +8,7 @@ ms.localizationpriority: medium
 
 # install command (winget)
 
-The **install** command of the [winget](index.md) tool installs the specified application. Use the [**search**](search.md) command to identify the application you want to install.  
+The **install** command of the [winget](index.md) tool installs the specified application. Use the [**search**](search.md) command to identify the application you want to install.
 
 The **install** command requires that you specify the exact string to install. If there is any ambiguity, you will be prompted to further filter the **install** command to  an exact application.
 
@@ -23,9 +23,8 @@ The **install** command requires that you specify the exact string to install. I
 The following arguments are available.
 
 | Argument      | Description |
-|-------------|-------------|  
+|-------------|-------------|
 | **-q,--query**  |  The query used to search for an app. |
-| **-?, --help** |  Get additional help on this command. |
 
 > [!NOTE]
 > The query argument is positional. Wild-card style syntax is not supported. This is most often the string of characters you expect to uniquely identify the package you wish to install.
@@ -35,28 +34,38 @@ The following arguments are available.
 The options allow you to customize the install experience to meet your needs.
 
 | Option  | Description |
-|-------------|-------------|  
+|-------------|-------------|
 | **-m, --manifest** |  Must be followed by the path to the manifest (YAML) file. You can use the manifest to run the install experience from a [local YAML file](#local-install). |
-| **--id**    |  Limits the install to the ID of the application.   |  
-| **--name**   |  Limits the search to the name of the application. |  
-| **--moniker**   | Limits the search to the moniker listed for the application. |  
-| **-v, --version**  |  Enables you to specify an exact version to install. If not specified, latest will install the highest versioned application. |  
-| **-s, --source**   |  Restricts the search to the source name provided. Must be followed by the source name. |  
-| **--scope**   |  Allows you to specify if the installer should target user or machine scope. See [known issues relating to package installation scope](./troubleshooting.md#scope-for-specific-user-vs-machine-wide).|  
-| **-a, --architecture**   |  Select the architecture to install. | 
-| **-e, --exact**   |   Uses the exact string in the query, including checking for case-sensitivity. It will not use the default behavior of a substring. |  
-| **-i, --interactive** |  Runs the installer in interactive mode. The default experience shows installer progress. |  
-| **-h, --silent** |  Runs the installer in silent mode. This suppresses all UI. The default experience shows installer progress. |  
+| **--id**    |  Limits the install to the ID of the application.   |
+| **--name**   |  Limits the search to the name of the application. |
+| **--moniker**   | Limits the search to the moniker listed for the application. |
+| **-v, --version**  |  Enables you to specify an exact version to install. If not specified, latest will install the highest versioned application. |
+| **-s, --source**   |  Restricts the search to the source name provided. Must be followed by the source name. |
+| **--scope**   |  Allows you to specify if the installer should target user or machine scope. See [known issues relating to package installation scope](./troubleshooting.md#scope-for-specific-user-vs-machine-wide).|
+| **-a, --architecture**   |  Select the architecture to install. |
+| **-e, --exact**   |   Uses the exact string in the query, including checking for case-sensitivity. It will not use the default behavior of a substring. |
+| **-i, --interactive** |  Runs the installer in interactive mode. The default experience shows installer progress. |
+| **-h, --silent** |  Runs the installer in silent mode. This suppresses all UI. The default experience shows installer progress. |
 | **--locale** | Specifies which locale to use (BCP47 format). |
 | **-o, --log**  |  Directs the logging to a log file. You must provide a path to a file that you have the write rights to. |
+| **--custom** | Arguments to be passed on to the installer in addition to the defaults.    |
 | **--override** | A string that will be passed directly to the installer.    |
 | **-l, --location** |    Location to install to (if supported). |
-| **--force** | Overrides the installer hash check. Not recommended. |
+| **--ignore-security-hash** |    Ignore the installer hash check failure. Not recommended. |
+| **--ignore-local-archive-malware-scan** |    Ignore the malware scan performed as part of installing an archive type package from local manifest. |
+| **--dependency-source** |    Find package dependencies using the specified source. |
 | **--accept-package-agreements** | Used to accept the license agreement, and avoid the prompt. |
 | **--accept-source-agreements** | Used to accept the source license agreement, and avoid the prompt. |
+| **--no-upgrade** |    Skips upgrade if an installed version already exists. |
 | **--header** | Optional Windows-Package-Manager REST source HTTP header. |
 | **-r, --rename** | The value to rename the executable file (portable) |
-| **--verbose-logs** | Used to override the logging setting and create a verbose log. |
+| **--uninstall-previous** | Uninstall the previous version of the package during upgrade |
+| **--force** | Direct run the command and continue with non security related issues. |
+| **-?, --help** |  Get additional help on this command. |
+| **--wait** | Prompts the user to press any key before exiting. |
+| **--logs,--open-logs** | Open the default logs location. |
+| **--verbose, --verbose-logs** | Used to override the logging setting and create a verbose log. |
+| **--disable-interactivity** | Disable interactive prompts. |
 
 ### Example queries
 
@@ -85,7 +94,7 @@ If the query provided to **winget** does not result in a single application, the
 The best way to limit the selection to one file is to use the **id** of the application combined with the **exact** query option.  For example:
 
 ```CMD
-winget install --id Git.Git -e 
+winget install --id Git.Git -e
 ```
 
 If multiple sources are configured, it is possible to have duplicate entries. Specifying a source is required to further disambiguate.
@@ -107,7 +116,7 @@ The **manifest** option enables you to install an application by passing in a YA
 Usage: `winget install --manifest \<path>`
 
 | Option  | Description |
-|---------|-------------|  
+|---------|-------------|
 |  **-m, --manifest** | The path to the manifests of the application to install. |
 
 > [!NOTE]
@@ -119,7 +128,7 @@ The log files for winget unless redirected, will be located in the following fol
 
 ## License Agreements
 
-Some applications when installed will require the user to agree to the license or other agreements before installing.  When this occurs, the Windows Package Manager will prompt the user to agree to the agreements.  If the user does not agree, the application will not install.  
+Some applications when installed will require the user to agree to the license or other agreements before installing.  When this occurs, the Windows Package Manager will prompt the user to agree to the agreements.  If the user does not agree, the application will not install.
 
 ![Image of agreement](./images/agreements.png)
 

--- a/hub/package-manager/winget/list.md
+++ b/hub/package-manager/winget/list.md
@@ -1,6 +1,6 @@
 ---
 title: list Command
-description: Displays the list of listed apps and if an update is available. 
+description: Displays the list of listed apps and if an update is available.
 ms.date: 05/5/2021
 ms.topic: overview
 ms.localizationpriority: medium
@@ -28,9 +28,8 @@ The **list** command also supports filters which can be used to limit your list 
 The following arguments are available.
 
 | Argument      | Description |
-|-------------|-------------|  
+|-------------|-------------|
 | **-q,--query**  |  The query used to search for an app. |
-| **-?, --help** |  Get additional help on this command. |
 
 > [!NOTE]
 > The query argument is positional. Wild-card style syntax is not supported. This is most often the string of characters you expect to help find the installed package you are searching for.
@@ -40,18 +39,24 @@ The following arguments are available.
 The options allow you to customize the list experience to meet your needs.
 
 | Option      | Description |
-|-------------|-------------|  
-| **--id**    |  Limits the list to the ID of the application.   |  
-| **--name**   |  Limits the list to the name of the application. |  
-| **--moniker**   | Limits the list to the moniker listed for the application. |  
-| **-s, --source**   |  Restricts the list to the source name provided. Must be followed by the source name. |  
-| **--tag** |  Filters results by tags. |  
-| **--command** |  Filters results by command specified by the application. |  
+|-------------|-------------|
+| **--id**    |  Limits the list to the ID of the application.   |
+| **--name**   |  Limits the list to the name of the application. |
+| **--moniker**   | Limits the list to the moniker listed for the application. |
+| **-s, --source**   |  Restricts the list to the source name provided. Must be followed by the source name. |
+| **--tag** |  Filters results by tags. |
+| **--cmd, --command** |  Filters results by command specified by the application. |
 | **-n, --count** | Limits the number of apps displayed in one query.   |
-| **-e, --exact**   |   Uses the exact string in the list query, including checking for case-sensitivity. It will not use the default behavior of a substring. |  
-| **--accept-source-agreements** | Used to accept the source license agreement, and avoid the prompt. |
+| **-e, --exact**   |   Uses the exact string in the list query, including checking for case-sensitivity. It will not use the default behavior of a substring. |
+| **--scope** | Select installed package scope filter (user or machine). |
 | **--header** | Optional Windows-Package-Manager REST source HTTP header. |
-| **--verbose-logs** | Used to override the logging setting and create a verbose log. |
+| **--accept-source-agreements** | Used to accept the source license agreement, and avoid the prompt. |
+| **--upgrade-available** | Lists only packages which have an upgrade available. |
+| **-?, --help** |  Get additional help on this command. |
+| **--wait** | Prompts the user to press any key before exiting. |
+| **--logs,--open-logs** | Open the default logs location. |
+| **--verbose, --verbose-logs** | Used to override the logging setting and create a verbose log. |
+| **--disable-interactivity** | Disable interactive prompts. |
 
 ### Example queries
 

--- a/hub/package-manager/winget/pinning.md
+++ b/hub/package-manager/winget/pinning.md
@@ -29,7 +29,7 @@ winget pin <subcommand> <options>
 
 The following options are available.
 
-| Options  | Description |
+| Option  | Description |
 |--------------|-------------|
 | **-?, --help** |  Gets additional help on this command. |
 | **--wait** | Prompts the user to press any key before exiting. |

--- a/hub/package-manager/winget/pinning.md
+++ b/hub/package-manager/winget/pinning.md
@@ -25,13 +25,17 @@ WinGet supports three types of package pins:
 winget pin <subcommand> <options>
 ```
 
-## Arguments
+## Options
 
-The following arguments are available.
+The following options are available.
 
-| Argument  | Description |
+| Options  | Description |
 |--------------|-------------|
 | **-?, --help** |  Gets additional help on this command. |
+| **--wait** | Prompts the user to press any key before exiting. |
+| **--logs,--open-logs** | Open the default logs location. |
+| **--verbose, --verbose-logs** | Used to override the logging setting and create a verbose log. |
+| **--disable-interactivity** | Disable interactive prompts. |
 
 ## Subcommands
 
@@ -59,7 +63,6 @@ winget pin add [[-q] <query>] [<options>]
 | Argument      | Description |
 |-------------|-------------|
 | **-q,--query**  |  The query used to search for an app. |
-| **-?, --help** |  Get additional help on this command. |
 
 ### Options
 
@@ -80,6 +83,7 @@ The options allow you to customize adding pins to meet your needs.
 | **--installed** | Pin a specific installed version |
 | **--accept-source-agreements** | Used to accept the source license agreement, and avoid the prompt. |
 | **--header** | Optional Windows-Package-Manager REST source HTTP header. |
+| **-?, --help** |  Get additional help on this command. |
 | **--wait** | Prompts the user to press any key before exiting |
 | **--logs, --open-logs**  | Open the default logs location. |
 | **--verbose, --verbose-logs** | Used to override the logging setting and create a verbose log. |
@@ -120,7 +124,6 @@ winget pin remove [[-q] <query>] [<options>]
 | Argument      | Description |
 |-------------|-------------|
 | **-q,--query**  |  The query used to search for an app. |
-| **-?, --help** |  Get additional help on this command. |
 
 ### Options
 
@@ -138,6 +141,7 @@ The options allow you to customize removing pins to meet your needs.
 | **--installed** | Pin a specific installed version |
 | **--accept-source-agreements** | Used to accept the source license agreement, and avoid the prompt. |
 | **--header** | Optional Windows-Package-Manager REST source HTTP header. |
+| **-?, --help** |  Get additional help on this command. |
 | **--wait** | Prompts the user to press any key before exiting |
 | **--logs, --open-logs**  | Open the default logs location. |
 | **--verbose, --verbose-logs** | Used to override the logging setting and create a verbose log. |
@@ -172,7 +176,6 @@ winget pin list [[-q] <query>] [<options>]
 | Argument      | Description |
 |-------------|-------------|
 | **-q,--query**  |  The query used to search for an app. |
-| **-?, --help** |  Get additional help on this command. |
 
 ### Options
 
@@ -189,6 +192,7 @@ The options allow you to customize listing pins to meet your needs.
 | **-e, --exact**   |   Uses the exact string in the query, including checking for case-sensitivity. It will not use the default behavior of a substring. |
 | **--accept-source-agreements** | Used to accept the source license agreement, and avoid the prompt. |
 | **--header** | Optional Windows-Package-Manager REST source HTTP header. |
+| **-?, --help** |  Get additional help on this command. |
 | **--wait** | Prompts the user to press any key before exiting |
 | **--logs, --open-logs**  | Open the default logs location. |
 | **--verbose, --verbose-logs** | Used to override the logging setting and create a verbose log. |

--- a/hub/package-manager/winget/pinning.md
+++ b/hub/package-manager/winget/pinning.md
@@ -7,7 +7,7 @@ ms.topic: reference
 
 # pin command (winget)
 
-The [winget](index.md) **pin** command allows you to limit the Windows Package Manager from upgrading a package to specific ranges of versions, or it can prevent it from upgrading a package altogether. A pinned package may still upgrade on its own and be upgraded from outside the Windows Package Manager. 
+The [winget](index.md) **pin** command allows you to limit the Windows Package Manager from upgrading a package to specific ranges of versions, or it can prevent it from upgrading a package altogether. A pinned package may still upgrade on its own and be upgraded from outside the Windows Package Manager.
 
 ## Pin Types
 
@@ -17,7 +17,7 @@ WinGet supports three types of package pins:
 
 - **Blocking**: The package is blocked from `winget upgrade --all` or `winget upgrade <package>`, you will have to unpin the package to let WinGet perform an upgrade. The `--force` option can be used to override the pin's behavior.
 
-- **Gating**: The package is pinned to a specific version or version range. You can specify an exact version you want a package to be pinned to or you can utilize the wildcard character `*` as the last version part to specify a version range. For example, if a package is pinned to version `1.2.*`, any version between `1.2.0` to `1.2.x` is considered valid. The `--force` option can be used to override the pin's behavior. 
+- **Gating**: The package is pinned to a specific version or version range. You can specify an exact version you want a package to be pinned to or you can utilize the wildcard character `*` as the last version part to specify a version range. For example, if a package is pinned to version `1.2.*`, any version between `1.2.0` to `1.2.x` is considered valid. The `--force` option can be used to override the pin's behavior.
 
 ## Usage
 
@@ -57,7 +57,7 @@ winget pin add [[-q] <query>] [<options>]
 ### Arguments
 
 | Argument      | Description |
-|-------------|-------------|  
+|-------------|-------------|
 | **-q,--query**  |  The query used to search for an app. |
 | **-?, --help** |  Get additional help on this command. |
 
@@ -66,23 +66,23 @@ winget pin add [[-q] <query>] [<options>]
 The options allow you to customize adding pins to meet your needs.
 
 | Option  | Description |
-|-------------|-------------|  
-| **--id**    |  Limits the search to the ID of the application.   |  
-| **--name**   |  Limits the search to the name of the application. |  
-| **--moniker**   | Limits the search to the moniker listed for the application. |  
-| **--tag**   | Limits the search to the tag listed for the application. | 
-| **--cmd, --command**   | Limits the search to the command of the application. |   
-| **-v, --version**  |  Enables you to specify an exact version to pin. The wildcard * can be used as the last version part. Changes pin behavior to be [`gating`](#pin-types). |  
-| **-s, --source**   |  Restricts the search to the source name provided. Must be followed by the source name. |  
-| **-e, --exact**   |   Uses the exact string in the query, including checking for case-sensitivity. It will not use the default behavior of a substring. |  
+|-------------|-------------|
+| **--id**    |  Limits the search to the ID of the application.   |
+| **--name**   |  Limits the search to the name of the application. |
+| **--moniker**   | Limits the search to the moniker listed for the application. |
+| **--tag**   | Limits the search to the tag listed for the application. |
+| **--cmd, --command**   | Limits the search to the command of the application. |
+| **-v, --version**  |  Enables you to specify an exact version to pin. The wildcard * can be used as the last version part. Changes pin behavior to be [`gating`](#pin-types). |
+| **-s, --source**   |  Restricts the search to the source name provided. Must be followed by the source name. |
+| **-e, --exact**   |   Uses the exact string in the query, including checking for case-sensitivity. It will not use the default behavior of a substring. |
 | **--force** | Direct run the command and continue with non security related issues. |
 | **--blocking** | Block from upgrading until the pin is removed, preventing override arguments. Changes pin behavior to be [`blocking`](#pin-types). |
 | **--installed** | Pin a specific installed version |
 | **--accept-source-agreements** | Used to accept the source license agreement, and avoid the prompt. |
 | **--header** | Optional Windows-Package-Manager REST source HTTP header. |
 | **--wait** | Prompts the user to press any key before exiting |
-| **--logs, --open-log**  | Open the default logs location. |
-| **--verbose-logs** | Used to override the logging setting and create a verbose log. |
+| **--logs, --open-logs**  | Open the default logs location. |
+| **--verbose, --verbose-logs** | Used to override the logging setting and create a verbose log. |
 | **--disable-interactivity** | Disable interactive prompts. |
 
 ### Examples
@@ -99,7 +99,7 @@ The following example adds a blocking pin for an application using its ID. Addin
 winget pin add --id Microsoft.PowerToys --blocking
 ```
 
-The following example adds a gating pin for an application using its ID. Adding a gating pin will prevent upgrades that upgrade the package version outside of a specific version or the gated wildcard range. 
+The following example adds a gating pin for an application using its ID. Adding a gating pin will prevent upgrades that upgrade the package version outside of a specific version or the gated wildcard range.
 
 ```cmd
 winget pin add --id Microsoft.PowerToys --version 0.70.*
@@ -118,7 +118,7 @@ winget pin remove [[-q] <query>] [<options>]
 ### Arguments
 
 | Argument      | Description |
-|-------------|-------------|  
+|-------------|-------------|
 | **-q,--query**  |  The query used to search for an app. |
 | **-?, --help** |  Get additional help on this command. |
 
@@ -127,25 +127,25 @@ winget pin remove [[-q] <query>] [<options>]
 The options allow you to customize removing pins to meet your needs.
 
 | Option  | Description |
-|-------------|-------------|  
-| **--id**    |  Limits the search to the ID of the application.   |  
-| **--name**   |  Limits the search to the name of the application. |  
-| **--moniker**   | Limits the search to the moniker listed for the application. |  
-| **--tag**   | Limits the search to the tag listed for the application. | 
-| **--cmd, --command**   | Limits the search to the command of the application. |   
-| **-s, --source**   |  Restricts the search to the source name provided. Must be followed by the source name. |  
-| **-e, --exact**   |   Uses the exact string in the query, including checking for case-sensitivity. It will not use the default behavior of a substring. |  
+|-------------|-------------|
+| **--id**    |  Limits the search to the ID of the application.   |
+| **--name**   |  Limits the search to the name of the application. |
+| **--moniker**   | Limits the search to the moniker listed for the application. |
+| **--tag**   | Limits the search to the tag listed for the application. |
+| **--cmd, --command**   | Limits the search to the command of the application. |
+| **-s, --source**   |  Restricts the search to the source name provided. Must be followed by the source name. |
+| **-e, --exact**   |   Uses the exact string in the query, including checking for case-sensitivity. It will not use the default behavior of a substring. |
 | **--installed** | Pin a specific installed version |
 | **--accept-source-agreements** | Used to accept the source license agreement, and avoid the prompt. |
 | **--header** | Optional Windows-Package-Manager REST source HTTP header. |
 | **--wait** | Prompts the user to press any key before exiting |
-| **--logs, --open-log**  | Open the default logs location. |
-| **--verbose-logs** | Used to override the logging setting and create a verbose log. |
+| **--logs, --open-logs**  | Open the default logs location. |
+| **--verbose, --verbose-logs** | Used to override the logging setting and create a verbose log. |
 | **--disable-interactivity** | Disable interactive prompts. |
 
 ### Examples
 
-The following example removes a pin for an application. 
+The following example removes a pin for an application.
 
 ```cmd
 winget pin remove powertoys
@@ -159,7 +159,7 @@ winget pin remove --id Microsoft.PowerToys
 
 ## list
 
-The **list** subcommand lists all current pins. 
+The **list** subcommand lists all current pins.
 
 Usage:
 
@@ -170,7 +170,7 @@ winget pin list [[-q] <query>] [<options>]
 ### Arguments
 
 | Argument      | Description |
-|-------------|-------------|  
+|-------------|-------------|
 | **-q,--query**  |  The query used to search for an app. |
 | **-?, --help** |  Get additional help on this command. |
 
@@ -179,24 +179,24 @@ winget pin list [[-q] <query>] [<options>]
 The options allow you to customize listing pins to meet your needs.
 
 | Option  | Description |
-|-------------|-------------|  
-| **--id**    |  Limits the search to the ID of the application.   |  
-| **--name**   |  Limits the search to the name of the application. |  
-| **--moniker**   | Limits the search to the moniker listed for the application. |  
-| **--tag**   | Limits the search to the tag listed for the application. | 
-| **--cmd, --command**   | Limits the search to the command of the application. |   
-| **-s, --source**   |  Restricts the search to the source name provided. Must be followed by the source name. |  
-| **-e, --exact**   |   Uses the exact string in the query, including checking for case-sensitivity. It will not use the default behavior of a substring. |  
+|-------------|-------------|
+| **--id**    |  Limits the search to the ID of the application.   |
+| **--name**   |  Limits the search to the name of the application. |
+| **--moniker**   | Limits the search to the moniker listed for the application. |
+| **--tag**   | Limits the search to the tag listed for the application. |
+| **--cmd, --command**   | Limits the search to the command of the application. |
+| **-s, --source**   |  Restricts the search to the source name provided. Must be followed by the source name. |
+| **-e, --exact**   |   Uses the exact string in the query, including checking for case-sensitivity. It will not use the default behavior of a substring. |
 | **--accept-source-agreements** | Used to accept the source license agreement, and avoid the prompt. |
 | **--header** | Optional Windows-Package-Manager REST source HTTP header. |
 | **--wait** | Prompts the user to press any key before exiting |
-| **--logs, --open-log**  | Open the default logs location. |
-| **--verbose-logs** | Used to override the logging setting and create a verbose log. |
+| **--logs, --open-logs**  | Open the default logs location. |
+| **--verbose, --verbose-logs** | Used to override the logging setting and create a verbose log. |
 | **--disable-interactivity** | Disable interactive prompts. |
 
 ### Examples
 
-The following example lists all current pins. 
+The following example lists all current pins.
 
 ```cmd
 winget pin list

--- a/hub/package-manager/winget/search.md
+++ b/hub/package-manager/winget/search.md
@@ -27,7 +27,6 @@ The following arguments are available.
 | Argument  | Description |
  --------------|-------------|
 | **-q,--query** |  The query flag is the default argument used to search for an app. It does not need to be specified. Entering the command `winget search foo` will default to using `--query` so including it is unnecessary.|
-| **-?, --help** |  Gets additional help on this command. |
 
 > [!NOTE]
 > The query argument is positional. Wild-card style syntax is not supported. This is most often the string of characters you expect to help find the package you are searching for.
@@ -41,7 +40,7 @@ To show all of the winget packages available, use the command:
 In PowerShell, you will need to escape the quotes, so this command becomes:
 
 ```powershell
-winget search -q `"`" 
+winget search -q `"`"
 ```
 
 > [!NOTE]
@@ -57,13 +56,18 @@ Search strings can be filtered with the following options.
 | **--name**      |  Limits the search to the name of the application. |
 | **--moniker**  |    Limits the search to the moniker specified. |
 | **--tag**    |  Limits the search to the tags listed for the application. |
-| **--command**   |   Limits the search to the commands listed for the application. |
-| **--verbose-logs** | Used to override the logging setting and create a verbose log. |
-| **-e, --exact**  |     Uses the exact string in the query, including checking for case-sensitivity. It will not use the default behavior of a substring.  |  
-| **-n, --count**      |  Show no more than specified number of results (between 1 and 1000). |
+| **--cmd, --command**   |   Limits the search to the commands listed for the application. |
 | **-s, --source**     |  Find package using the specified [source](source.md) name. |
+| **-n, --count**      |  Show no more than specified number of results (between 1 and 1000). |
+| **-e, --exact**  |     Uses the exact string in the query, including checking for case-sensitivity. It will not use the default behavior of a substring.  |
 | **--header** | Optional Windows-Package-Manager REST source HTTP header. |
-| **--accept-source-agreements** | Accept all source license agreements and avoid the prompt. |
+| **--accept-source-agreements** | Accept all source agreements during source operations. |
+| **--versions** | Show available versions of the package. |
+| **--verbose, --verbose-logs** | Used to override the logging setting and create a verbose log. |
+| **-?, --help** |  Gets additional help on this command. |
+| **--wait** | Prompts the user to press any key before exiting. |
+| **--logs,--open-logs** | Open the default logs location. |
+| **--disable-interactivity** | Disable interactive prompts. |
 
 The string will be treated as a substring. The search by default is also case insensitive. For example, `winget search micro` could return the following:
 

--- a/hub/package-manager/winget/show.md
+++ b/hub/package-manager/winget/show.md
@@ -25,7 +25,6 @@ The following arguments are available.
 | Argument  | Description |
 |--------------|-------------|
 | **-q,--query** |  The query used to search for an application. |
-| **-?, --help** |  Gets additional help on this command. |
 
 > [!NOTE]
 > The query argument is positional. Wild-card style syntax is not supported. This is most often the string of characters you expect to help find the package you are searching for.
@@ -43,10 +42,17 @@ The following options are available.
 | **-v,--version** |  Use the specified version. The default is the latest version. |
 | **-s,--source** |   Find the application using the specified [source](source.md). |
 | **-e,--exact**     | Find the application using exact match. |
+| **--scope**     | Select install scope (user or machine). |
+| **-a,--architecture**     | Select the architecture to install. |
+| **--locale**     | Locale to use (BCP47 format). |
 | **--versions**    | Show available versions of the application. |
 | **--header** | Optional Windows-Package-Manager REST source HTTP header. |
 | **--accept-source-agreements** | Used to accept the source license agreement, and avoid the prompt. |
-| **--verbose-logs** | Used to override the logging setting and create a verbose log. |
+| **-?,--help** | Shows help about the selected command. |
+| **--wait** | Prompts the user to press any key before exiting. |
+| **--logs,--open-logs** | Open the default logs location. |
+| **--verbose, --verbose-logs** | Used to override the logging setting and create a verbose log. |
+| **--disable-interactivity** | Disable interactive prompts. |
 
 ## Multiple selections
 

--- a/hub/package-manager/winget/source.md
+++ b/hub/package-manager/winget/source.md
@@ -35,6 +35,18 @@ The following image shows **help** for the **source** command:
 
 :::image type="content" source="images/source.png" alt-text="Screenshot showing help for the source command.":::
 
+## Options
+
+The following options are available.
+
+| Option  | Description |
+|--------------|-------------|
+| **-?,--help** | Shows help about the selected command. |
+| **--wait** | Prompts the user to press any key before exiting. |
+| **--logs,--open-logs** | Open the default logs location. |
+| **--verbose, --verbose-logs** | Used to override the logging setting and create a verbose log. |
+| **--disable-interactivity** | Disable interactive prompts. |
+
 ## Subcommands
 
 The **source** command supports the following subcommands.
@@ -58,6 +70,30 @@ Usage:
 winget source add [-n, --name] <name> [-a, --arg] <url> [[-t, --type] <type>]
 ```
 
+#### Arguments
+
+The following arguments are available.
+
+| Argument  | Description |
+|--------------|-------------|
+| **-n, --name** | The name to identify the source by. |
+| **-a, --arg** | The URL or UNC of the source. |
+| **-t, --type** | The type of source. |
+
+#### Options
+
+The following options are available.
+
+| Option  | Description |
+|--------------|-------------|
+| **--header** | Optional Windows-Package-Manager REST source HTTP header. |
+| **--accept-source-agreements** | Used to accept the source license agreement, and avoid the prompt. |
+| **-?, --help** |  Get additional help on this command. |
+| **--wait** | Prompts the user to press any key before exiting. |
+| **--logs,--open-logs** | Open the default logs location. |
+| **--verbose, --verbose-logs** | Used to override the logging setting and create a verbose log. |
+| **--disable-interactivity** | Disable interactive prompts. |
+
 For example,  `winget source add --name Contoso https://www.contoso.com/cache` adds the Contoso repository at URL `https://www.contoso.com/cache`.
 
 #### Optional type parameter
@@ -77,6 +113,26 @@ Usage:
 ```cmd
 winget source list [[-n, --name] <name>]
 ```
+
+#### Arguments
+
+The following arguments are available.
+
+| Argument  | Description |
+|--------------|-------------|
+| **-n, --name** | The name to identify the source by. |
+
+#### Options
+
+The following options are available.
+
+| Option  | Description |
+|--------------|-------------|
+| **-?, --help** |  Get additional help on this command. |
+| **--wait** | Prompts the user to press any key before exiting. |
+| **--logs,--open-logs** | Open the default logs location. |
+| **--verbose, --verbose-logs** | Used to override the logging setting and create a verbose log. |
+| **--disable-interactivity** | Disable interactive prompts. |
 
 #### list all
 
@@ -99,10 +155,10 @@ winget source list --name Contoso
 Returns the following output:
 
 ```output
-Name   : Contoso  
-Type   : Microsoft.PreIndexed.Package  
-Arg    : https://pkgmgr-int.azureedge.net/cache  
-Data   : AppInstallerSQLiteIndex-int_g4ype1skzj3jy  
+Name   : Contoso
+Type   : Microsoft.PreIndexed.Package
+Arg    : https://pkgmgr-int.azureedge.net/cache
+Data   : AppInstallerSQLiteIndex-int_g4ype1skzj3jy
 Updated: 2020-4-14 17:45:32.000
 ```
 
@@ -122,6 +178,26 @@ Usage:
 winget source update [[-n, --name] <name>]
 ```
 
+#### Arguments
+
+The following arguments are available.
+
+| Argument  | Description |
+|--------------|-------------|
+| **-n, --name** | The name to identify the source by. |
+
+#### Options
+
+The following options are available.
+
+| Option  | Description |
+|--------------|-------------|
+| **-?, --help** |  Get additional help on this command. |
+| **--wait** | Prompts the user to press any key before exiting. |
+| **--logs,--open-logs** | Open the default logs location. |
+| **--verbose, --verbose-logs** | Used to override the logging setting and create a verbose log. |
+| **--disable-interactivity** | Disable interactive prompts. |
+
 #### update all
 
 The **update** subcommand by itself, `winget source update`, requests updates to all repos.
@@ -140,7 +216,33 @@ Usage:
 winget source remove [-n, --name] <name>
 ```
 
-For example: `winget source remove --name Contoso` removes the Contoso repository.
+#### Arguments
+
+The following arguments are available.
+
+| Argument  | Description |
+|--------------|-------------|
+| **-n, --name** | The name to identify the source by. |
+
+#### Options
+
+The following options are available.
+
+| Option  | Description |
+|--------------|-------------|
+| **-?, --help** |  Get additional help on this command. |
+| **--wait** | Prompts the user to press any key before exiting. |
+| **--logs,--open-logs** | Open the default logs location. |
+| **--verbose, --verbose-logs** | Used to override the logging setting and create a verbose log. |
+| **--disable-interactivity** | Disable interactive prompts. |
+
+#### Examples
+
+```cmd
+winget source remove --name Contoso
+```
+
+This command removes the Contoso repository.
 
 ### reset
 
@@ -154,11 +256,51 @@ Usage:
 winget source reset --force
 ```
 
+#### Arguments
+
+The following arguments are available.
+
+| Argument  | Description |
+|--------------|-------------|
+| **-n, --name** | The name to identify the source by. |
+
+#### Options
+
+The following options are available.
+
+| Option  | Description |
+|--------------|-------------|
+| **-?, --help** |  Get additional help on this command. |
+| **--wait** | Prompts the user to press any key before exiting. |
+| **--logs,--open-logs** | Open the default logs location. |
+| **--verbose, --verbose-logs** | Used to override the logging setting and create a verbose log. |
+| **--disable-interactivity** | Disable interactive prompts. |
+
 ### export
 
 The **export** sub-command exports the specific details for a source to JSON output.
 
-For example:
+#### Arguments
+
+The following arguments are available.
+
+| Argument  | Description |
+|--------------|-------------|
+| **-n, --name** | The name to identify the source by. |
+
+#### Options
+
+The following options are available.
+
+| Option  | Description |
+|--------------|-------------|
+| **-?, --help** |  Get additional help on this command. |
+| **--wait** | Prompts the user to press any key before exiting. |
+| **--logs,--open-logs** | Open the default logs location. |
+| **--verbose, --verbose-logs** | Used to override the logging setting and create a verbose log. |
+| **--disable-interactivity** | Disable interactive prompts. |
+
+#### Examples
 
 ```cmd
 winget source export winget
@@ -169,21 +311,6 @@ Returns the following output:
 ```output
 {"Arg":"https://winget.azureedge.net/cache","Data":"Microsoft.Winget.Source_8wekyb3d8bbwe","Identifier":"Microsoft.Winget.Source_8wekyb3d8bbwe","Name":"winget","Type":"Microsoft.PreIndexed.Package"}
 ```
-
-## Options
-
-The  **source** command supports the following options.
-
-| Option  | Description |
-|--------------|-------------|
-|  **-n,--name** | The name to identify the source by. |
-|  **-a,--arg** | The URL or UNC of the source. |
-|  **--force** | Used by **reset** to ensure that a reset is desired. |
-|  **-t,--type** | The type of source. |
-| **--accept-source-agreements** | Accepts the source license agreement, and avoids the prompt. |
-| **--header** | Optional Windows-Package-Manager REST source HTTP header. |
-| **--verbose-logs** | Overrides the logging setting and creates a verbose log. |
-|  **-?, --help** |  Gets additional help on this command. |
 
 ## Source agreement
 

--- a/hub/package-manager/winget/uninstall.md
+++ b/hub/package-manager/winget/uninstall.md
@@ -26,9 +26,8 @@ The **uninstall** command requires that you specify the exact string to uninstal
 The following arguments are available.
 
 | Argument      | Description |
-|-------------|-------------|  
+|-------------|-------------|
 | **-q,--query**  |  The query used to search for an app. |
-| **-?, --help** |  Get additional help on this command. |
 
 > [!NOTE]
 > The query argument is positional. Wild-card style syntax is not supported. This is most often the string of characters you expect to help find the package you are uninstalling.
@@ -38,23 +37,29 @@ The following arguments are available.
 The options allow you to customize the uninstall experience to meet your needs.
 
 | Option      | Description |
-|-------------|-------------|  
+|-------------|-------------|
 | **-m, --manifest** |   Must be followed by the path to the manifest (YAML) file. You can use the manifest to run the uninstall experience from a [local YAML file](install.md#local-install). |
-| **--id**    |  Limits the uninstall to the ID of the application.   |  
-| **--name**   |  Limits the search to the name of the application. |  
-| **--moniker**   | Limits the search to the moniker listed for the application. |  
+| **--id**    |  Limits the uninstall to the ID of the application.   |
+| **--name**   |  Limits the search to the name of the application. |
+| **--moniker**   | Limits the search to the moniker listed for the application. |
 | **--product-code** | Filters using the product code |
-| **-v, --version**  |  Enables you to specify an exact version to uninstall. If not specified, latest will uninstall the highest versioned application. |  
-| **-s, --source**   |  Restricts the search to the source name provided. Must be followed by the source name. |  
-| **-e, --exact**   |   Uses the exact string in the query, including checking for case-sensitivity. It will not use the default behavior of a substring. |  
-| **-i, --interactive** |  Runs the uninstaller in interactive mode. The default experience shows uninstaller progress. |  
-| **-h, --silent** |  Runs the uninstaller in silent mode. This suppresses all UI. The default experience shows uninstaller progress. |  
+| **-v, --version**  |  Enables you to specify an exact version to uninstall. If not specified, latest will uninstall the highest versioned application. |
+| **-s, --source**   |  Restricts the search to the source name provided. Must be followed by the source name. |
+| **-e, --exact**   |   Uses the exact string in the query, including checking for case-sensitivity. It will not use the default behavior of a substring. |
+| **--scope** | Select installed package scope filter (user or machine) |
+| **-i, --interactive** |  Runs the uninstaller in interactive mode. The default experience shows uninstaller progress. |
+| **-h, --silent** |  Runs the uninstaller in silent mode. This suppresses all UI. The default experience shows uninstaller progress. |
+| **--force** | Direct run the command and continue with non security related issues. |
 | **--purge** | Deletes all files and directories in the package directory (portable) |
 | **--preserve** | Retains all files and directories created by the package (portable) |
 | **-o, --log**  |  Directs the logging to a log file. You must provide a path to a file that you have the write rights to. |
-| **--accept-source-agreements** | Used to accept the source license agreement, and avoid the prompt. |
 | **--header** | Optional Windows-Package-Manager REST source HTTP header. |
-| **--verbose-logs** | Used to override the logging setting and create a verbose log. |
+| **--accept-source-agreements** | Used to accept the source license agreement, and avoid the prompt. |
+| **-?,--help** | Shows help about the selected command. |
+| **--wait** | Prompts the user to press any key before exiting. |
+| **--logs,--open-logs** | Open the default logs location. |
+| **--verbose, --verbose-logs** | Used to override the logging setting and create a verbose log. |
+| **--disable-interactivity** | Disable interactive prompts. |
 
 After you have successfully identified the application intended to uninstall, winget will execute the uninstall command. In the example below, the **name** 'orca' and the **id** was passed in.
 

--- a/hub/package-manager/winget/upgrade.md
+++ b/hub/package-manager/winget/upgrade.md
@@ -100,7 +100,7 @@ In the example below, you will see **winget upgrade** shows the user which apps 
 To search for an available update for a specific app, use to the [**list**](.\list.md) command. Once you have identified that a update is available for your specific app, use **upgrade** to install the latest.
 
 The example below shows the [**list**](.\list.md) command being used to identify that an update is available for *Microsoft.WindowsTerminalPreview*. The user then uses **upgrade** to update the application.
-![Animation demonstrating upgrade command](./images/listUpgrade.gif)
+![Animation demonstrating list command used in conjunction with upgrade command](./images/listUpgrade.gif)
 
 ## **upgrade** --all
 

--- a/hub/package-manager/winget/upgrade.md
+++ b/hub/package-manager/winget/upgrade.md
@@ -8,7 +8,7 @@ ms.localizationpriority: medium
 
 # upgrade command (winget)
 
-The **upgrade** command of the [winget](index.md) tool upgrades the specified application. Optionally, you may use the [**list**](.\list.md) command to identify the application you want to upgrade.  
+The **upgrade** command of the [winget](index.md) tool upgrades the specified application. Optionally, you may use the [**list**](.\list.md) command to identify the application you want to upgrade.
 
 The **upgrade** command requires that you specify the exact string to upgrade. If there is any ambiguity, you will be prompted to further filter the **upgrade** command to  an exact application.
 
@@ -23,9 +23,8 @@ The **upgrade** command requires that you specify the exact string to upgrade. I
 The following arguments are available.
 
 | Argument      | Description |
-|-------------|-------------|  
+|-------------|-------------|
 | **-q,--query**  |  The query used to search for an app. |
-| **-?, --help** |  Get additional help on this command. |
 
 > [!NOTE]
 > The query argument is positional. Wild-card style syntax is not supported. This is most often the string of characters you expect to help find the package you are upgrading.
@@ -35,27 +34,40 @@ The following arguments are available.
 The options allow you to customize the upgrade experience to meet your needs.
 
 | Option      | Description |
-|-------------|-------------|  
+|-------------|-------------|
 | **-m, --manifest** |   Must be followed by the path to the manifest (YAML) file. You can use the manifest to run the upgrade experience from a [local YAML file](install.md#local-install). |
-| **--id**    |  Limits the upgrade to the ID of the application.   |  
-| **--name**   |  Limits the search to the name of the application. |  
-| **--moniker**   | Limits the search to the moniker listed for the application. |  
-| **-v, --version**  |  Enables you to specify an exact version to upgrade. If not specified, latest will upgrade the highest versioned application. |  
-| **-s, --source**   |  Restricts the search to the source name provided. Must be followed by the source name. |  
-| **-e, --exact**   |   Uses the exact string in the query, including checking for case-sensitivity. It will not use the default behavior of a substring. |  
-| **-i, --interactive** |  Runs the installer in interactive mode. The default experience shows installer progress. |  
+| **--id**    |  Limits the upgrade to the ID of the application.   |
+| **--name**   |  Limits the search to the name of the application. |
+| **--moniker**   | Limits the search to the moniker listed for the application. |
+| **-v, --version**  |  Enables you to specify an exact version to upgrade. If not specified, latest will upgrade the highest versioned application. |
+| **-s, --source**   |  Restricts the search to the source name provided. Must be followed by the source name. |
+| **-e, --exact**   |   Uses the exact string in the query, including checking for case-sensitivity. It will not use the default behavior of a substring. |
+| **-i, --interactive** |  Runs the installer in interactive mode. The default experience shows installer progress. |
 | **-h, --silent** |  Runs the installer in silent mode. This suppresses all UI. The default experience shows installer progress. |
 | **--purge** | Deletes all files and directories in the package directory (portable) |
 | **-o, --log**  |  Directs the logging to a log file. You must provide a path to a file that you have the write rights to. |
+| **--custom** | Arguments to be passed on to the installer in addition to the defaults.  |
 | **--override** | A string that will be passed directly to the installer.    |
 | **-l, --location** |    Location to upgrade to (if supported). |
-| **--force** | When a hash mismatch is discovered will ignore the error and attempt to install the package.    |
+| **-scope** | Select installed package scope filter (user or machine). |
+| **a, --architecture** | Select the architecture to install. |
+| **--locale** | Specifies which locale to use (BCP47 format). |
+| **--ignore-security-hash** | Ignore the installer hash check failure. Not recommended. |
+| **--ignore-local-archive-malware-scan** | Ignore the malware scan performed as part of installing an archive type package from local manifest. |
 | **--accept-package-agreements** | Used to accept the license agreement, and avoid the prompt. |
 | **--accept-source-agreements** | Used to accept the source license agreement, and avoid the prompt. |
 | **--header** | Optional Windows-Package-Manager REST source HTTP header. |
-| **--all** | Updates all available packages to the latest application. |
-| **--include-unknown** | Upgrade packages even if their current version cannot be determined. |
-| **--verbose-logs** | Used to override the logging setting and create a verbose log. |
+| **-r, --recurse, --all** | Updates all available packages to the latest application. |
+| **-u, --unknown, --include-unknown** | Upgrade packages even if their current version cannot be determined. |
+| **--pinned,--include-pinned** | Upgrade packages even if they have a non-blocking pin. |
+| **--uninstall-previous** | Uninstall the previous version of the package during upgrade. |
+| **--force** | Direct run the command and continue with non security related issues. |
+| **-?,--help** | Shows help about the selected command. |
+| **--wait** | Prompts the user to press any key before exiting. |
+| **--logs,--open-logs** | Open the default logs location. |
+| **--verbose, --verbose-logs** | Used to override the logging setting and create a verbose log. |
+| **--disable-interactivity** | Disable interactive prompts. |
+
 ### Example queries
 
 The following example upgrades a specific version of an application.
@@ -78,14 +90,14 @@ winget upgrade --all
 
 ## Using **upgrade**
 
-To identify which apps are in need of an update, simply use **upgrade** without any arguments to show all available upgrades. 
+To identify which apps are in need of an update, simply use **upgrade** without any arguments to show all available upgrades.
 
 In the example below, you will see **winget upgrade** shows the user which apps have an available update. From the available updates, the user identifies that an update is available for *JanDeDobbeleer.OhMyPosh* and uses **upgrade** to update the application.
 
 ![Animation demonstrating upgrade command](./images/upgrade.gif)
 
 ## Using **list** and **upgrade**
-To search for an available update for a specific app, use to the [**list**](.\list.md) command. Once you have identified that a update is available for your specific app, use **upgrade** to install the latest. 
+To search for an available update for a specific app, use to the [**list**](.\list.md) command. Once you have identified that a update is available for your specific app, use **upgrade** to install the latest.
 
 The example below shows the [**list**](.\list.md) command being used to identify that an update is available for *Microsoft.WindowsTerminalPreview*. The user then uses **upgrade** to update the application.
 ![Animation demonstrating upgrade command](./images/listUpgrade.gif)

--- a/hub/package-manager/winget/validate.md
+++ b/hub/package-manager/winget/validate.md
@@ -21,8 +21,18 @@ The following arguments are available.
 | Argument  | Description |
 |--------------|-------------|
 | **--manifest** |  the path to the manifest to be validated. |
-| **--verbose-logs** | Used to override the logging setting and create a verbose log. |
-| **-?, --help** |  get additional help on this command |
+
+## Options
+
+The options allow you to customize the validate experience to meet your needs.
+
+| Option  | Description |
+|-------------|-------------|
+| **-?,--help** | Shows help about the selected command. |
+| **--wait** | Prompts the user to press any key before exiting. |
+| **--logs,--open-logs** | Open the default logs location. |
+| **--verbose, --verbose-logs** | Used to override the logging setting and create a verbose log. |
+| **--disable-interactivity** | Disable interactive prompts. |
 
 ## Related topics
 


### PR DESCRIPTION
Added new arguments / options that are supported on the latest 1.5 stable release of WinGet.

Here is a summary of the changes:

- Changed order of commands to match as they appear in the WinGet client to make this easy to review if you see the corresponding WinGet client outputs
- Added new options / modified existing ones to be up to date with the WinGet client
- `-?, --help` is classified as an option not an argument in most commands, so I have changed that accordingly in the docs
- Trimmed trailing whitespaces from the markdown files
- Add arguments and options for each subcommand of `winget source` to be consistent with how they are listed in other commands, say `winget pin`
