### PR TITLE
[PowerToys] Updates for v0.76.0: Add QOI provider to policies and File Explorer page

### DIFF
--- a/hub/powertoys/file-explorer.md
+++ b/hub/powertoys/file-explorer.md
@@ -18,11 +18,12 @@ Preview Pane is an existing feature in the Windows File Explorer which allows yo
 
 Preview Pane supports:
 
-- SVG icons (.svg)
+- SVG images (.svg)
 - Markdown files (.md)
 - Source code files (.cs, .cpp, .rs, ...)
 - PDF files (.pdf)
 - G-code files (.gcode)
+- QOI images (.qoi)
 
 ### Settings for Source code files previewer
 
@@ -63,10 +64,11 @@ To enable thumbnail preview support, set the extension to **On**.
 
 Thumbnail preview supports:
 
-- SVG icons (.svg)
+- SVG images (.svg)
 - PDF files (.pdf)
 - G-code files (.gcode)
 - STL files (.stl)
+- QOI images (.qoi)
 
 > [!NOTE]
 > A reboot may be required after enabling the thumbnail previewer for the settings to take effect. Thumbnails might not appear on paths managed by cloud storage solutions like OneDrive, since these solutions may get their thumbnails from the cloud instead of generating them locally.

--- a/hub/powertoys/grouppolicy.md
+++ b/hub/powertoys/grouppolicy.md
@@ -100,15 +100,17 @@ These policies have a higher priority than the policy "Configure global utility 
 |Environment Variables|Environment Variables: Configure enabled state|ConfigureEnabledUtilityEnvironmentVariables|
 |FancyZones|FancyZones: Configure enabled state|ConfigureEnabledUtilityFancyZones|
 |File Locksmith|File Locksmith: Configure enabled state|ConfigureEnabledUtilityFileLocksmith|
-|SVG file preview|SVG file preview: Configure enabled state|ConfigureEnabledUtilityFileExplorerSVGPreview|
-|Markdown file preview|Markdown file preview: Configure enabled state|ConfigureEnabledUtilityFileExplorerMarkdownPreview|
-|Source code file preview|Source code file preview: Configure enabled state|ConfigureEnabledUtilityFileExplorerMonacoPreview|
-|PDF file preview|PDF file preview: Configure enabled state|ConfigureEnabledUtilityFileExplorerPDFPreview|
 |Gcode file preview|Gcode file preview: Configure enabled state|ConfigureEnabledUtilityFileExplorerGcodePreview|
-|SVG file thumbnail|SVG file thumbnail: Configure enabled state|ConfigureEnabledUtilityFileExplorerSVGThumbnails|
-|PDF file thumbnail|PDF file thumbnail: Configure enabled state|ConfigureEnabledUtilityFileExplorerPDFThumbnails|
+|Markdown file preview|Markdown file preview: Configure enabled state|ConfigureEnabledUtilityFileExplorerMarkdownPreview|
+|PDF file preview|PDF file preview: Configure enabled state|ConfigureEnabledUtilityFileExplorerPDFPreview|
+|QOI file preview|QOI file preview: Configure enabled state|ConfigureEnabledUtilityFileExplorerQOIPreview|
+|Source code file preview|Source code file preview: Configure enabled state|ConfigureEnabledUtilityFileExplorerMonacoPreview|
+|SVG file preview|SVG file preview: Configure enabled state|ConfigureEnabledUtilityFileExplorerSVGPreview|
 |Gcode file thumbnail|Gcode file thumbnail: Configure enabled state|ConfigureEnabledUtilityFileExplorerGcodeThumbnails|
+|PDF file thumbnail|PDF file thumbnail: Configure enabled state|ConfigureEnabledUtilityFileExplorerPDFThumbnails|
+|QOI file thumbnail|QOI file thumbnail: Configure enabled state|ConfigureEnabledUtilityFileExplorerQOIThumbnails|
 |STL file thumbnail|STL file thumbnail: Configure enabled state|ConfigureEnabledUtilityFileExplorerSTLThumbnails|
+|SVG file thumbnail|SVG file thumbnail: Configure enabled state|ConfigureEnabledUtilityFileExplorerSVGThumbnails|
 |Hosts file editor|Hosts file editor: Configure enabled state|ConfigureEnabledUtilityHostsFileEditor|
 |Image Resizer|Image Resizer: Configure enabled state|ConfigureEnabledUtilityImageResizer|
 |Keyboard Manager|Keyboard Manager: Configure enabled state|ConfigureEnabledUtilityKeyboardManager|


### PR DESCRIPTION
This PR updates the policy docs for the v0.76.0 release:
- Reordering of File Explorer utility policies in the table.
- Adding QOI provider utilities to the table. _[Left over from microsoft/PowerToys/pull/29735 (microsoft/PowerToys/issues/29742).]_

This PR updates the File Explorer  add-ons docs for the v0.76.0 release:
- Add QOI provider to the lists. _[Left over from microsoft/PowerToys/pull/29735 (microsoft/PowerToys/issues/29742).]_


---

**PLEASE DO NOT MERGE BEFORE:**
- An approval of @crutkas or @jaimecbernardo .
- **The RELEASE OF POWERTOYS 0.76.0 .**