### PR TITLE
Add download to winget command table

### DIFF
--- a/hub/package-manager/winget/index.md
+++ b/hub/package-manager/winget/index.md
@@ -95,7 +95,7 @@ The current preview of the **winget** tool supports the following commands.
 | [import](import.md) | Installs all the packages in a file. |
 | [pin](pinning.md) | Manage package pins. |
 | [configure](configure.md) | Configures the system into a desired state. |
-| [download](download.md) | Downloads the specification application's installation file. |
+| [download](download.md) | Downloads the specified application's installation file. |
 
 ### Options
 

--- a/hub/package-manager/winget/index.md
+++ b/hub/package-manager/winget/index.md
@@ -95,6 +95,7 @@ The current preview of the **winget** tool supports the following commands.
 | [import](import.md) | Installs all the packages in a file. |
 | [pin](pinning.md) | Manage package pins. |
 | [configure](configure.md) | Configures the system into a desired state. |
+| [download](download.md) | Downloads the specification application's installation file. |
 
 ### Options
 

--- a/hub/package-manager/winget/index.md
+++ b/hub/package-manager/winget/index.md
@@ -95,7 +95,7 @@ The current preview of the **winget** tool supports the following commands.
 | [import](import.md) | Installs all the packages in a file. |
 | [pin](pinning.md) | Manage package pins. |
 | [configure](configure.md) | Configures the system into a desired state. |
-| [download](download.md) | Downloads the specified application's installation file. |
+| [download](download.md) | Downloads the specified application's installer. |
 
 ### Options
 


### PR DESCRIPTION
`winget download` was added from [this issue](https://github.com/microsoft/winget-cli/issues/658). This PR updates the main winget documentation page to add `download` to the command table.