### PR TITLE
Update get-started.md

### DIFF
--- a/uwp/cpp-and-winrt-apis/get-started.md
+++ b/uwp/cpp-and-winrt-apis/get-started.md
@@ -45,7 +45,7 @@ int main()
 
     Uri rssFeedUri{ L"https://blogs.windows.com/feed" };
     SyndicationClient syndicationClient;
-    syndicationClient.SetRequestHeader(L"user-agent", L"C++/WinRT Test Agent");
+    syndicationClient.SetRequestHeader(L"User-Agent", L"Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident/6.0)");
     SyndicationFeed syndicationFeed = syndicationClient.RetrieveFeedAsync(rssFeedUri).get();
     for (const SyndicationItem syndicationItem : syndicationFeed.Items())
     {

--- a/uwp/cpp-and-winrt-apis/get-started.md
+++ b/uwp/cpp-and-winrt-apis/get-started.md
@@ -45,6 +45,7 @@ int main()
 
     Uri rssFeedUri{ L"https://blogs.windows.com/feed" };
     SyndicationClient syndicationClient;
+    syndicationClient.SetRequestHeader(L"user-agent", L"C++/WinRT Test Agent");
     SyndicationFeed syndicationFeed = syndicationClient.RetrieveFeedAsync(rssFeedUri).get();
     for (const SyndicationItem syndicationItem : syndicationFeed.Items())
     {


### PR DESCRIPTION
If the `user-agent` is not present in the request headers, a 403 status code is received.