### PR TITLE
[PowerToys] Update extract MSI instructions

### DIFF
--- a/hub/powertoys/install.md
+++ b/hub/powertoys/install.md
@@ -63,7 +63,7 @@ Here are the common commands you may want:
 
 ### Extracting the MSI from the bundle
 
-Make sure to have [WiX Toolset](https://wixtoolset.org/releases) installed.
+Make sure to have [WiX Toolset v3](https://wixtoolset.org/docs/wix3) installed. The command doesn't work with WiX Toolset v4.
 
 This PowerShell example assumes the default install location for WiX Toolset and the PowerToys installer downloaded to the desktop.
 


### PR DESCRIPTION
- Specified to install WiX Toolset v3 since the command doesn't work with WiX Toolset v4.
- Changed the link: the old one link to WiX Toolset v4 download.

Refer to https://github.com/microsoft/PowerToys/issues/28756