### PR TITLE
Update always-on-top.md

### DIFF
--- a/hub/powertoys/always-on-top.md
+++ b/hub/powertoys/always-on-top.md
@@ -6,26 +6,29 @@ ms.topic: article
 no-loc: [PowerToys, Windows, Always on Top, Win]
 ---
 
-# Always on Top utility
+# Always On Top utility
 
-A system-wide utility for Windows to pin windows above other windows.
+A system-wide Windows utility to pin windows above other windows.
 
 ![AlwaysOnTop screenshot.](../images/pt-always-on-top.png)
 
-## Toggle windows to be on top
+## Pin a window
 
-With the activation/deactivation shortcut (default: <kbd>⊞ Win</kbd>+<kbd>Ctrl</kbd>+<kbd>T</kbd>), the active window will be placed above all non-topmost windows and should stay above them, even when the window is deactivated.
+When you activate Always On Top (default: <kbd>⊞ Win</kbd>+<kbd>Ctrl</kbd>+<kbd>T</kbd>), the utility pins the active window above all other windows. The pinned window stays on top, even when you select other windows.
 
 ## Settings
 
-From the Settings tab, you can configure the following options:
+Always On Top has the following settings:
 
 | Setting | Description |
 | :--- | :--- |
-| Activation shortcut | The customizable keyboard command to turn on or off the always-on-top property for that window. |
-| Do not activate when Game Mode is on | Prevents the feature from being activated when actively playing a game on the system. |
-| Color mode | Choose either **Windows default** or **Custom color** for the highlight border. |
-| Color | The custom color of the highlight border. |
-| Border thickness (px) | The thickness of the highlight border. Measured in pixels. |
-| Play a sound | Toggle playing of a short alert chirp. Activating and deactivating use different sounds. |
-| Excluded apps | Add an application's name, or part of the name, one per line. (e.g. adding `Notepad` will match both `Notepad.exe` and `Notepad++.exe`; to match only `Notepad.exe`, add the `.exe` extension) |
+| **Activation shortcut** | The customizable keyboard command to turn on or off the always-on-top property for that window. |
+| **Do not activate when Game Mode is on** | Prevents the feature from being activated when actively playing a game on the system. |
+| **Show a border around the pinned window** | When **On**, this option shows a colored border around the pinned window.  |
+| **Color mode** | Choose either **Windows default** or **Custom color** for the highlight border. |
+| **Color** | The custom color of the highlight border. **Color** is only available when **Color mode** is set to **Custom color**. |
+| **Opacity (%)** | The opacity of the highlight border. |
+| **Thickness (px)** | The thickness of the highlight border in pixels. |
+| **Enable round corners** | When selected, the highlight border around the pinned window will have rounded corners.  |
+| **Play a sound when pinning a window** | When selected, this option plays a sound when you activate or deactivate Always On Top. |
+| **Excluded apps** | Prevents you from pinning an application using Always On Top. Add an application's name to stop it from being pinned. The list will also exclude partial matches. For example, `Notepad` will prevent both `Notepad.exe` and `Notepad++.exe` from being pinned. To only prevent a specific application, add `Notepad.exe` to the excluded list. |

--- a/hub/powertoys/always-on-top.md
+++ b/hub/powertoys/always-on-top.md
@@ -31,4 +31,4 @@ Always On Top has the following settings:
 | **Thickness (px)** | The thickness of the highlight border in pixels. |
 | **Enable round corners** | When selected, the highlight border around the pinned window will have rounded corners.  |
 | **Play a sound when pinning a window** | When selected, this option plays a sound when you activate or deactivate Always On Top. |
-| **Excluded apps** | Prevents you from pinning an application using Always On Top. Add an application's name to stop it from being pinned. The list will also exclude partial matches. For example, `Notepad` will prevent both `Notepad.exe` and `Notepad++.exe` from being pinned. To only prevent a specific application, add `Notepad.exe` to the excluded list. |
+| **Excluded apps** | Prevents you from pinning an application using Always On Top. Add an application's name to stop it from being pinned. The list will also exclude partial matches. For example, `Notepad` will prevent both Notepad.exe and Notepad++.exe from being pinned. To only prevent a specific application, add `Notepad.exe` to the excluded list. |


### PR DESCRIPTION
This PR aims to:

* clarifying some of the wording for the Always On Top utility in PowerToys
* make verbs consistent with the Always On Top utility ('pin', rather than 'place' or 'Toggle')
* correcting capitalisation of docs to align with the utility name (`Always On Top`, not `Always on Top`)
* add some Always On Top settings that are missing from the docs
* align the Always On Top documentation closer to the Microsoft style guide, specifically:
  * [bold for UI text (settings names)](https://learn.microsoft.com/en-us/style-guide/procedures-instructions/formatting-text-in-instructions#in-documentation-and-technical-content)
  * ['select' as the verb for checkbox](https://learn.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/c/check-checkbox-check-mark)
  * [use of active voice instead of passive](https://learn.microsoft.com/en-us/style-guide/grammar/verbs#active-and-passive-voice)