### PR TITLE
Explicitate that accelerators are instantiated as virtual-keys.

### DIFF
--- a/hub/apps/design/input/keyboard-accelerators.md
+++ b/hub/apps/design/input/keyboard-accelerators.md
@@ -586,6 +586,9 @@ We recommend localizing all keyboard accelerators. You can do this with the stan
 </Button>
 ```
 
+> [!NOTE]
+> Keyboard accelerators are implemented as virtual-keys. Localized accelerators must be chosen from the predefined domain of virtual-keys (see [Virtual-Key codes](/windows/win32/inputdev/virtual-key-codes)). Any other character is not supported and will lead to Xaml parser error.
+
 ### Setup an accelerator programmatically
 
 Here is an example of programmatically defining an accelerator:

--- a/hub/apps/design/input/keyboard-accelerators.md
+++ b/hub/apps/design/input/keyboard-accelerators.md
@@ -587,7 +587,7 @@ We recommend localizing all keyboard accelerators. You can do this with the stan
 ```
 
 > [!NOTE]
-> Keyboard accelerators are implemented as virtual-keys. Localized accelerators must be chosen from the predefined domain of virtual-keys (see [Virtual-Key codes](/windows/win32/inputdev/virtual-key-codes)). Any other character is not supported and will lead to Xaml parser error.
+> Keyboard accelerators are implemented as virtual-keys. Localized accelerators must be chosen from the predefined collection of [Virtual-Key codes](/windows/win32/inputdev/virtual-key-codes) (otherwise, a XAML parser error will occur).
 
 ### Setup an accelerator programmatically
 


### PR DESCRIPTION
Adding call out to domain of accelerators is bound to domain of virtual-keys, and that localized virtual-keys must remain in the same domain.