### PR TITLE
Rephrased question in hub/dev-drive/index.md

### DIFF
--- a/hub/dev-drive/index.md
+++ b/hub/dev-drive/index.md
@@ -331,9 +331,9 @@ No, applications or tools installed on your machine’s C: drive can utilize fil
 
 Yes, ReFS uses slightly more memory than NTFS. We recommend a machine with at least 8gb of memory, ideally 16gb.
 
-### Can I only have a single Dev Drive on my machine?
+### Can I have more than one Dev Drive on my machine?
 
-No. If you have the space, you can create as many Dev Drives as you would like. Using a separate Dev Drive for each software development project would allow you to simply delete the drive at the end of development, rather than repartitioning your disk again. However, keep in mind that the minimum size for a Dev Drive is 50GB.
+Yes. If you have the space, you can create as many Dev Drives as you would like. Using a separate Dev Drive for each software development project would allow you to simply delete the drive at the end of development, rather than repartitioning your disk again. However, keep in mind that the minimum size for a Dev Drive is 50GB.
 
 ### What do I need to know about using Dev Drive with Visual Studio?
 


### PR DESCRIPTION
Question `Can I only have a single Dev Drive on my machine?` can be interpreted in a few ways by the reader.

1. The question can be interpreted as following: Can I have a PC configuration which has just one dev-drive (no less no more)? Will this configuration work?

That's how I interpreted it initially. And I was quite surprised when the first word of an answer was `No.` which meant that I have to have either 0 dev-drives or ≥2 dev-drives. And after that I've read an explanation that implied you clearly meant other interpretation of the question.

2. The second interpretation is yours. (And I actually still don't quite understand as non-native how the question can be interpreted that way)

So I rephrased the question and the answer for clarification.