### PR TITLE
Fixing code on the guide on implementing Pattern availability

### DIFF
--- a/hub/apps/design/accessibility/custom-automation-peers.md
+++ b/hub/apps/design/accessibility/custom-automation-peers.md
@@ -302,7 +302,7 @@ protected override object GetPatternCore(PatternInterface patternInterface)
     {
         return this;
     }
-    return base.GetPattern(patternInterface);
+    return base.GetPatternCore(patternInterface);
 }
 ```
 


### PR DESCRIPTION
In the text, it is said that when we need to fallback to the base class, we call the `GetPatternCore`, but in the code, it was just `GetPattern`, which can cause a stack overflow as it will be calling itself forever.