### PR TITLE
Add direct link to templates directory within the GitHub project

### DIFF
--- a/hub/apps/winui/winui3/winui-project-templates-in-visual-studio.md
+++ b/hub/apps/winui/winui3/winui-project-templates-in-visual-studio.md
@@ -76,3 +76,4 @@ The following item templates are available for use in a WinUI 3 project. To acce
 * [Create your first WinUI 3 project](./create-your-first-winui3-app.md)
 * [Stable release channel for the Windows App SDK](../../windows-app-sdk/stable-channel.md)
 * [Windows App SDK Samples](https://github.com/microsoft/WindowsAppSDK-Samples)
+* [Templates source in Windows App SDK Samples](https://github.com/microsoft/WindowsAppSDK-Samples/tree/main/Templates)

--- a/hub/apps/winui/winui3/winui-project-templates-in-visual-studio.md
+++ b/hub/apps/winui/winui3/winui-project-templates-in-visual-studio.md
@@ -76,4 +76,4 @@ The following item templates are available for use in a WinUI 3 project. To acce
 * [Create your first WinUI 3 project](./create-your-first-winui3-app.md)
 * [Stable release channel for the Windows App SDK](../../windows-app-sdk/stable-channel.md)
 * [Windows App SDK Samples](https://github.com/microsoft/WindowsAppSDK-Samples)
-* [Templates source in Windows App SDK Samples](https://github.com/microsoft/WindowsAppSDK-Samples/tree/main/Templates)
+* [Windows App SDK Sample Templates](https://github.com/microsoft/WindowsAppSDK-Samples/tree/main/Templates)


### PR DESCRIPTION
It wasn't immediately obvious to me that the WinUI 3 templates are defined in `Windows App SDK Samples` on GitHub. This change adds a direct link to the Templates folder to `See also`.