### PR TITLE
Improve Windows Dev Options page

### DIFF
--- a/hub/apps/get-started/dev-options.md
+++ b/hub/apps/get-started/dev-options.md
@@ -17,20 +17,21 @@ There is a wide range of options for developing applications for Windows. The be
 
 To read more about each of these Windows app development options, see [Writing apps for Windows](index.md).
 
-| Feature | .NET MAUI | React Native (RNW) | UWP | Win32 | Windows Forms | WinUI 3 | WPF |
+| Feature | .NET MAUI | React Native (RNW) | UWP XAML (Windows.UI.Xaml) | Win32 | Windows Forms | WinUI 3 | WPF |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | **Language** | C# | JavaScript, TypeScript | C#, C++, Visual Basic | C++, Rust | C#, Visual Basic | C#, C++ | C#, Visual Basic |
 | **UI language** | XAML/Code | JSX | XAML | Code | Code | XAML | XAML |
 | **UI designer**<br/>(drag & drop) | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ | ✅ |
 | **UI debugging** | [Hot Reload](/dotnet/maui/xaml/hot-reload) | [Fast Refresh](https://reactnative.dev/docs/fast-refresh) | [Hot Reload](/visualstudio/xaml-tools/xaml-hot-reload) | - | [Hot Reload](/visualstudio/debugger/hot-reload) | [Hot Reload](/visualstudio/xaml-tools/xaml-hot-reload) | [Hot Reload](/visualstudio/xaml-tools/xaml-hot-reload) |
-| **Fluent Design** | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
-| **.NET Runtime** | .NET | N/A | Minimal CLR runtime | N/A | .NET & .NET Framework | .NET | .NET & .NET Framework |
+| **Fluent Design** | ✅ | ✅ | ✅ (through [WinUI 2](/windows/apps/winui/winui2)) | ❌ | ❌ | ✅ | ❌ |
+| **.NET Runtime** | .NET | N/A | .NET Core & .NET Native | N/A | .NET & .NET Framework | .NET | .NET & .NET Framework |
 | **Windows App SDK** | ✅ ([more info](/dotnet/maui/platform-integration/invoke-platform-code)) | ✅ ([more info](https://techcommunity.microsoft.com/t5/modern-work-app-consult-blog/getting-started-with-react-native-for-windows/ba-p/912093)) | ❌ | ✅ | ✅ ([more info](../windows-app-sdk/winforms-plus-winappsdk.md)) | ✅ | ✅ ([more info](../windows-app-sdk/wpf-plus-winappsdk.md)) |
-| **Enterprise Apps** | ⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐ | ⭐⭐⭐⭐⭐ |
+| **Enterprise Apps** | ⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐ | ⭐⭐⭐⭐⭐ |
 | **Consumer Apps** | ⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐ | ⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐ |
 | **Great for touch** | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ |
-| **Cross-platform** | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **Xbox/HoloLens apps** | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
+| **Cross-platform** | ✅ | ✅ | ✅ (through [Uno Platform](/windows/apps/how-tos/uno-multiplatform)) | ❌ | ❌ | ✅ (through [Uno Platform](/windows/apps/how-tos/uno-multiplatform)) | ❌ |
+| **Xbox/HoloLens apps** | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| **Sandboxing** | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
 | **Currently supported** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **Receiving updates** | ✅ | ✅ | ✅ (security & bugfix) | ✅ | ✅ | ✅ | ✅ |
 | **Roadmap** | [GitHub](https://github.com/dotnet/maui/wiki/Roadmap) | [GitHub](https://aka.ms/rnw-roadmap) | n/a | n/a | [GitHub](https://github.com/dotnet/winforms/blob/main/docs/roadmap.md) | [GitHub](https://github.com/microsoft/WindowsAppSDK/blob/main/docs/roadmap.md) | [GitHub](https://github.com/dotnet/wpf/blob/main/roadmap.md) |

--- a/hub/apps/get-started/dev-options.md
+++ b/hub/apps/get-started/dev-options.md
@@ -23,15 +23,15 @@ To read more about each of these Windows app development options, see [Writing a
 | **UI language** | XAML/Code | JSX | XAML | Code | Code | XAML | XAML |
 | **UI designer**<br/>(drag & drop) | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ | ✅ |
 | **UI debugging** | [Hot Reload](/dotnet/maui/xaml/hot-reload) | [Fast Refresh](https://reactnative.dev/docs/fast-refresh) | [Hot Reload](/visualstudio/xaml-tools/xaml-hot-reload) | - | [Hot Reload](/visualstudio/debugger/hot-reload) | [Hot Reload](/visualstudio/xaml-tools/xaml-hot-reload) | [Hot Reload](/visualstudio/xaml-tools/xaml-hot-reload) |
-| **Fluent Design** | ✅ | ✅ | ✅ (through [WinUI 2](/windows/apps/winui/winui2)) | ❌ | ❌ | ✅ | ❌ |
-| **.NET Runtime** | .NET | N/A | .NET Core & .NET Native | N/A | .NET & .NET Framework | .NET | .NET & .NET Framework |
+| **Fluent Design** | ✅ | ✅ | ✅ (via [WinUI 2](/windows/apps/winui/winui2)) | ❌ | ❌ | ✅ | ❌ |
+| **.NET** | .NET | N/A | .NET Core & .NET Native | N/A | .NET & .NET Framework | .NET | .NET & .NET Framework |
 | **Windows App SDK** | ✅ ([more info](/dotnet/maui/platform-integration/invoke-platform-code)) | ✅ ([more info](https://techcommunity.microsoft.com/t5/modern-work-app-consult-blog/getting-started-with-react-native-for-windows/ba-p/912093)) | ❌ | ✅ | ✅ ([more info](../windows-app-sdk/winforms-plus-winappsdk.md)) | ✅ | ✅ ([more info](../windows-app-sdk/wpf-plus-winappsdk.md)) |
 | **Enterprise Apps** | ⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐ | ⭐⭐⭐⭐⭐ |
 | **Consumer Apps** | ⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐ | ⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐ |
 | **Great for touch** | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ |
-| **Cross-platform** | ✅ | ✅ | ✅ (through [Uno Platform](/windows/apps/how-tos/uno-multiplatform)) | ❌ | ❌ | ✅ (through [Uno Platform](/windows/apps/how-tos/uno-multiplatform)) | ❌ |
+| **Cross-platform** | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | **Xbox/HoloLens apps** | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| **Sandboxing** | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| **Sandboxing (AppContainer)** | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
 | **Currently supported** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **Receiving updates** | ✅ | ✅ | ✅ (security & bugfix) | ✅ | ✅ | ✅ | ✅ |
 | **Roadmap** | [GitHub](https://github.com/dotnet/maui/wiki/Roadmap) | [GitHub](https://aka.ms/rnw-roadmap) | n/a | n/a | [GitHub](https://github.com/dotnet/winforms/blob/main/docs/roadmap.md) | [GitHub](https://github.com/microsoft/WindowsAppSDK/blob/main/docs/roadmap.md) | [GitHub](https://github.com/dotnet/wpf/blob/main/roadmap.md) |


### PR DESCRIPTION
Changes:
- Corrected the **.NET Runtime** row for UWP.
- Corrected the **Fluent Design** row for UWP.
- Corrected the **Xbox/HoloLens apps** row for Win32.
- Clarifying that UWP here means the Windows.UI.Xaml framework not UWP as a platform.
- Added **Uno Platform** as a cross-platform option for UWP and WinUI 3.
- Added a row for **Sandboxing**.
- Added additional star in the **Enterprise Apps** row for UWP because of sandboxing (many enterprise companies prefer sandboxed apps).