### PR TITLE
Fix wrong sample code

### DIFF
--- a/hub/apps/windows-app-sdk/notifications/app-notifications/app-notifications-quickstart.md
+++ b/hub/apps/windows-app-sdk/notifications/app-notifications/app-notifications-quickstart.md
@@ -149,7 +149,7 @@ namespace CsUnpackagedAppNotifications
     {
         private bool m_isRegistered;
 
-        private Dictionary<string, Action<AppNotificationActivatedEventArgs>> c_map;
+        private Dictionary<int, Action<AppNotificationActivatedEventArgs>> c_map;
 
         public NotificationManager()
         {


### PR DESCRIPTION
In this sample code, `Dictionary` *c_map* takes `int` instead of `string` as its `key`.