### PR TITLE
DependencyProperties: add static property to C++/WinRT example

### DIFF
--- a/uwp/xaml-platform/custom-dependency-properties.md
+++ b/uwp/xaml-platform/custom-dependency-properties.md
@@ -104,9 +104,19 @@ namespace ImageWithLabelControlApp
 
 // ImageWithLabelControl.h
 ...
+struct ImageWithLabelControl : ImageWithLabelControlT<ImageWithLabelControl>
+{
+...
+public:
+    static Windows::UI::Xaml::DependencyProperty LabelProperty()
+    {
+        return m_labelProperty;
+    }
+
 private:
     static Windows::UI::Xaml::DependencyProperty m_labelProperty;
 ...
+};
 
 // ImageWithLabelControl.cpp
 ...


### PR DESCRIPTION
Today, the C++/WinRT example on the Custom Dependency Properties page does not include the static getter, which is required. This change adds it.