### PR TITLE
Makes headings consistent across PowerToys documentation

### DIFF
--- a/hub/powertoys/always-on-top.md
+++ b/hub/powertoys/always-on-top.md
@@ -12,7 +12,7 @@ A system-wide Windows utility to pin windows above other windows.
 
 ![AlwaysOnTop screenshot.](../images/pt-always-on-top.png)
 
-## Pin a window
+## Pinning a window
 
 When you activate Always On Top (default: <kbd>⊞ Win</kbd>+<kbd>Ctrl</kbd>+<kbd>T</kbd>), the utility pins the active window above all other windows. The pinned window stays on top, even when you select other windows.
 

--- a/hub/powertoys/awake.md
+++ b/hub/powertoys/awake.md
@@ -10,7 +10,7 @@ ms.localizationpriority: medium
 
 PowerToys Awake is a tool for Windows designed to keep a computer awake without having to manage its [power & sleep settings](https://support.microsoft.com/windows/how-to-adjust-power-and-sleep-settings-26f623b5-4fcc-4194-863d-b824e5ea7679). This can be helpful when running time-consuming tasks, ensuring that the computer does not go to sleep or turn off its screens.
 
-## Getting started
+## Using PowerToys Awake
 
 You can use PowerToys Awake directly from PowerToys Settings or as a standalone executable. When it's running from PowerToys, it can be managed from PowerToys Settings or the system tray.
 

--- a/hub/powertoys/cmd-not-found.md
+++ b/hub/powertoys/cmd-not-found.md
@@ -20,7 +20,7 @@ A PowerShell 7 module that detects command-line errors and suggests a relevant W
  - [PowerShell 7](/PowerShell/scripting/install/installing-PowerShell-on-windows)
  - [PowerShell Microsoft.WinGet.Client module](https://www.powershellgallery.com/packages/Microsoft.WinGet.Client)
 
-## Install the module
+## Installing the module
 
 To install the Command Not Found module, navigate to the Command Not Found page in PowerToys settings and select the **Install** button. Once the module installation has completed, PowerShell 7 experimental features needed for the module to function will be enabled:
 
@@ -37,6 +37,6 @@ Import-Module "<powertoys install dir>/WinGetCommandNotFound.psd1"
 
 **Note:** The profile file will be created if needed. Restart PowerShell session to use the module.
 
-## Uninstall the module
+## Uninstalling the module
 
 To uninstall the Command Not Found module, navigate to the Command Not Found page in PowerToys settings and select the **Uninstall** button. Once the module uninstall has completed, the block of commands previously added will be removed from the PowerShell profile file. 

--- a/hub/powertoys/cmd-not-found.md
+++ b/hub/powertoys/cmd-not-found.md
@@ -20,7 +20,7 @@ A PowerShell 7 module that detects command-line errors and suggests a relevant W
  - [PowerShell 7](/PowerShell/scripting/install/installing-PowerShell-on-windows)
  - [PowerShell Microsoft.WinGet.Client module](https://www.powershellgallery.com/packages/Microsoft.WinGet.Client)
 
-## Installing the module
+## Installing Command Not Found
 
 To install the Command Not Found module, navigate to the Command Not Found page in PowerToys settings and select the **Install** button. Once the module installation has completed, PowerShell 7 experimental features needed for the module to function will be enabled:
 
@@ -37,6 +37,6 @@ Import-Module "<powertoys install dir>/WinGetCommandNotFound.psd1"
 
 **Note:** The profile file will be created if needed. Restart PowerShell session to use the module.
 
-## Uninstalling the module
+## Uninstalling Command Not Found
 
 To uninstall the Command Not Found module, navigate to the Command Not Found page in PowerToys settings and select the **Uninstall** button. Once the module uninstall has completed, the block of commands previously added will be removed from the PowerShell profile file. 

--- a/hub/powertoys/color-picker.md
+++ b/hub/powertoys/color-picker.md
@@ -13,13 +13,11 @@ A system-wide color picking utility for Windows to pick colors from any screen a
 
 ![ColorPicker.](../images/pt-colorpicker-hex-editor.png)
 
-## Getting started
-
-### Enabling Color Picker
+## Enabling Color Picker
 
 Enable Color Picker in the **Color Picker** tab in PowerToys.
 
-### Activating Color Picker
+## Activating Color Picker
 
 You can choose what happens when you activate Color Picker (default: <kbd>Win</kbd>+<kbd>Shift</kbd>+<kbd>C</kbd>) by changing **Activation Behavior**:
 
@@ -139,7 +137,7 @@ For example `%ReX` means the red value in hex uppercase two digits format.
 
 Color formats can contain any words or characters that you prefer. For example, the default color format, which shows up on color format creation is: `_'new Color (R = %Re, G = %Gr, B = %Bl)'_`.
 
-## Limitations
+## Limitations of Color Picker
 
 - Color Picker can't display on top of the Start menu or Action Center, but you can still pick a color.
 - If you started the currently-focused application with an administrator elevation (**Run as administrator**), the Color Picker activation shortcut won't work, unless you also started PowerToys with an administrator elevation.

--- a/hub/powertoys/crop-and-lock.md
+++ b/hub/powertoys/crop-and-lock.md
@@ -7,7 +7,7 @@ ms.localizationpriority: medium
 no-loc: [PowerToys, Windows, Crop And Lock, Win]
 ---
 
-# Crop And Lock
+# Crop And Lock utility
 
 PowerToys **Crop And Lock** allows you to crop a current application into a smaller window or just create a thumbnail. Focus the target window and press the shortcut to start cropping.</value>
 
@@ -15,7 +15,7 @@ PowerToys **Crop And Lock** allows you to crop a current application into a smal
 
 ## Getting started
 
-### How to use
+### Cropping a window
 
 To start using Crop And Lock, enable it in the PowerToys Settings (**Crop And Lock** tab).
 

--- a/hub/powertoys/environment-variables.md
+++ b/hub/powertoys/environment-variables.md
@@ -6,7 +6,7 @@ ms.topic: article
 no-loc: [PowerToys, Windows, Environment Variables, Win]
 ---
 
-# Environment Variables
+# Environment Variables utility
 
 Environment Variables offers an easy and convenient way to manage environment variables. It also allows you to create profiles for managing a set of variables together. Profile variables have precedence over User and System variables. Applying the profile adds variables to User environment variables in the background. When a profile is applied, if there is an existing User variable with the same name, a backup variable is created in User variables which will be reverted to the original value on profile un-apply.
 
@@ -14,13 +14,13 @@ Applied variables list shows the current state of the environment, respecting th
 
 ![PowerToys Environment Variables screenshot.](../images/powertoys-environment-variables.png)
 
-## Edit/Remove variable
+## Editing or removing a variable
 
 To edit or remove a variable (profile, User or System), select the more options button (**•••**) on the desired variable:
 
 ![PowerToys Environment Variables: Edit/Remove variable](../images/powertoys-environment-variables-edit-variable.gif)
 
-## Add profile
+## Adding a profile
 
 To add a new profile:
 
@@ -34,7 +34,7 @@ To add a new profile:
 
 To edit or remove a profile, select the more options button (**•••**) on the desired profile.
 
-## Apply profile
+## Applying a profile
 
 To apply a profile, set the profile toggle to On. Only one profile can be applied at a time. The Applied variables list will show applied profile variables at the top (below Path variable):
 

--- a/hub/powertoys/file-explorer.md
+++ b/hub/powertoys/file-explorer.md
@@ -12,7 +12,7 @@ no-loc: [PowerToys, Windows, File Explorer, Monaco]
 > [!WARNING]
 > Enabling the preview handlers will override other preview handlers already installed - there have been reports of incompatibility between Outlook and the PDF Preview Handler.
 
-## Preview Pane previewers
+## Previewing files with Preview Pane
 
 Preview Pane is an existing feature in the Windows File Explorer which allows you to see a preview of the file's contents in the view's reading pane. PowerToys adds multiple extensions: Markdown, SVG, PDF, G-code and QOI. In addition to those, PowerToys also adds support for source code files for more than 150 file extensions.
 
@@ -35,7 +35,7 @@ Expand the **Source code files (Monaco)** section to change the following settin
 | Try to format the source for preview | Enable or disable formatting of the source code for json and xml files.<br />The original file stays unchanged. |
 | Maximum file size to preview | Maximum file size in kilobytes to preview. |
 
-### Enabling Preview Pane support
+### Enabling Preview Pane
 
 To enable preview support, set the extension to **On**.
 
@@ -58,7 +58,7 @@ Open Windows File Explorer, select the **View** tab in the Explorer ribbon, and 
 > [!NOTE]
 > It is not possible to change the background color of the preview pane, so if you are working with transparent images with white shapes, you may not be able to see them in the preview.
 
-## Thumbnail Previews
+## Previewing files with thumbnail previews
 
 To enable thumbnail preview support, set the extension to **On**.
 

--- a/hub/powertoys/file-locksmith.md
+++ b/hub/powertoys/file-locksmith.md
@@ -12,7 +12,7 @@ File Locksmith is a Windows shell extension for checking which files are in use 
 
 ![File Locksmith Demo.](../images/powertoys-file-locksmith.gif)
 
-## How to activate and use File Locksmith
+## Activating and using File Locksmith
 
 To activate File Locksmith, open PowerToys and turn on the **Enable File Locksmith** toggle. Select one or more files or directories in Windows File Explorer. If a directory is selected, all of its files and subdirectories will be scanned as well. Right-click on the selected file(s), select **Show more options** from the menu to expand your list of menu options, then select **What's using this file?** to open File Locksmith and see which processes are using the file(s).
 

--- a/hub/powertoys/grouppolicy.md
+++ b/hub/powertoys/grouppolicy.md
@@ -10,25 +10,25 @@ no-loc: [PowerToys, Windows, Group Policy, Win]
 
 Since version 0.64, PowerToys is released on GitHub with Administrative Templates that allows you to configure PowerToys using Group Policies.
 
-## How to install
+## Installing PowerToys using Group Policy
 
 ### Download
 
 You can find the latest administrative templates (ADMX files) in the assets section of our newest PowerToys release on <https://github.com/microsoft/PowerToys/releases>. The file is named `GroupPolicyObjectsFiles-<Version>.zip`.
 
-### Add the administrative template to an individual computer
+### Adding the administrative template to an individual computer
 
 1. Copy the "PowerToys.admx" file to your Policy Definition template folder. (Example: C:\Windows\PolicyDefinitions)
 2. Copy the "PowerToys.adml" file to the matching language folder in your Policy Definition folder. (Example: C:\Windows\PolicyDefinitions\en-US)
 
-### Add the administrative template to Active Directory
+### Adding the administrative template to Active Directory
 
 1. On a domain controller or workstation with RSAT, go to the **PolicyDefinition** folder (also known as the *Central Store*) on any domain controller for your domain. For older versions of Windows Server, you might need to create the **PolicyDefinition** folder. For more information, see [How to create and manage the Central Store for Group Policy Administrative Templates in Windows](https://support.microsoft.com/help/3087759/how-to-create-and-manage-the-central-store-for-group-policy-administra).
 2. Copy the "PowerToys.admx" file to the PolicyDefinition folder. (Example: %systemroot%\sysvol\domain\policies\PolicyDefinitions)
 3. Copy the "PowerToys.adml" file to the matching language folder in the PolicyDefinition folder. Create the folder if it doesn't already exist. (Example: %systemroot%\sysvol\domain\policies\PolicyDefinitions\EN-US)
 4. If your domain has more than one domain controller, the new ADMX files will be replicated to them at the next domain replication interval.
 
-### Import the administrative template in Intune
+### Importing the administrative template in Intune
 
 You can find all instructions on how to import the administrative templates in Intune [here](/mem/intune/configuration/administrative-templates-import-custom#add-the-admx-and-adml-files).
 
@@ -42,7 +42,7 @@ You will find the policies under "Administrative Templates/Microsoft PowerToys" 
 The syntax of OMA-URI is the following: ./Device/Vendor/MSFT/Policy/Config/PowerToys~Policy~PowerToys[[~<category1>]~<categoryN>]/<ADMX-DisplayName-ID>
 -->
 
-### Configure global utility enabled state
+### Configuring global utility enabled state
 
 > Supported on PowerToys 0.75.0 or later.
 
@@ -74,7 +74,7 @@ The individual enabled state policies for the utilities will override this polic
 - OMA-URI: `./Device/Vendor/MSFT/Policy/Config/PowerToys~Policy~PowerToys/ConfigureGlobalUtilityEnabledState`
 - Example value: `<disabled/>`
 
-### Configure enabled state for individual utilities
+### Configuring enabled state for individual utilities
 
 > Supported on PowerToys 0.64.0 or later depending on the utility.
 
@@ -155,7 +155,7 @@ These policies have a higher priority than the policy "Configure global utility 
 
 - Example value: `<disabled/>`
 
-### Allow experimentation
+### Allowing experimentation
 
 > Supported on PowerToys 0.68.0 or later.
 
@@ -186,7 +186,7 @@ This policy configures whether PowerToys experimentation is allowed. With experi
 
 ### Installer and Updates
 
-#### Disable per-user installation
+#### Disabling per-user installation
 
 > Supported on PowerToys 0.68.0 or later.
 
@@ -218,7 +218,7 @@ This policy configures whether PowerToys per-user installation is allowed or not
 - OMA-URI: `./Device/Vendor/MSFT/Policy/Config/PowerToys~Policy~PowerToys~InstallerUpdates/DisablePerUserInstallation`
 - Example value: `<enabled/>`
 
-#### Disable automatic downloads
+#### Disabling automatic downloads
 
 > Supported on PowerToys 0.68.0 or later.
 
@@ -347,7 +347,7 @@ You can override this policy for individual plugins using the policy "Configure 
 - OMA-URI: `./Device/Vendor/MSFT/Policy/Config/PowerToys~Policy~PowerToys~PowerToysRun/PowerToysRunAllPluginsEnabledState`
 - Example value: `<disabled/>`
 
-#### Configure enabled state for individual plugins
+#### Configuring enabled state for individual plugins
 
 > Supported on PowerToys 0.75.0 or later.
 

--- a/hub/powertoys/hosts-file-editor.md
+++ b/hub/powertoys/hosts-file-editor.md
@@ -32,7 +32,7 @@ To filter host file entries, select the filter icon and then enter characters in
 
 ![PowerToys Hosts File Editor: Filtering entries](../images/pt-hosts-file-editor-filter.gif)
 
-## Back up Hosts file
+## Backing up the hosts file
 
 Hosts File Editor creates a backup of the hosts file before editing session. The backup files are located near the hosts file in `%SystemRoot%/System32/drivers/etc` named `hosts_PowerToysBackup_YYYYMMDDHHMMSS`.
 
@@ -47,7 +47,7 @@ From the Settings menu, the following options can be configured:
 | Additional lines position | Default value is **Top**. If **Bottom** is selected, the file header is moved below hosts settings to the bottom. |
 | Consider loopback addresses as duplicates | Loopback addresses (like 127.0.0.1 and ::1) are considered as duplicates. |
 
-## Troubleshooting
+## Troubleshooting Hosts File Editor
 
 A "Failed to save hosts file" error appears if a change is made without administrator permissions:
 

--- a/hub/powertoys/hosts-file-editor.md
+++ b/hub/powertoys/hosts-file-editor.md
@@ -8,7 +8,7 @@ no-loc: [PowerToys, Windows, Hosts File Editor, Win]
 
 # Hosts File Editor utility
 
-Windows includes a local "Hosts" file that contains domain names and matching IP addresses, acting as a map to identify and locate hosts on IP networks. Every time you visit a website, your computer will check the hosts file first to see which IP address it connects to. If the information is not there, your internet service provider will look into the <abbr title="Domain Name Server">DNS</abbr> for the resources to load the site.
+Windows includes a local "Hosts" file that contains domain names and matching IP addresses, acting as a map to identify and locate hosts on IP networks. Every time you visit a website, your computer will check the hosts file first to see which IP address it connects to. If the information is not there, your internet service provider will look into the Domain Name Server (DNS) for the resources to load the site.
 
 The Hosts File Editor provides a convenient way to edit the hosts file configuration. This can be useful for scenarios like migrating a website to a new hosting provider or domain name, which may take a 24-48 hour period of downtime. Creating a custom IP address to associate with your domain using the hosts file can enable you to see how it will look on the new server.
 

--- a/hub/powertoys/image-resizer.md
+++ b/hub/powertoys/image-resizer.md
@@ -9,7 +9,11 @@ no-loc: [PowerToys, Windows, File Explorer, Image Resizer]
 
 # Image Resizer utility
 
-Image Resizer is a Windows shell extension for bulk image-resizing. After installing PowerToys, right-click on one or more selected image files in File Explorer, and select **Resize pictures** from the menu.
+Image Resizer is a Windows shell extension for bulk image-resizing. 
+
+## Resizing images with Image Resizer
+
+After installing PowerToys, right-click on one or more selected image files in File Explorer, and select **Resize pictures** from the menu.
 
 ![Image Resizer Demo.](../images/powertoys-resize-images.gif)
 

--- a/hub/powertoys/keyboard-manager.md
+++ b/hub/powertoys/keyboard-manager.md
@@ -101,7 +101,7 @@ There are a few rules to follow when remapping shortcuts. These rules only apply
 - Shortcuts must end with an action key (all non-modifier keys): A, B, C, 1, 2, 3, etc.
 - Shortcuts cannot be longer than four keys
 
-### Remap a shortcut to a single key
+### Remapping a shortcut to a single key
 
 It is possible to remap a shortcut (key combination) to a single key press by selecting **Remap a shortcut** in PowerToys Settings.
 
@@ -114,7 +114,7 @@ For example, to replace the shortcut <kbd>⊞ Win</kbd>+<kbd>←</kbd> (left arr
 > [!IMPORTANT]
 > Shortcut remapping will be maintained even if the remapped key is used inside another shortcut. The order of key press matters in this scenario as the action is executed during key-down, not key-up. For example: pressing <kbd>⊞ Win</kbd>+<kbd>←</kbd>+<kbd>Shift</kbd> would result in `Alt` + `Shift`.
 
-### Remap a shortcut to text
+### Remapping a shortcut to text
 
 For example, to replace the shortcut <kbd>Ctrl</kbd>+<kbd>G</kbd> with `Hello!` text, first select "Text" in the combo box and then fill the text box with "Hello!":
 
@@ -144,7 +144,7 @@ Keyboard Manager uses process-names (not application names) to target apps. For 
 | Word            | winword.exe   |
 | Powerpoint      | powerpnt.exe  |
 
-## How to select a key
+## Selecting a key
 
 To select a key or shortcut to remap:
 
@@ -197,7 +197,7 @@ Keyboard Manager lists mappings for all known physical keyboard keys. Some of th
 
 ![PowerToys Keyboard Manager List of Keys.](../images/pt-key-remap-drop-down.png)
 
-## Troubleshooting
+## Troubleshooting Keyboard Manager
 
 If you have tried to remap a key or shortcut and are having trouble, it could be one of the following issues:
 

--- a/hub/powertoys/mouse-utilities.md
+++ b/hub/powertoys/mouse-utilities.md
@@ -11,7 +11,7 @@ no-loc: [PowerToys, Windows, Mouse, jump]
 
 Mouse utilities is a collection of features that enhance mouse and cursor functionality on Windows.
 
-## Find my mouse
+## Find My Mouse
 
 Activate a spotlight that focuses on the cursor's position pressing the <kbd>Ctrl</kbd> key twice, using a custom shortcut or shaking the mouse. Click the mouse or press any keyboard key to dismiss it. If you move the mouse while the spotlight is active, the spotlight will dismiss on its own shortly after the mouse stops moving.
 
@@ -56,7 +56,7 @@ From the settings page, the following options can be configured:
 | Fade delay | How long it takes before a highlight starts to disappear - Measured in milliseconds. |
 | Fade duration | Duration of the disappear animation - Measured in milliseconds. |
 
-## Mouse jump
+## Mouse Jump
 
 ![Screenshot of Mouse jump.](../images/pt-mouse-jump.gif)
 
@@ -66,7 +66,7 @@ Mouse jump allows moving the mouse pointer long distances on a single screen or 
 | :--- | :--- |
 | Activation shortcut | The customizable keyboard command to activate the mouse jump. |
 
-## Mouse pointer Crosshairs
+## Mouse Pointer Crosshairs
 
 ![Screenshot of Crosshairs.](../images/pt-mouseutilities-crosshairs.png)
 

--- a/hub/powertoys/mouse-without-borders.md
+++ b/hub/powertoys/mouse-without-borders.md
@@ -6,7 +6,7 @@ ms.topic: article
 no-loc: [PowerToys, Windows, Mouse without borders]
 ---
 
-# Mouse Without Borders
+# Mouse Without Borders utility
 
 **Mouse Without Borders** enables you to control up to 4 computers from the same machine.
 
@@ -16,11 +16,11 @@ Features:
 - Share clipboard between the machines.
 - Transfer files between the machines.
 
-## How to use Mouse Without Borders
+## Using Mouse Without Borders
 
 With the latest version of PowerToys installed, you will see Mouse Without Borders listed in the PowerToys Settings, where you will need to do some initial configuration.
 
-### Initial configuration
+### Setting up Mouse Without Borders
 
 1. Open Mouse Without borders in PowerToys Settings to configure your connections.
 
@@ -40,7 +40,7 @@ It's possible to switch the order of the devices by dragging the device icon to 
 
    ![Animation of Mouse Without Borders settings configuring device layout.](../images/powertoys-mouse-without-borders-drag-device-layout.gif)
 
-### Install Mouse Without Borders as a service
+### Installing Mouse Without Borders as a service
 
 To allow Mouse Without Borders to control elevated applications or the lock screen from another computer, it's possible to run Mouse Without Borders as a service under the System account.
 

--- a/hub/powertoys/paste-as-plain-text.md
+++ b/hub/powertoys/paste-as-plain-text.md
@@ -7,7 +7,7 @@ ms.localizationpriority: medium
 no-loc: [PowerToys, Windows, Paste as Plain Text, Win]
 ---
 
-# Paste as Plain Text
+# Paste As Plain Text utility
 
 PowerToys **Paste as Plain Text** enables you to paste text stored in your clipboard, excluding any text-formatting, using a quick key shortcut. Any formatting included with the clipboard text will be replaced with an unformatted version of the text.
 
@@ -15,11 +15,11 @@ PowerToys **Paste as Plain Text** enables you to paste text stored in your clipb
 
 ## Getting started
 
-### Enabling
+### Enabling Paste As Plain Text
 
 To start using Paste as Plain Text, enable it in the PowerToys Settings (Paste as Plain Text tab).
 
-### Activating
+### Activating Paste As Plain Text
 
 Execute the paste as plain text action with the activation shortcut (default: <kbd>Ctrl</kbd>+<kbd>Win</kbd>+<kbd>Alt</kbd>+<kbd>V</kbd>).
 

--- a/hub/powertoys/peek.md
+++ b/hub/powertoys/peek.md
@@ -12,13 +12,13 @@ A system-wide utility for Windows that allows you to preview file content withou
 
 ![Screenshot of PowerToys Peek utility.](../images/powertoys-peek.png)
 
-## Preview a file
+## Previewing a file
 
 Select a file in the File Explorer and open the Peek preview using the activation / deactivation shortcut (default: <kbd>Ctrl</kbd>+<kbd>Space</kbd>).
 
 Using <kbd>Left</kbd> and <kbd>Right</kbd> or <kbd>Up</kbd> and <kbd>Down</kbd>, you can scroll between all files in the current folder. Select multiple files in the File Explorer for previewing to scroll only between selected ones.
 
-## Pin preview window position and size
+## Pinning the position and size of a Peek preview window
 
 The Peek window adjusts its size based on the dimensions of the images being previewed. However, if you prefer to keep the window's size and position, you can utilize the pinning feature.
 
@@ -26,7 +26,7 @@ By selecting the pinning button located in the top right corner of the Peek wind
 
 Selecting the pinning button again will unpin the window. When unpinned, the Peek window will return to the default position and size when previewing the next file.
 
-## Open file with the default program
+## Opening a file with the default program
 
 Select **Open with** on the top or <kbd>Enter</kbd> to open the current file with the default program.
 

--- a/hub/powertoys/powerrename.md
+++ b/hub/powertoys/powerrename.md
@@ -17,13 +17,13 @@ PowerRename is a bulk renaming tool that enables you to:
 - Check expected rename results in a preview window before finalizing a bulk rename.
 - Undo a rename operation after it is completed.
 
-## Demo
+## An example of using PowerRename
 
 In this demo, all instances of the file name "foo" are replaced with "foobar". Since all of the files are uniquely named, this would have taken a long time to complete manually one-by-one. PowerRename enables a single bulk rename. Notice that the Explorer's "Undo Rename" (Ctrl+Z) command makes it possible to undo the last change.
 
 ![PowerRename Demo.](../images/powerrename-demo.gif)
 
-## PowerRename window
+## Using PowerRename
 
 After selecting files in Windows File Explorer, right-click and select **PowerRename** (which will appear only if enabled in PowerToys). The selected items will be displayed, along with search and replace values, a list of options, and a preview pane displaying results of the search and replace values entered.
 

--- a/hub/powertoys/quick-accent.md
+++ b/hub/powertoys/quick-accent.md
@@ -14,7 +14,7 @@ Quick Accent is an alternative way to type accented characters, useful when a ke
 
 In order to use the Quick Accent utility, open PowerToys Settings, select the **Quick Accent** tab, and turn on the **Enable** toggle.
 
-## How to activate
+## Activating Quick Accent
 
 Activate by holding the key for the character you want to add an accent to, then (while held down) press the activation key (Space key or Left / Right arrow keys). If you continue to hold, an overlay to choose the accented character will appear.
 
@@ -22,7 +22,7 @@ For example: If you want "à", press and hold <kbd>A</kbd> and press <kbd>Space<
 
 With the dialog enabled, keep pressing your activation key.
 
-## Character sets
+## Choosing which character sets to show
 
 You can limit the available characters by selecting a character set from the settings menu. Available character sets are:
 

--- a/hub/powertoys/registry-preview.md
+++ b/hub/powertoys/registry-preview.md
@@ -15,17 +15,17 @@ PowerToys **Registry Preview** simplifies the process of visualizing and editing
 
 ## Getting started
 
-### Enable
+### Enabling Registry Preview
 
 To start using Registry Preview, enable it in the PowerToys Settings (**Registry Preview** tab).
 
-### How to activate
+### Activating Registry Preview
 
 Select one or more .reg files in Windows File Explorer. Right-click on the selected file(s), select **Show more options** from the menu to expand the list of menu options, then select **Preview** to open Registry Preview. **Registry Preview** can also be opened from PowerToys Settings' **Registry Preview** tab.
 
 **Note:** Currently, there is a 10MB file limit for opening Windows Registry files with Registry Preview. It will show a message if a file contains invalid content.
 
-## How to use
+## Using Registry Preview
 
 After opening a Windows Registry file, the file content is shown. This content can be updated at any time.
 

--- a/hub/powertoys/run.md
+++ b/hub/powertoys/run.md
@@ -11,15 +11,6 @@ no-loc: [PowerToys, Windows, File Explorer, PowerToys Run, Window Walker]
 
 PowerToys Run is a quick launcher for power users that contains additional features without sacrificing performance. It is open source and modular for additional plugins.
 
-To use PowerToys Run, select <kbd>Alt</kbd>+<kbd>Space</kbd> and start typing! _(Note that this shortcut can be changed in the settings window.)_
-
-> [!IMPORTANT]
-> PowerToys must be running in the background and Run must be enabled for this utility to work.
-
-![PowerToys Run demo opening apps.](../images/pt-powerrun-demo.gif)
-
-## Features
-
 PowerToys Run features include:
 
 - Search for applications, folders or files
@@ -33,6 +24,27 @@ PowerToys Run features include:
 - Calculate hashes
 - Generate GUIDs
 - Open web pages or start a web search
+
+## Using PowerToys Run
+
+To use PowerToys Run, select <kbd>Alt</kbd>+<kbd>Space</kbd> and start typing! _(Note that this shortcut can be changed in the settings window.)_
+
+> [!IMPORTANT]
+> PowerToys must be running in the background and Run must be enabled for this utility to work.
+
+![PowerToys Run demo opening apps.](../images/pt-powerrun-demo.gif)
+
+### General keyboard shortcuts
+
+| Shortcut | Action |
+| :--- | :--- |
+| <kbd>Alt</kbd>+<kbd>Space</kbd> (default) | Show or hide PowerToys Run |
+| <kbd>Esc</kbd> | Hide PowerToys Run |
+| <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Enter</kbd> | Open the selected application as administrator (only applicable to applications) |
+| <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>U</kbd> | Open the selected application as different user (only applicable to applications) |
+| <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>E</kbd> | Open containing folder in File Explorer (only applicable to applications and files) |
+| <kbd>Ctrl</kbd>+<kbd>C</kbd> | Copy path location (only applicable to folders and files) |
+| <kbd>Tab</kbd> | Navigate through the search results and context menu buttons |
 
 ## Settings
 
@@ -56,18 +68,18 @@ The following general options are available on the PowerToys Run settings page.
 | Preferred monitor position | If multiple displays are in use, PowerToys Run can be launched on:<br />• Primary display<br />• Display with mouse cursor<br />• Display with focused window |
 | App theme | Change the color theme used by PowerToys Run |
 
-### Plugin manager
+## Using plugins for PowerToys Run
 
 PowerToys Run uses a plugin system to provide different types of results. The settings page includes a plugin manager that allows you to enable/disable the various available plugins. By selecting and expanding the sections, you can customize the direct activation commands used by each plugin. In addition, you can select whether a plugin appears in global results and set additional plugin options where available.
 
 ![PowerToys Run Plugin Manager.](../images/pt-run-plugin-manager.png)
 
-#### Direct activation commands
+### Activating plugins with direct activation commands
 
 The plugins can be activated with a direct activation command so that PowerToys Run will only use the targeted plugin. The following table shows the direct activation commands assigned by default.
 
 > [!TIP]
-> You can change commands to fit your personal needs in the [plugin manager](#plugin-manager).
+> You can change commands to fit your personal needs in the [plugin manager](#using-plugins-for-powertoys-run).
 
 > [!IMPORTANT]
 > Some characters and phrases may conflict with global queries of other plugins if you use them as activation commands. For example, using `(` breaks global calculation queries starting with an opening brace.
@@ -98,21 +110,7 @@ The plugins can be activated with a direct activation command so that PowerToys 
 | Windows Terminal profiles | `_` | `_ powershell` to list all profiles that contains 'powershell' in their name. |
 | [Window Walker](#window-walker-plugin) | `<` | `< outlook` to find all open windows that contain 'outlook' in their name or the name of their process. |
 
-## Using PowerToys Run
-
-### General keyboard shortcuts
-
-| Shortcut | Action |
-| :--- | :--- |
-| <kbd>Alt</kbd>+<kbd>Space</kbd> (default) | Show or hide PowerToys Run |
-| <kbd>Esc</kbd> | Hide PowerToys Run |
-| <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Enter</kbd> | Open the selected application as administrator (only applicable to applications) |
-| <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>U</kbd> | Open the selected application as different user (only applicable to applications) |
-| <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>E</kbd> | Open containing folder in File Explorer (only applicable to applications and files) |
-| <kbd>Ctrl</kbd>+<kbd>C</kbd> | Copy path location (only applicable to folders and files) |
-| <kbd>Tab</kbd> | Navigate through the search results and context menu buttons |
-
-### System commands
+### System commands plugin
 
 The Windows System Commands plugin provides a set of system level actions that can be executed.
 

--- a/hub/powertoys/run.md
+++ b/hub/powertoys/run.md
@@ -115,7 +115,7 @@ The plugins can be activated with a direct activation command so that PowerToys 
 The Windows System Commands plugin provides a set of system level actions that can be executed.
 
 > [!TIP]
-> If your system language is supported by PowerToys, the system commands will be localized. If you prefer English commands, clear the **Use localized system commands instead of English ones** checkbox in the [plugin manager](#plugin-manager).
+> If your system language is supported by PowerToys, the system commands will be localized. If you prefer English commands, clear the **Use localized system commands instead of English ones** checkbox in the [plugin manager](#using-plugins-for-powertoys-run).
 
 | Command | Action | Note |
 | :--- | :--- | :--- |
@@ -164,7 +164,7 @@ If the program plugin's option "Include in global result" is not selected, inclu
 
 > [!IMPORTANT]
 > Please be aware of the different decimal and thousand delimiters in different locals.
-> The Calculator plugin respects the number format settings of your system. If you prefer the English (United States) number format, you can change the behavior for the query input and the result output in the [plugin manager](#plugin-manager).
+> The Calculator plugin respects the number format settings of your system. If you prefer the English (United States) number format, you can change the behavior for the query input and the result output in the [plugin manager](#using-plugins-for-powertoys-run).
 > If your system's number format uses the comma (`,`) as the decimal delimiter, you have to write a space between the number(s) and comma(s) on operations with multiple parameters. The input has to look like this: `min( 1,2 , 3 , 5,7)` or `min( 1.2 , 3 , 5.7)`.
 
 > [!TIP]
@@ -375,7 +375,7 @@ To search by location you can use the following syntax:
 
 The Service plugin lets you search, start, stop and restart Windows services directly from the PowerToys Run search screen.
 
-To search for Windows services, [enable the plugin](#plugin-manager), open PowerToys Run and enter the name of the service.
+To search for Windows services, [enable the plugin](#using-plugins-for-powertoys-run), open PowerToys Run and enter the name of the service.
 Additionally, you can use the following syntax:
 
 - `!startup:automatic` to list all services with start type 'automatic'.

--- a/hub/powertoys/screen-ruler.md
+++ b/hub/powertoys/screen-ruler.md
@@ -6,17 +6,17 @@ ms.topic: article
 no-loc: [PowerToys, Windows, Screen ruler, Win]
 ---
 
-# Screen ruler utility
+# Screen Ruler utility
 
 ![Screen ruler utility](../images/pt-screen-ruler.png)
 
-Screen ruler allows you to quickly measure pixels on your screen based on image edge detection. This was inspired by [Pete Blois's Rooler](https://github.com/peteblois/rooler).
+Screen Ruler allows you to quickly measure pixels on your screen based on image edge detection. This was inspired by [Pete Blois's Rooler](https://github.com/peteblois/rooler).
 
-## How to activate
+## Activating Screen Ruler
 
 Press <kbd>⊞ Win</kbd>+<kbd>Shift</kbd>+<kbd>M</kbd> to activate and then select which tool you want to measure with. To exit, press <kbd>Esc</kbd> or click &#9587; in the toolbar.
 
-## How to use
+## Using Screen Ruler
 
 - Bounds (Dashed square symbol): This is a bounding box. Click and drag with your mouse. If you hold <kbd>Shift</kbd>, the box(es) will stay in place until you cancel the interaction.
 - Spacing (&#9547;): This will measure horizontal and vertical spacing at the same time.  Click the symbol and move your mouse to your target location.

--- a/hub/powertoys/shortcut-guide.md
+++ b/hub/powertoys/shortcut-guide.md
@@ -7,11 +7,11 @@ ms.localizationpriority: medium
 no-loc: [PowerToys, Windows, File Explorer]
 ---
 
-# Windows key shortcut guide
+# Shortcut Guide utility
 
 This guide uses PowerToys to display common keyboard shortcuts that use the Windows key.
 
-## Getting started
+## Using Shortcut Guide
 
 Open the shortcut guide with the shortcut key combination: <kbd>⊞ Win</kbd>+<kbd>Shift</kbd>+<kbd>/</kbd> (or as we like to think, <kbd>⊞ Win</kbd>+<kbd>?</kbd>) or hold down the <kbd>⊞ Win</kbd> for the time as set in the Settings. An overlay will appear showing keyboard shortcuts that use the Windows key, including:
 

--- a/hub/powertoys/text-extractor.md
+++ b/hub/powertoys/text-extractor.md
@@ -10,15 +10,15 @@ no-loc: [PowerToys, Windows, Text Extractor, Win]
 
 Text Extractor enables you to copy text from anywhere on your screen, including inside images or videos. This code is based on [Joe Finney's Text Grab](https://github.com/TheJoeFin/Text-Grab).
 
-## How to activate
+## Activating Text Extractor
 
 With the activation shortcut (default: <kbd>⊞ Win</kbd>+<kbd>Shift</kbd>+<kbd>T</kbd>), you'll see an overlay on the screen. Click and hold your primary mouse button and drag to activate your capture. The text will be saved to your clipboard.
 
-## How to deactivate
+## Deactivating Text Extractor
 
-Capture mode is deactivated immediately after text in the selected region is recognized and copied to the clipboard. You can exit capture mode by pressing <kbd>Esc</kbd> at any moment.
+Capture mode is deactivated immediately after text in the selected region is recognized and copied to the clipboard. You can deactivate capture mode by pressing <kbd>Esc</kbd> at any moment.
 
-## Adjust while trying to capture
+## Adjusting the capture region while using Text Extractor
 
 By holding <kbd>Shift</kbd>, you will change from adjusting the capture region's size to moving the capture region. When you release <kbd>Shift</kbd>, you will be able to resize again.
 
@@ -51,7 +51,7 @@ The list can be obtained via PowerShell by running the following commands:
 [Windows.Media.Ocr.OcrEngine]::AvailableRecognizerLanguages
 ```
 
-### How to query for OCR language packs
+### Viewing supported OCR language packs
 
 To return the list of all supported language packs, open PowerShell as an Administrator (right-click, then select "Run as Administrator"), and enter the following command:
 
@@ -79,7 +79,7 @@ State : NotPresent
 
 The language and location is abbreviated, so "en-US" would be "English-United States" and "en-GB" would be "English-Great Britain". If a language is not available in the output, then it's not supported by OCR. `State: NotPresent` languages must be installed first.
 
-### How to install an OCR language pack
+### Installing an OCR language pack
 
 The following commands install the OCR pack for "en-US":
 
@@ -91,7 +91,7 @@ $Capability = Get-WindowsCapability -Online | Where-Object { $_.Name -Like 'Lang
 $Capability | Add-WindowsCapability -Online
 ```
 
-### How to remove an OCR language pack
+### Removing an OCR language pack
 
 The following commands remove the OCR pack for "en-US":
 
@@ -103,7 +103,7 @@ $Capability = Get-WindowsCapability -Online | Where-Object { $_.Name -Like 'Lang
 $Capability | Remove-WindowsCapability -Online
 ```
 
-## Troubleshooting
+## Troubleshooting Text Extractor
 
 This section will list possible errors and solutions.
 

--- a/hub/powertoys/video-conference-mute.md
+++ b/hub/powertoys/video-conference-mute.md
@@ -7,14 +7,14 @@ ms.localizationpriority: medium
 no-loc: [PowerToys, Windows, File Explorer, Video Conference Mute, Shift]
 ---
 
-# Video Conference Mute
+# Video Conference Mute utility
 
 > [!NOTE]
 > VCM is moving into legacy mode. Please find more about what this means [in our dedicated discussion issue](https://github.com/microsoft/PowerToys/issues/21473).
 
 Quickly mute your microphone (audio) and turn off your camera (video) with a single keystroke while on a conference call, regardless of what application has focus on your computer.
 
-## Getting started
+## Using Video Conference Mute
 
 The default shortcuts to use Video Conference Mute are:
 
@@ -48,7 +48,7 @@ The Video Conference Mute page in Settings provides the following options:
 
 ![Video Conference Mute options in PowerToys settings.](../images/pt-video-conference-mute-settings.png)
 
-## How this works under the hood
+## How Video Conference Mute works
 
 Applications interact with audio and video in different ways. If a camera stops working, the application using it tends not to recover until the API does a full reset. To toggle the global privacy camera on and off while using the camera in an application, typically it will crash and not recover.
 
@@ -57,7 +57,7 @@ So, how does PowerToys handle this so you can keep streaming?
 - **Audio:** PowerToys uses the global microphone mute API in Windows. Apps should recover when this is toggled on and off.
 - **Video:** PowerToys has a virtual driver for the camera. The video is routed _through_ the driver and then to the application. Selecting the Video Conference Mute shortcut key stops video from streaming, but the application still thinks it is receiving video. The video is just replaced with black or the image placeholder you've saved in the settings.
 
-### Debug the camera driver
+### Debugging the camera driver
 
 To debug the camera driver, open this file on your machine: `C:\Windows\ServiceProfiles\LocalService\AppData\Local\Temp\PowerToysVideoConference.log`
 


### PR DESCRIPTION
The headings across the PowerToys documentation are very inconsistent.

This PR:

* makes headings more consistent by applying the most used verb form in the PowerToys docs - the present participle - across as many pages and headings as possible (`Use PowerToys Run` becomes `Using PowerToys Run`)
* makes non action-based headings, action-based (for example, `Plugin manager` becomes `Using plugins for PowerToys Run`)
* makes generic headings specific to the utility (`How to use` becomes `Using Quick Accent`)
* simplifies the heading structure on some pages
* improves the heading structure of pages that had too broad of a heading structure
* adds missing `utility` suffix to H1s
* makes short, undescriptive headings more specific (for example, `Limitations` becomes `Limitations of Color Picker`

Some generic headings, such as `Settings`, have been left alone.

If it turns out that another verb format is better for headings, this PR should make it easier to change as most headings now follow a similar structure.