### PR TITLE
[PowerToys]Add supported languages:Arabic, Farsi, Hebrew, Ukrainian

### DIFF
--- a/hub/powertoys/index.md
+++ b/hub/powertoys/index.md
@@ -292,7 +292,7 @@ The currently available utilities include:
 
 ## Languages
 
-Currently, PowerToys is available in the following languages: Chinese (simplified), Chinese (traditional), Czech, Dutch, English, French, German, Hungarian, Italian, Japanese, Korean, Polish, Portuguese, Portuguese (Brazil), Russian, Spanish, Turkish.
+Currently, PowerToys is available in the following languages: Arabic (Saudi Arabia), Chinese (simplified), Chinese (traditional), Czech, Dutch, English, Farsi (Persian), French, German, Hebrew, Hungarian, Italian, Japanese, Korean, Polish, Portuguese, Portuguese (Brazil), Russian, Spanish, Turkish, Ukrainian.
 
 _Note that new elements of the app might sometimes not yet be translated in the first version release._
 

--- a/hub/powertoys/index.md
+++ b/hub/powertoys/index.md
@@ -292,7 +292,7 @@ The currently available utilities include:
 
 ## Languages
 
-Currently, PowerToys is available in the following languages: Arabic (Saudi Arabia), Chinese (simplified), Chinese (traditional), Czech, Dutch, English, Farsi (Persian), French, German, Hebrew, Hungarian, Italian, Japanese, Korean, Polish, Portuguese, Portuguese (Brazil), Russian, Spanish, Turkish, Ukrainian.
+Currently, PowerToys is available in the following languages: Arabic (Saudi Arabia), Chinese (simplified), Chinese (traditional), Czech, Dutch, English, French, German, Hebrew, Hungarian, Italian, Japanese, Korean, Persian, Polish, Portuguese, Portuguese (Brazil), Russian, Spanish, Turkish, Ukrainian.
 
 _Note that new elements of the app might sometimes not yet be translated in the first version release._
 


### PR DESCRIPTION
@alvinashcraft only to be merged after we release 0.78 😄 

Adds reference that we support the following languages:
- Arabic (Saudi Arabia) "ar-SA"
- Farsi/Persian (Iran) "fa-IR"
- Hebrew (Israel) "he-IL"
- Ukrainian (Ukraine) "uk-UA"

I'm not sure about the guidelines for each language, so can you please confirm how they should be listed?
@alvinashcraft @crutkas 
I ended up going with:
- Arabic (Saudi Arabia)
- Farsi (Persian)
- Hebrew
- Ukrainian