### PR TITLE
Add aliases for WinGet Commands

### DIFF
--- a/hub/package-manager/winget/configure.md
+++ b/hub/package-manager/winget/configure.md
@@ -21,6 +21,12 @@ The **configure** command of the [winget](./index.md) tool uses a [WinGet Config
 - Windows 10 RS5 or later, and Windows 11.
 - Winget version v1.5.1572 or later.
 
+## Aliases
+
+The following aliases are available for this command:
+
+- configuration
+
 ## Usage
 
 `winget configure -f <C:/Users/<username>/winget-configs/config-file-name.dsc.yaml>`

--- a/hub/package-manager/winget/install.md
+++ b/hub/package-manager/winget/install.md
@@ -18,6 +18,12 @@ The **install** command requires that you specify the exact string to install. I
 
 ![search command](./images/install.png)
 
+## Aliases
+
+The following aliases are available for this command:
+
+- add
+
 ## Arguments
 
 The following arguments are available.

--- a/hub/package-manager/winget/list.md
+++ b/hub/package-manager/winget/list.md
@@ -14,6 +14,12 @@ The **list** command will also display if an update is available for an app, and
 
 The **list** command also supports filters which can be used to limit your list query.
 
+## Aliases
+
+The following aliases are available for this command:
+
+- ls
+
 ## Usage
 
 `winget list [[-q] \<query>] [\<options>]`

--- a/hub/package-manager/winget/search.md
+++ b/hub/package-manager/winget/search.md
@@ -20,6 +20,12 @@ The **search** command includes parameters for filtering down the applications r
 
 ![Screenshot of the Windows Power Shell window displaying the results of the winget search.](./images/search.png)
 
+## Aliases
+
+The following aliases are available for this command:
+
+- find
+
 ## Arguments
 
 The following arguments are available.

--- a/hub/package-manager/winget/settings.md
+++ b/hub/package-manager/winget/settings.md
@@ -15,6 +15,12 @@ The **settings** command will launch your default text editor. Windows by defaul
 >[!NOTE]
 >You can easily install Visual Studio Code by typing `winget install Microsoft.VisualStudioCode`
 
+## Aliases
+
+The following aliases are available for this command:
+
+- config
+
 ## Use the winget settings command
 
 Launch your default JSON editing tool: `winget settings`

--- a/hub/package-manager/winget/show.md
+++ b/hub/package-manager/winget/show.md
@@ -12,6 +12,12 @@ The **show** command of the [winget](index.md) tool displays details for the spe
 
 The **show** command only shows metadata that was submitted with the application. If the submitted application excludes some metadata, then the data will not be displayed.
 
+## Aliases
+
+The following aliases are available for this command:
+
+- view
+
 ## Usage
 
 `winget show [[-q] \<query>] [\<options>]`

--- a/hub/package-manager/winget/source.md
+++ b/hub/package-manager/winget/source.md
@@ -114,6 +114,12 @@ Usage:
 winget source list [[-n, --name] <name>]
 ```
 
+#### Aliases
+
+The following aliases are available for this subcommand:
+
+- ls
+
 #### Arguments
 
 The following arguments are available.
@@ -178,6 +184,12 @@ Usage:
 winget source update [[-n, --name] <name>]
 ```
 
+#### Aliases
+
+The following aliases are available for this subcommand:
+
+- refresh
+
 #### Arguments
 
 The following arguments are available.
@@ -215,6 +227,12 @@ Usage:
 ```cmd
 winget source remove [-n, --name] <name>
 ```
+
+#### Aliases
+
+The following aliases are available for this subcommand:
+
+- rm
 
 #### Arguments
 

--- a/hub/package-manager/winget/uninstall.md
+++ b/hub/package-manager/winget/uninstall.md
@@ -12,6 +12,13 @@ The **uninstall** command of the [winget](index.md) tool uninstalls the specifie
 
 The **uninstall** command requires that you specify the exact string to uninstall. If there is any ambiguity, you will be prompted to further filter the **uninstall** command to an exact application.
 
+## Aliases
+
+The following aliases are available for this command:
+
+- remove
+- rm
+
 ## Usage
 
 `winget uninstall [[-q] \<query>] [\<options>]`

--- a/hub/package-manager/winget/upgrade.md
+++ b/hub/package-manager/winget/upgrade.md
@@ -12,6 +12,12 @@ The **upgrade** command of the [winget](index.md) tool upgrades the specified ap
 
 The **upgrade** command requires that you specify the exact string to upgrade. If there is any ambiguity, you will be prompted to further filter the **upgrade** command to  an exact application.
 
+## Aliases
+
+The following aliases are available for this command:
+
+- update
+
 ## Usage
 
 `winget upgrade [[-q] \<query>] [\<options>]`


### PR DESCRIPTION
To verify the added aliases, you can do `winget <command> --help` that'll show all the aliases available for that particular command.