### PR TITLE
Add Windows subsystem for Android to developer tools TOC

### DIFF
--- a/hub/dev-environment/toc.yml
+++ b/hub/dev-environment/toc.yml
@@ -153,6 +153,8 @@ items:
         href: ../powertoys/video-conference-mute.md
   - name: Windows Subsystem for Linux
     href: /windows/wsl/
+  - name: Windows Subsystem for Android
+    href: /windows/android/wsa/
   - name: Windows Terminal
     href: /windows/terminal/
   - name: Mac to Windows guide


### PR DESCRIPTION
Adds WSA to the Windows development environment TOC. It is also available further down in the navigation, but in my opinion it fits also here.