### PR TITLE
formatting and small text adjustments

### DIFF
--- a/hub/powertoys/administrator.md
+++ b/hub/powertoys/administrator.md
@@ -59,8 +59,8 @@ The simplest way to run an app or program in administrative mode is to right-cli
 
 If you see this User Account Control prompt, the application is requesting administrator level elevated permission:
 
-![Windows UAC elevated permission prompt screenshot.](../images/pt-admin-prompt.png)
+![Windows UAC elevated permission prompt screenshot](../images/pt-admin-prompt.png)
 
 In the case of an elevated command line, typically the text "Administrator" will be included in the title bar.
 
-![Windows Powershell and Command Line with elevated permissions screenshot.](../images/pt-admin-terminal.png)
+![Windows Powershell and Command Line with elevated permissions screenshot](../images/pt-admin-terminal.png)

--- a/hub/powertoys/always-on-top.md
+++ b/hub/powertoys/always-on-top.md
@@ -10,7 +10,7 @@ no-loc: [PowerToys, Windows, Always On Top, Win]
 
 A system-wide Windows utility to pin windows above other windows.
 
-![Always On Top screenshot.](../images/pt-always-on-top.png)
+![Always On Top screenshot](../images/pt-always-on-top.png)
 
 ## Pin a window
 

--- a/hub/powertoys/awake.md
+++ b/hub/powertoys/awake.md
@@ -21,7 +21,7 @@ You can use PowerToys Awake directly from PowerToys Settings or as a standalone 
 
 In the PowerToys Settings, start PowerToys Awake by toggling **Enable Awake** on. Once enabled, the application will manage the awakeness state of the computer.
 
-![A screenshot of the Awake settings.](../images/pt-awake-settings-menu.png)
+![A screenshot of the Awake settings](../images/pt-awake-settings-menu.png)
 
 You can choose the following Awake states:
 
@@ -45,7 +45,7 @@ This feature only works if Awake is running in one of the three **Keep awake** s
 
 To manage the execution of the tool from the system tray, right-click on the PowerToys Awake icon.
 
-![Awake settings managed from the system tray on Windows.](../images/pt-awake-tray.gif)
+![Awake settings managed from the system tray on Windows](../images/pt-awake-tray.gif)
 
 ## Command Line Interface (CLI)
 

--- a/hub/powertoys/cmd-not-found.md
+++ b/hub/powertoys/cmd-not-found.md
@@ -11,9 +11,9 @@ no-loc: [PowerToys, Windows, Command Not Found, Win]
 A PowerShell 7 module that detects command-line errors and suggests a relevant WinGet package to install, if available.
 
 > [!IMPORTANT]
-> There are some incompatibilities between Command Not Found and some PowerShell configurations. You can read more about them in [issue 30818](https://github.com/microsoft/PowerToys/issues/30818) on GitHub.
+> There are some incompatibilities between Command Not Found and some PowerShell configurations. Read more about them in [issue 30818](https://github.com/microsoft/PowerToys/issues/30818) on GitHub.
 
-![Command Not Found screenshot.](../images/pt-cmd-not-found.png)
+![Command Not Found screenshot](../images/pt-cmd-not-found.png)
 
 ## Requirements
 
@@ -27,7 +27,7 @@ To install the Command Not Found module, navigate to the Command Not Found page 
  - PSFeedbackProvider
  - PSCommandNotFoundSuggestion
 
-After that, PowerShell profile file will be appended with following block of PowerShell commands:
+After that, the PowerShell profile file will be appended with following block of PowerShell commands:
 
 ```psh
 #34de4b3d-13a8-4540-b76d-b9e8d3851756 PowerToys CommandNotFound module

--- a/hub/powertoys/color-picker.md
+++ b/hub/powertoys/color-picker.md
@@ -11,7 +11,7 @@ no-loc: [PowerToys, Windows, Color Picker, Color, Picker]
 
 A system-wide color picking utility for Windows to pick colors from any screen and copy it in a configurable format to the clipboard.
 
-![Color Picker screenshot.](../images/pt-colorpicker-hex-editor.png)
+![Color Picker screenshot](../images/pt-colorpicker-hex-editor.png)
 
 ## Getting started
 
@@ -21,7 +21,7 @@ Enable Color Picker in the **Color Picker** tab in PowerToys Settings.
 
 ### Activating Color Picker
 
-You can choose what happens when you activate Color Picker (default: <kbd>Win</kbd>+<kbd>Shift</kbd>+<kbd>C</kbd>) by changing **Activation Behavior**:
+Choose what happens when you activate Color Picker (default: <kbd>Win</kbd>+<kbd>Shift</kbd>+<kbd>C</kbd>) by changing **Activation Behavior**:
 
 :::image type="content" source="../images/pt-colorpicker-activation.gif" alt-text="Color Picker behaviors.":::
 
@@ -35,7 +35,7 @@ After activating Color Picker, select a color on your screen to pick that color.
 
 Color Picker copies the selected color to the clipboard in the **Default color format** you've chosen in Color Picker's settings (default: HEX).
 
-![Selecting a Color.](../images/pt-colorpicker.gif)
+![Selecting a Color](../images/pt-colorpicker.gif)
 
 > [!TIP]
 > To select the color of the non-hover state of a element:
@@ -46,7 +46,7 @@ Color Picker copies the selected color to the clipboard in the **Default color f
 
 ## Using the Color Picker editor
 
-The Color Picker editor stores a history of up to 20 picked colors and lets you copy them to the clipboard. You can choose which color formats are visible in the editor in **Color formats** in PowerToys Settings.
+The Color Picker editor stores a history of up to 20 picked colors and lets you copy them to the clipboard. Choose which color formats are visible in the editor in **Color formats** in PowerToys Settings.
 
 The colored bar at the top of the Color Picker editor lets you:
 
@@ -57,7 +57,7 @@ To fine tune your chosen color, select the central color in the color bar. The f
 
 To choose a similar color, select one of the segments on the left and right edges of the color bar. The Color Picker editor suggests two lighter shades on the left of the bar, and two darker shades on the right of the bar. Selecting one of these similar colors adds that color to the colors history.
 
-![Color Picker Editor window.](../images/pt-colorpicker-editor.gif)
+![Color Picker Editor window](../images/pt-colorpicker-editor.gif)
 
 To remove a color from the colors history, right-click a color and select **Remove**.
 
@@ -75,7 +75,7 @@ Color Picker has the following settings:
 | **Show color name** | When turned on, this setting shows a high-level representation of the color. For example, 'Light Green', 'Green', or 'Dark Green'. |
 | **Color formats** | This section lets you enable and add different color formats, and change the order of color formats in the Color Picker editor. Read more about **Color formats** in [Managing color formats](#managing-color-formats).
 
-![Color Picker Settings screenshot.](../images/pt-colorpicker-settings.png)
+![Color Picker Settings screenshot](../images/pt-colorpicker-settings.png)
 
 ### Managing color formats
 
@@ -87,9 +87,9 @@ To disable a color format, turn off the toggle next to that color format. Color 
 
 To delete a color format, select **•••** next to a color format and select **Delete**.
 
-To add a new color format, select **Add custom color format**. You can choose the color format's **Name** and **Format**. Select **Save** to add the color format. The syntax for color formats is described in the **Add custom color format** dialog.
+To add a new color format, select **Add custom color format**. Choose the color format's **Name** and **Format**. Select **Save** to add the color format. The syntax for color formats is described in the **Add custom color format** dialog.
 
-To edit a color format, select it from the list. You can edit the color format's **Name** and **Format** in the **Edit custom color format** dialog. Select **Update** to save your changes. The syntax for color formats is described in the **Edit custom color format** dialog.
+To edit a color format, select it from the list. Edit the color format's **Name** and **Format** in the **Edit custom color format** dialog. Select **Update** to save your changes. The syntax for color formats is described in the **Edit custom color format** dialog.
 
 Define color formats with these parameters:
 

--- a/hub/powertoys/crop-and-lock.md
+++ b/hub/powertoys/crop-and-lock.md
@@ -22,7 +22,7 @@ To start using Crop And Lock, enable it in the PowerToys Settings (**Crop And Lo
 Once enabled, focus a Window and press the "Thumbnail" shortcut (default: <kbd>⊞ Win</kbd>+<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>T</kbd>) or the "Reparent" shortcut (default: <kbd>⊞ Win</kbd>+<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>R</kbd>) to select an area of the window to crop.
 
 > [!TIP]
-> Select the <kbd>Esc</kbd> key to cancel the crop selection.
+> Use <kbd>Esc</kbd> to cancel the crop selection.
 
 After you've selected the area of the window, a new window will appear and behave according to the selected crop mode.
 

--- a/hub/powertoys/crop-and-lock.md
+++ b/hub/powertoys/crop-and-lock.md
@@ -11,7 +11,7 @@ no-loc: [PowerToys, Windows, Crop And Lock, Win]
 
 PowerToys **Crop And Lock** allows you to crop a current application into a smaller window or just create a thumbnail. Focus the target window and press the shortcut to start cropping.
 
-![Crop And Lock screenshot.](../images/powertoys-crop-and-lock.gif)
+![Crop And Lock screenshot](../images/powertoys-crop-and-lock.gif)
 
 ## Getting started
 
@@ -19,14 +19,14 @@ PowerToys **Crop And Lock** allows you to crop a current application into a smal
 
 To start using Crop And Lock, enable it in the PowerToys Settings (**Crop And Lock** tab).
 
-Once enabled, you can focus a Window and press the "Thumbnail" shortcut (default: <kbd>⊞ Win</kbd>+<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>T</kbd>) or the "Reparent" shortcut (default: <kbd>⊞ Win</kbd>+<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>R</kbd>) to select an area of the window to crop.
+Once enabled, focus a Window and press the "Thumbnail" shortcut (default: <kbd>⊞ Win</kbd>+<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>T</kbd>) or the "Reparent" shortcut (default: <kbd>⊞ Win</kbd>+<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>R</kbd>) to select an area of the window to crop.
 
 > [!TIP]
-> You can use the <kbd>Esc</kbd> key to cancel the crop selection.
+> Select the <kbd>Esc</kbd> key to cancel the crop selection.
 
 After you've selected the area of the window, a new window will appear and behave according to the selected crop mode.
 
-Use the **X** button on the top right corner of the cropped window to close it and restore the original window.
+Select the **Close** button of the cropped window to close it and restore the original window.
 
 ## Crop modes
 
@@ -42,4 +42,4 @@ Creates a window that replaces the original window, showing only the selected ar
 
 - Cropping maximized or full-screen windows in "Reparent" mode might not work. It's recommended to resize the window to fill the screen corners instead.
 - Some UWP apps won't react well to being cropped in "Reparent" mode. The Windows Calculator is a notable example of this.
-- Applications that use sub-windows or tabs can also react poorly to being cropped in "Reparent" mode. Notepad and OneNote are notable examples of applications that react poorly.
+- Applications that use sub-windows or tabs can react poorly to being cropped in "Reparent" mode. Notepad and OneNote are notable examples of applications that react poorly.

--- a/hub/powertoys/dsc-configure.md
+++ b/hub/powertoys/dsc-configure.md
@@ -1,12 +1,12 @@
 ---
 title: PowerToys DSC Configure module
-description: DSC configure module documentation for PowerToys
+description: Desired State Configuration module documentation for PowerToys
 ms.date: 04/03/2024
 ms.topic: article
 no-loc: [PowerToys, Windows, DSC, Win]
 ---
 
-# DSC configuration
+# Desired State Configuration
 
 Since version 0.80, the PowerToys installer has been released on GitHub with `Microsoft.PowerToys.Configure` [DSC resource](/powershell/dsc/overview) that allows you to configure PowerToys using a [Winget configuration file](/windows/package-manager/configuration/create).
 
@@ -14,26 +14,26 @@ Since version 0.80, the PowerToys installer has been released on GitHub with `Mi
 
 ### Prerequisites
 
-- `PSDesiredStateConfiguration` 2.0.7 or higher: Refer to the [PowerShell DSC documentation](/powershell/dsc/overview) for installation instructions.
+- PSDesiredStateConfiguration 2.0.7 or later: Refer to the [PowerShell DSC documentation](/powershell/dsc/overview) for installation instructions.
 - PowerShell 7.2 or higher.
 - WinGet [version v1.6.2631 or later](https://github.com/microsoft/winget-cli/releases).
 
 ### Download
 
-`Microsoft.PowerToys.Configure` is [installed alongside PowerToys](install.md). Depending on the installer type, it's installed as follows:
+Microsoft.PowerToys.Configure is [installed with PowerToys](install.md). Depending on the installer type, it's installed as follows:
 
 - For the per-user install scope, the module is located in `%USERPROFILE%\Documents\PowerShell\Modules\Microsoft.PowerToys.Configure`.
 - For the machine-wide install scope, it's found in `%ProgramFiles%\WindowsPowerShell\Modules\Microsoft.PowerToys.Configure`.
 
 ## Usage
 
-You can invoke the resource directly using the following syntax:
+You can invoke the resource directly using the following Powershell syntax:
 
 ```ps
 Invoke-DscResource -Name PowerToysConfigure -Method Set -ModuleName Microsoft.PowerToys.Configure -Property @{ Awake = @{ Enabled = $false; Mode = "TIMED"; IntervalMinutes = "10" } }
 ```
 
-However, creating a configuration.dsc.yaml file that contains the required settings in a simpler format is more convenient. Here's an example:
+However, creating a _configuration.dsc.yaml_ file that contains the required settings in a simpler format is more convenient. Here's an example:
 
 ```yaml
 properties:
@@ -67,7 +67,7 @@ Use the following command to apply the configuration from the file:
 winget configure .\configuration.dsc.yaml
 ```
 
-This command installs the latest version of PowerToys and uses the PowerToysConfigure resource to apply settings for multiple PowerToys modules. More examples can be found [here](https://github.com/microsoft/PowerToys/tree/main/src/dsc/Microsoft.PowerToys.Configure/examples).
+This command installs the latest version of PowerToys and uses the PowerToysConfigure resource to apply settings for multiple PowerToys modules. More examples can be found [in the PowerToys repo](https://github.com/microsoft/PowerToys/tree/main/src/dsc/Microsoft.PowerToys.Configure/examples).
 
 ## Available Configuration Settings by Module
 
@@ -75,34 +75,34 @@ This command installs the latest version of PowerToys and uses the PowerToysConf
 
 | Name | Type | Description | Available |
 | :--- | :--- | :--- | :--- |
-| Enabled | Bool | The enabled state for this utility. | ✅ |
+| Enabled | Boolean | The enabled state for this utility. | ✅ |
 | Hotkey | KeyboardKeys | Customize the shortcut to pin or unpin an app window. | ✅ |
-| FrameEnabled | Bool | Show a border around the pinned window. | ✅ |
+| FrameEnabled | Boolean | Show a border around the pinned window. | ✅ |
 | FrameThickness | Int | Border thickness in pixels. | ✅ |
 | FrameColor | String | Specify a color in a `#FFFFFFFF` format. | ✅ |
 | FrameOpacity | Int | Border opacity in percentage. | ✅ |
-| FrameAccentColor | Bool | Whether to use a custom FrameColor value. | ✅ |
-| SoundEnabled | Bool | Play a sound when pinning a window. | ✅ |
-| DoNotActivateOnGameMode | Bool | Disable activation shortcut when Game Mode is on. | ✅ |
+| FrameAccentColor | Boolean | Use a custom FrameColor value. | ✅ |
+| SoundEnabled | Boolean | Play a sound when pinning a window. | ✅ |
+| DoNotActivateOnGameMode | Boolean | Disable activation shortcut when Game Mode is on. | ✅ |
 | ExcludedApps | String | '\r'-separated list of executable names to exclude from pinning on top. | ✅ |
-| RoundCornersEnabled | Bool | Enable round corners. | ✅ |
+| RoundCornersEnabled | Boolean | Enable round corners. | ✅ |
 
 ### Awake
 
 | Name | Type | Description | Available |
 | :--- | :--- | :--- | :--- |
-| Enabled | Bool | The enabled state for this utility. | ✅ |
+| Enabled | Boolean | The enabled state for this utility. | ✅ |
 | KeepDisplayOn | Boolean | This setting is only available when keeping the PC awake. | ✅ |
 | Mode | AwakeMode | Possible values: PASSIVE, INDEFINITE, TIMED, EXPIRABLE.  | ✅ |
-| IntervalHours | UInt32 | When using TIMED Mode, specifies the number of hours. | ✅ |
-| IntervalMinutes | UInt32 | When using TIMED Mode, specifies the number of minutes. | ✅ |
-| ExpirationDateTime | DateTimeOffset | When using EXPIRABLE Mode, specifies the date and time in a format parsable with `DateTimeOffset.TryParse`. | ✅ |
+| IntervalHours | UInt32 | When using TIMED mode, specifies the number of hours. | ✅ |
+| IntervalMinutes | UInt32 | When using TIMED mode, specifies the number of minutes. | ✅ |
+| ExpirationDateTime | DateTimeOffset | When using EXPIRABLE mode, specifies the date and time in a format parsable with `DateTimeOffset.TryParse`. | ✅ |
 
 ### ColorPicker
 
 | Name | Type | Description | Available |
 | :--- | :--- | :--- | :--- |
-| Enabled | Bool | The enabled state for this utility. | ✅ |
+| Enabled | Boolean | The enabled state for this utility. | ✅ |
 | ActivationShortcut | HotkeySettings | Customize the shortcut to activate this module. | ✅ |
 | CopiedColorRepresentation | String | The default color representation to be used. Example :"HEX". | ✅ |
 | ActivationAction | ColorPickerActivationAction | Possible values: OpenEditor, OpenColorPickerAndThenEditor, OpenOnlyColorPicker. | ✅ |
@@ -116,7 +116,7 @@ This command installs the latest version of PowerToys and uses the PowerToysConf
 
 | Name | Type | Description | Available |
 | :--- | :--- | :--- | :--- |
-| Enabled | Bool | The enabled state for this utility. | ✅ |
+| Enabled | Boolean | The enabled state for this utility. | ✅ |
 | ReparentHotkey | KeyboardKeys | Shortcut to crop an application's window into a cropped window. | ✅ |
 | ThumbnailHotkey | KeyboardKeys | Shortcut to crop and create a thumbnail of another window. | ✅ |
 
@@ -124,46 +124,46 @@ This command installs the latest version of PowerToys and uses the PowerToysConf
 
 | Name | Type | Description | Available |
 | :--- | :--- | :--- | :--- |
-| Enabled | Bool | The enabled state for this utility. | ✅ |
+| Enabled | Boolean | The enabled state for this utility. | ✅ |
 | LaunchAdministrator | Boolean | Needs to be launched as administrator in order to make changes to the system environment variables. | ✅ |
 
 ### FancyZones
 
 | Name | Type | Description | Available |
 | :--- | :--- | :--- | :--- |
-| Enabled | Bool | The enabled state for this utility. | ✅ |
-| FancyzonesShiftDrag | Bool | Hold Shift key to activate zones while dragging a window. | ✅ |
-| FancyzonesMouseSwitch | Bool | Use a non-primary mouse button to toggle zone activation. | ✅ |
-| FancyzonesMouseMiddleClickSpanningMultipleZones | Bool | Use middle-click mouse button to toggle multiple zones spanning. | ✅ |
-| FancyzonesOverrideSnapHotkeys | Bool | This overrides the Windows Snap shortcut (Win + arrow) to move windows between zones. | ✅ |
-| FancyzonesMoveWindowsAcrossMonitors | Bool | Move windows between zones across all monitors. | ✅ |
-| FancyzonesMoveWindowsBasedOnPosition | Bool | Move windows based on relative position or zone index. | ✅ |
+| Enabled | Boolean | The enabled state for this utility. | ✅ |
+| FancyzonesShiftDrag | Boolean | Hold Shift key to activate zones while dragging a window. | ✅ |
+| FancyzonesMouseSwitch | Boolean | Use a non-primary mouse button to toggle zone activation. | ✅ |
+| FancyzonesMouseMiddleClickSpanningMultipleZones | Boolean | Use middle-click mouse button to toggle multiple zones spanning. | ✅ |
+| FancyzonesOverrideSnapHotkeys | Boolean | This overrides the Windows Snap shortcut (Win + arrow) to move windows between zones. | ✅ |
+| FancyzonesMoveWindowsAcrossMonitors | Boolean | Move windows between zones across all monitors. | ✅ |
+| FancyzonesMoveWindowsBasedOnPosition | Boolean | Move windows based on relative position or zone index. | ✅ |
 | FancyzonesOverlappingZonesAlgorithm | Int | When multiple zones overlap algorithm index. | ✅ |
-| FancyzonesDisplayOrWorkAreaChangeMoveWindows | Bool | Keep windows in their zones when the screen resolution or work area changes. | ✅ |
-| FancyzonesZoneSetChangeMoveWindows | Bool | During zone layout changes, windows assigned to a zone will match new size/positions. | ✅ |
-| FancyzonesAppLastZoneMoveWindows | Bool | Move newly created windows to their last known zone. | ✅ |
-| FancyzonesOpenWindowOnActiveMonitor | Bool | Move newly created windows to the curreynt active monitor (Experimental). | ✅ |
-| FancyzonesRestoreSize | Bool | Restore the original size of windows when unsnapping. | ✅ |
-| FancyzonesQuickLayoutSwitch | Bool | Enable quick layout switch. | ✅ |
-| FancyzonesFlashZonesOnQuickSwitch | Bool | Flash zones when switching layout. | ✅ |
-| UseCursorposEditorStartupscreen | Bool | Whether to launch editor on the display where the mouse point is. | ✅ |
-| FancyzonesShowOnAllMonitors | Bool | Show zones on all monitors while dragging a window. | ✅ |
-| FancyzonesSpanZonesAcrossMonitors | Bool | Allow zones to span across monitors. | ✅ |
-| FancyzonesMakeDraggedWindowTransparent | Bool | Make dragged window transparent. | ✅ |
-| FancyzonesAllowChildWindowSnap | Bool | Allow child windows snapping. | ✅ |
-| FancyzonesDisableRoundCornersOnSnap | Bool | Disable round corners when window is snapped. | ✅ |
+| FancyzonesDisplayOrWorkAreaChangeMoveWindows | Boolean | Keep windows in their zones when the screen resolution or work area changes. | ✅ |
+| FancyzonesZoneSetChangeMoveWindows | Boolean | During zone layout changes, windows assigned to a zone will match new size/positions. | ✅ |
+| FancyzonesAppLastZoneMoveWindows | Boolean | Move newly created windows to their last known zone. | ✅ |
+| FancyzonesOpenWindowOnActiveMonitor | Boolean | Move newly created windows to the curreynt active monitor (Experimental). | ✅ |
+| FancyzonesRestoreSize | Boolean | Restore the original size of windows when unsnapping. | ✅ |
+| FancyzonesQuickLayoutSwitch | Boolean | Enable quick layout switch. | ✅ |
+| FancyzonesFlashZonesOnQuickSwitch | Boolean | Flash zones when switching layout. | ✅ |
+| UseCursorposEditorStartupscreen | Boolean | Open editor on the display where the mouse point is. | ✅ |
+| FancyzonesShowOnAllMonitors | Boolean | Show zones on all monitors while dragging a window. | ✅ |
+| FancyzonesSpanZonesAcrossMonitors | Boolean | Allow zones to span across monitors. | ✅ |
+| FancyzonesMakeDraggedWindowTransparent | Boolean | Make dragged window transparent. | ✅ |
+| FancyzonesAllowChildWindowSnap | Boolean | Allow child windows snapping. | ✅ |
+| FancyzonesDisableRoundCornersOnSnap | Boolean | Disable round corners when window is snapped. | ✅ |
 | FancyzonesZoneHighlightColor | String | If not using FancyzonesSystemTheme, highlight color to use in `#FFFFFFFF` format. | ✅ |
 | FancyzonesHighlightOpacity | Int | Zone opacity in percentage. | ✅ |
 | FancyzonesEditorHotkey | KeyboardKeys | Customize the shortcut to activate this module. | ✅ |
-| FancyzonesWindowSwitching | Bool | Switch between windows in the current zone. | ✅ |
+| FancyzonesWindowSwitching | Boolean | Switch between windows in the current zone. | ✅ |
 | FancyzonesNextTabHotkey | KeyboardKeys | Next window shortcut. | ✅ |
 | FancyzonesPrevTabHotkey | KeyboardKeys | Previous window shortcut. | ✅ |
 | FancyzonesExcludedApps | String | '\r'-separated list of executable names to exclude from snapping. | ✅ |
 | FancyzonesBorderColor | String | If not using FancyzonesSystemTheme, border color to use in `#FFFFFFFF` format. | ✅ |
 | FancyzonesInActiveColor | String | If not using FancyzonesSystemTheme, inactive color to use in `#FFFFFFFF` format. | ✅ |
 | FancyzonesNumberColor | String | If not using FancyzonesSystemTheme, number color to use in `#FFFFFFFF` format. | ✅ |
-| FancyzonesSystemTheme | Bool | Whether to use system theme for zone appearance. | ✅ |
-| FancyzonesShowZoneNumber | Bool | Whether to show zone number. | ✅ |
+| FancyzonesSystemTheme | Boolean | Use system theme for zone appearance. | ✅ |
+| FancyzonesShowZoneNumber | Boolean | Show zone number. | ✅ |
 
 > [!NOTE]
 > Configuring layouts through DSC is not yet supported.
@@ -172,17 +172,17 @@ This command installs the latest version of PowerToys and uses the PowerToysConf
 
 | Name | Type | Description | Available |
 | :--- | :--- | :--- | :--- |
-| Enabled | Bool | The enabled state for this utility. | ✅ |
-| ExtendedContextMenuOnly | Bool | Show File Locksmith in extended context menu only or in default context menu as well. | ✅ |
+| Enabled | Boolean | The enabled state for this utility. | ✅ |
+| ExtendedContextMenuOnly | Boolean | Show File Locksmith in extended context menu only or in default context menu as well. | ✅ |
 
 ### FindMyMouse
 
 | Name | Type | Description | Available |
 | :--- | :--- | :--- | :--- |
-| Enabled | Bool | The enabled state for this utility. | ✅ |
+| Enabled | Boolean | The enabled state for this utility. | ✅ |
 | ActivationMethod | Int | Activation method index. | ✅ |
 | ActivationShortcut | HotkeySettings | Custom activation shortcut when using Custom for ActivationMethod. | ✅ |
-| DoNotActivateOnGameMode | Bool | Disable activation shortcut when Game Mode is on. | ✅ |
+| DoNotActivateOnGameMode | Boolean | Disable activation shortcut when Game Mode is on. | ✅ |
 | BackgroundColor | String | Background color in `#FFFFFFFF` format. | ✅ |
 | SpotlightColor | String | Spotlight color in `#FFFFFFFF` format. | ✅ |
 | OverlayOpacity | Int | Overlay opacity in percentage. | ✅ |
@@ -198,8 +198,8 @@ This command installs the latest version of PowerToys and uses the PowerToysConf
 
 | Name | Type | Description | Available |
 | :--- | :--- | :--- | :--- |
-| Enabled | Bool | The enabled state for this utility. | ✅ |
-| LaunchAdministrator | Boolean | Needs to be launched as administrator in order to make changes to the system environment variables. | ✅ |
+| Enabled | Boolean | The enabled state for this utility. | ✅ |
+| LaunchAdministrator | Boolean | Needs to be opened as administrator in order to make changes to the system environment variables. | ✅ |
 | ShowStartupWarning | Boolean | Show a warning at startup. | ✅ |
 | LoopbackDuplicates | Boolean | Consider loopback addresses as duplicates. | ✅ |
 | AdditionalLinesPosition | HostsAdditionalLinesPosition | Possible values: Top, Bottom. | ✅ |
@@ -209,33 +209,33 @@ This command installs the latest version of PowerToys and uses the PowerToysConf
 
 | Name | Type | Description | Available |
 | :--- | :--- | :--- | :--- |
-| Enabled | Bool | The enabled state for this utility. | ✅ |
+| Enabled | Boolean | The enabled state for this utility. | ✅ |
 | ImageresizerSelectedSizeIndex | Int | Default size preset index. | ✅ |
-| ImageresizerShrinkOnly | Bool | Make pictures smaller but not larger. | ✅ |
-| ImageresizerReplace | Bool | Overwrite files. | ✅ |
-| ImageresizerIgnoreOrientation | Bool | Ignore the orientation of pictures. | ✅ |
+| ImageresizerShrinkOnly | Boolean | Make pictures smaller but not larger. | ✅ |
+| ImageresizerReplace | Boolean | Overwrite files. | ✅ |
+| ImageresizerIgnoreOrientation | Boolean | Ignore the orientation of pictures. | ✅ |
 | ImageresizerJpegQualityLevel | Int | JPEG quality level in percentage. | ✅ |
 | ImageresizerPngInterlaceOption | Int | PNG interlacing option index. | ✅ |
 | ImageresizerTiffCompressOption | Int | Tiff compression index. | ✅ |
 | ImageresizerFileName | String | This format is used as the filename for resized images.  | ✅ |
 | ImageresizerSizes | — | — | ❌ |
-| ImageresizerKeepDateModified | Bool | Remove metadata that doesn't affect rendering. | ✅ |
+| ImageresizerKeepDateModified | Boolean | Remove metadata that doesn't affect rendering. | ✅ |
 | ImageresizerFallbackEncoder | String | Fallback encoder to use. | ✅ |
 | ImageresizerCustomSize | — | — | ❌ |
 
 > [!NOTE]
-> Configuring custom sizes through DSC is not supported yet.
+> Configuring custom sizes through DSC is not yet supported.
 
 ### KeyboardManager
 
 | Name | Type | Description | Available |
 | :--- | :--- | :--- | :--- |
-| Enabled | Bool | The enabled state for this utility. | ✅ |
+| Enabled | Boolean | The enabled state for this utility. | ✅ |
 | ActiveConfiguration | — | — | ❌ |
 | KeyboardConfigurations | — | — | ❌ |
 
 > [!NOTE]
-> Configuring remappings through DSC is not supported yet.
+> Configuring remappings through DSC is not yet supported.
 
 ### MeasureTool
 
@@ -243,7 +243,7 @@ Measure Tool is the internal name for Screen Ruler.
 
 | Name | Type | Description | Available |
 | :--- | :--- | :--- | :--- |
-| Enabled | Bool | The enabled state for this utility. | ✅ |
+| Enabled | Boolean | The enabled state for this utility. | ✅ |
 | ActivationShortcut | HotkeySettings | Customize the shortcut to bring up the command bar. | ✅ |
 | ContinuousCapture | Boolean | Capture screen continuously during measuring. | ✅ |
 | DrawFeetOnCross | Boolean | Adds feet to the end of cross lines. | ✅ |
@@ -256,7 +256,7 @@ Measure Tool is the internal name for Screen Ruler.
 
 | Name | Type | Description | Available |
 | :--- | :--- | :--- | :--- |
-| Enabled | Bool | The enabled state for this utility. | ✅ |
+| Enabled | Boolean | The enabled state for this utility. | ✅ |
 | ActivationShortcut | HotkeySettings | Customize the shortcut to turn on or off this mode. | ✅ |
 | LeftButtonClickColor | String | Primary button highlight color in `#FFFFFFFF` format. | ✅ |
 | RightButtonClickColor | String | Secondary button highlight color in `#FFFFFFFF` format. | ✅ |
@@ -264,13 +264,13 @@ Measure Tool is the internal name for Screen Ruler.
 | HighlightRadius | Int | Highlight radius in pixels. | ✅ |
 | HighlightFadeDelayMs | Int | Fade delay in milliseconds. | ✅ |
 | HighlightFadeDurationMs | Int | Fade duration in milliseconds. | ✅ |
-| AutoActivate | Bool | Automatically activate on utility startup. | ✅ |
+| AutoActivate | Boolean | Automatically activate on utility startup. | ✅ |
 
 ### MouseJump
 
 | Name | Type | Description | Available |
 | :--- | :--- | :--- | :--- |
-| Enabled | Bool | The enabled state for this utility. | ✅ |
+| Enabled | Boolean | The enabled state for this utility. | ✅ |
 | ActivationShortcut | HotkeySettings | Customize the shortcut to turn on or off this mode. | ✅ |
 | ThumbnailSize | MouseJumpThumbnailSize | Thumbnail size. | ✅ |
 
@@ -278,7 +278,7 @@ Measure Tool is the internal name for Screen Ruler.
 
 | Name | Type | Description | Available |
 | :--- | :--- | :--- | :--- |
-| Enabled | Bool | The enabled state for this utility. | ✅ |
+| Enabled | Boolean | The enabled state for this utility. | ✅ |
 | ActivationShortcut | HotkeySettings | Customize the shortcut to show/hide the crosshairs. | ✅ |
 | CrosshairsColor | String | Crosshairs color in `#FFFFFFFF`. | ✅ |
 | CrosshairsOpacity | Int | Crosshairs opacity in percentage. | ✅ |
@@ -286,16 +286,16 @@ Measure Tool is the internal name for Screen Ruler.
 | CrosshairsThickness | Int | Crosshairs thickness in pixels. | ✅ |
 | CrosshairsBorderColor | String | Crosshairs border color in `#FFFFFFFF` format. | ✅ |
 | CrosshairsBorderSize | Int | Crosshairs border size in pixels. | ✅ |
-| CrosshairsAutoHide | Bool | Automatically hide crosshairs when the mouse pointer is hidden. | ✅ |
-| CrosshairsIsFixedLengthEnabled | Bool | Fix crosshairs length. | ✅ |
+| CrosshairsAutoHide | Boolean | Automatically hide crosshairs when the mouse pointer is hidden. | ✅ |
+| CrosshairsIsFixedLengthEnabled | Boolean | Fix crosshairs length. | ✅ |
 | CrosshairsFixedLength | Int | Crosshairs fixed length in pixels. | ✅ |
-| AutoActivate | Bool | Automatically activate on utility startup. | ✅ |
+| AutoActivate | Boolean | Automatically activate on utility startup. | ✅ |
 
 ### MouseWithoutBorders
 
 | Name | Type | Description | Available |
 | :--- | :--- | :--- | :--- |
-| Enabled | Bool | The enabled state for this utility. | ✅ |
+| Enabled | Boolean | The enabled state for this utility. | ✅ |
 | ShowOriginalUI | Boolean | Show the original Mouse Without Borders UI. | ✅ |
 | WrapMouse | Boolean | Move control back to the first machine when mouse moves past the last one. | ✅ |
 | ShareClipboard | Boolean | If share clipboard stops working, Ctrl+Alt+Del then Esc may solve the problem. | ✅ |
@@ -320,17 +320,17 @@ Measure Tool is the internal name for Screen Ruler.
 
 | Name | Type | Description | Available |
 | :--- | :--- | :--- | :--- |
-| Enabled | Bool | The enabled state for this utility. | ✅ |
+| Enabled | Boolean | The enabled state for this utility. | ✅ |
 | ActivationShortcut | HotkeySettings | Customize the shortcut to activate this module. | ✅ |
 
 ### Peek
 
 | Name | Type | Description | Available |
 | :--- | :--- | :--- | :--- |
-| Enabled | Bool | The enabled state for this utility. | ✅ |
+| Enabled | Boolean | The enabled state for this utility. | ✅ |
 | ActivationShortcut | HotkeySettings | Customize the shortcut to activate this module. | ✅ |
-| AlwaysRunNotElevated | Bool | Always run not elevated, even when PowerToys is elevated. | ✅ |
-| CloseAfterLosingFocus | Bool | Automatically close the Peek window after it loses focus. | ✅ |
+| AlwaysRunNotElevated | Boolean | Always run not elevated, even when PowerToys is elevated. | ✅ |
+| CloseAfterLosingFocus | Boolean | Automatically close the Peek window after it loses focus. | ✅ |
 
 ### PowerAccent
 
@@ -338,7 +338,7 @@ PowerAccent is the internal name for Quick Accent.
 
 | Name | Type | Description | Available |
 | :--- | :--- | :--- | :--- |
-| Enabled | Bool | The enabled state for this utility. | ✅ |
+| Enabled | Boolean | The enabled state for this utility. | ✅ |
 | ActivationKey | PowerAccentActivationKey | Possible values: LeftRightArrow, Space, Both. | ✅ |
 | DoNotActivateOnGameMode | Boolean | Disable activation shortcut when Game Mode is on. | ✅ |
 | ToolbarPosition | String | Toolbar position index. | ✅ |
@@ -355,10 +355,10 @@ PowerLaucher is the internal name for PowerToys Run.
 
 | Name | Type | Description | Available |
 | :--- | :--- | :--- | :--- |
-| Enabled | Bool | The enabled state for this utility. | ✅ |
+| Enabled | Boolean | The enabled state for this utility. | ✅ |
 | OpenPowerLauncher | HotkeySettings | Customize the shortcut to activate the module. | ✅ |
 | IgnoreHotkeysInFullscreen | Boolean | Ignore shortcuts in fullscreen mode. | ✅ |
-| ClearInputOnLaunch | Boolean | Clear the previous query on launch. | ✅ |
+| ClearInputOnLaunch | Boolean | Clear the previous query on open. | ✅ |
 | TabSelectsContextButtons | Boolean | Tab through context buttons. | ✅ |
 | Theme | Theme | Possible values: System, Light, Dark, HighContrastOne, HighContrastTwo, HighContrastBlack, HighContrastWhite. | ✅ |
 | TitleFontSize | Int32 | Text size in points. | ✅ |
@@ -372,25 +372,25 @@ PowerLaucher is the internal name for PowerToys Run.
 | SearchWaitForSlowResults | Boolean | Wait for slower plugin results before selecting top item in results. | ✅ |
 | MaximumNumberOfResults | Int | Number of results shown before having to scroll. | ✅ |
 | UsePinyin | Boolean | Use Pinyin. | ✅ |
-| GenerateThumbnailsFromFiles | Boolean | Whether thumbnail generation for files is turned on. | ✅ |
-| Plugins | explained in the next subsection | Whether thumbnail generation for files is turned on. | ✅ |
+| GenerateThumbnailsFromFiles | Boolean | Thumbnail generation for files is turned on. | ✅ |
+| Plugins | explained in the next subsection | Thumbnail generation for files is turned on. | ✅ |
 
 #### PowerToys Run plugins
 
-PowerToys Run plugins can be configured in the Plugins property. [A sample can be found in the PowerToys repository.](https://github.com/microsoft/PowerToys/blob/main/src/dsc/Microsoft.PowerToys.Configure/examples/configureLauncherPlugins.dsc.yaml)
+PowerToys Run plugins can be configured in the Plugins property. [A sample](https://github.com/microsoft/PowerToys/blob/main/src/dsc/Microsoft.PowerToys.Configure/examples/configureLauncherPlugins.dsc.yaml) can be found in the PowerToys repository.
 
 These are the available properties to configure each plugin:
 
 | Name | Type | Description |
 | :--- | :--- | :--- |
 | Name | String | Name of the plugin we want to configure |
-| Disabled | Boolean | Whether the plugin should be disabled |
-| IsGlobal | Boolean | Whether the results for this plugin are shown in the global results |
+| Disabled | Boolean | The plugin should be disabled |
+| IsGlobal | Boolean | The results for this plugin are shown in the global results |
 | ActionKeyword | String | Configure the action keyword of the plugin |
 | WeightBoost | Int | The weight modifier to help in ordering the results for this plugin |
 
 > [!NOTE]
-> Configuring additional properties of plugins is not yet supported through DSC.
+> Configuring additional properties of plugins through DSC is not yet supported.
 
 ### PowerOcr
 
@@ -398,7 +398,7 @@ PowerOcr is the internal name for Text Extractor.
 
 | Name | Type | Description | Available |
 | :--- | :--- | :--- | :--- |
-| Enabled | Bool | The enabled state for this utility. | ✅ |
+| Enabled | Boolean | The enabled state for this utility. | ✅ |
 | ActivationShortcut | HotkeySettings | Customize the shortcut to activate this module. | ✅ |
 | PreferredLanguage | String | Should match the full name of one of the languages installed in the system. Example: "English (United States)". | ✅ |
 
@@ -429,27 +429,27 @@ PowerOcr is the internal name for Text Extractor.
 
 | Name | Type | Description | Available |
 | :--- | :--- | :--- | :--- |
-| Enabled | Bool | The enabled state for this utility. | ✅ |
-| MRUEnabled | Bool | Enable auto-complete for the search & replace fields. | ✅ |
+| Enabled | Boolean | The enabled state for this utility. | ✅ |
+| MRUEnabled | Boolean | Enable auto-complete for the search & replace fields. | ✅ |
 | MaxMRUSize | Int | Maximum number of recently used items to remember. | ✅ |
-| ExtendedContextMenuOnly | Bool | Show PowerRename in extended context menu only or in default context menu as well. | ✅ |
-| UseBoostLib | Bool | Use Boost Library. | ✅ |
+| ExtendedContextMenuOnly | Boolean | Show PowerRename in extended context menu only or in default context menu as well. | ✅ |
+| UseBoostLib | Boolean | Use Boost Library. | ✅ |
 
 ### RegistryPreview
 
 | Name | Type | Description | Available |
 | :--- | :--- | :--- | :--- |
-| Enabled | Bool | The enabled state for this utility. | ✅ |
+| Enabled | Boolean | The enabled state for this utility. | ✅ |
 | DefaultRegApp | Boolean | Make Registry Preview default app for opening .reg files. | ✅ |
 
 ### ShortcutGuide
 
 | Name | Type | Description | Available |
 | :--- | :--- | :--- | :--- |
-| Enabled | Bool | The enabled state for this utility. | ✅ |
+| Enabled | Boolean | The enabled state for this utility. | ✅ |
 | OpenShortcutGuide | HotkeySettings | Customize the shortcut to activate this module. | ✅ |
 | OverlayOpacity | Int | Background opacity in percentage. | ✅ |
-| UseLegacyPressWinKeyBehavior | Bool | If ShortcutGuide should be activated by pressing the Windows key. | ✅ |
+| UseLegacyPressWinKeyBehavior | Boolean | If ShortcutGuide should be activated by pressing the Windows key. | ✅ |
 | PressTimeForGlobalWindowsShortcuts | Int | Press duration before showing global Windows shortcuts in milliseconds. | ✅ |
 | PressTimeForTaskbarIconShortcuts | Int | Press duration before showing taskbar icon shortcuts in milliseconds. | ✅ |
 | Theme | String | Theme index. | ✅ |
@@ -459,11 +459,11 @@ PowerOcr is the internal name for Text Extractor.
 
 | Name | Type | Description | Available |
 | :--- | :--- | :--- | :--- |
-| Enabled | Bool | The enabled state for this utility. | ✅ |
+| Enabled | Boolean | The enabled state for this utility. | ✅ |
 | MuteCameraAndMicrophoneHotkey | KeyboardKeys | Shortcut for muting the camera and microphone. | ✅ |
 | MuteMicrophoneHotkey | KeyboardKeys | Shortcut for muting the microphone. | ✅ |
 | PushToTalkMicrophoneHotkey | KeyboardKeys | Shortcut for push to talk. | ✅ |
-| PushToReverseEnabled | Bool | If enabled, allows both push to talk and push to mute, depending on microphone state. | ✅ |
+| PushToReverseEnabled | Boolean | If enabled, allows both push to talk and push to mute, depending on microphone state. | ✅ |
 | MuteCameraHotkey | KeyboardKeys | Shortcut for muting the camera. | ✅ |
 | SelectedCamera | String | Device name. | ✅ |
 | SelectedMicrophone | String | Device name or [All]. | ✅ |
@@ -477,13 +477,13 @@ PowerOcr is the internal name for Text Extractor.
 
 | Name | Type | Description | Available |
 | :--- | :--- | :--- | :--- |
-| Startup | Boolean | Whether PowerToys is automatically enabled at startup. | ✅ |
+| Startup | Boolean | PowerToys is automatically enabled at startup. | ✅ |
 | EnableWarningsElevatedApps | Boolean | Show a warning for functionality issues when running alongside elevated applications. | ✅ |
 | Theme | String | What theme to use for the Settings application: "system", "dark", "light". | ✅ |
 | ShowNewUpdatesToastNotification | Boolean | Show a toast notification when a new PowerToys update is available. | ✅ |
 | AutoDownloadUpdates | Boolean | If new updates of PowerToys should be automatically downloaded in the background. | ✅ |
 | ShowWhatsNewAfterUpdates | Boolean | After updating PowerToys, open the "What's new" screen. | ✅ |
-| EnableExperimentation | Boolean | Whether to opt-in into experimental features. | ✅ |
+| EnableExperimentation | Boolean | Opt-in into experimental features. | ✅ |
 
 ## Contributing
 

--- a/hub/powertoys/environment-variables.md
+++ b/hub/powertoys/environment-variables.md
@@ -10,13 +10,13 @@ no-loc: [PowerToys, Windows, Environment Variables, Win]
 
 Environment Variables offers an easy and convenient way to manage environment variables. It also allows you to create profiles for managing a set of variables together. Profile variables have precedence over User and System variables. Applying the profile adds variables to User environment variables in the background. When a profile is applied, if there is an existing User variable with the same name, a backup variable is created in User variables which will be reverted to the original value on profile un-apply.
 
-Applied variables list shows the current state of the environment, respecting the order of evaluation of environment variables (Profile -> User -> System). Evaluated Path variable value is shown at the top of the list. 
+Applied variables list shows the current state of the environment, respecting the order of evaluation of environment variables (Profile > User > System). Evaluated Path variable value is shown at the top of the list.
 
-![PowerToys Environment Variables screenshot.](../images/powertoys-environment-variables.png)
+![PowerToys Environment Variables screenshot](../images/powertoys-environment-variables.png)
 
 ## Edit/Remove variable
 
-To edit or remove a variable (profile, User or System), select the more options button (**•••**) on the desired variable:
+To edit or remove a variable (profile, User or System), select the **more** button (•••) on the desired variable:
 
 ![PowerToys Environment Variables: Edit/Remove variable](../images/powertoys-environment-variables-edit-variable.gif)
 
@@ -26,17 +26,17 @@ To add a new profile:
 
  - Select **New profile**
  - Enter profile name
- - Set Enabled toggle to On to apply the profile right after creation
- - Select **Add variable** to add variables to profile (either new variable or existing User/System variables).
+ - Set **Enabled** toggle to On to apply the profile right after creation
+ - Select **Add variable** to add variables to profile (either new variable or existing User/System variables)
  - Select **Save**
 
 ![PowerToys Environment Variables: Add profile](../images/powertoys-environment-variables-add-profile.gif)
 
-To edit or remove a profile, select the more options button (**•••**) on the desired profile.
+To edit or remove a profile, select the **more** button (•••) on the desired profile.
 
 ## Apply profile
 
-To apply a profile, set the profile toggle to On. Only one profile can be applied at a time. The Applied variables list will show applied profile variables at the top (below Path variable):
+To apply a profile, set the **profile** toggle to On. Only one profile can be applied at a time. The Applied variables list will show applied profile variables at the top (below Path variable):
 
 ![PowerToys Environment Variables: Apply profile](../images/powertoys-environment-variables-apply-profile.gif)
 
@@ -46,4 +46,4 @@ From the Settings menu, the following options can be configured:
 
 | Setting | Description |
 | :--- | :--- |
-| Launch as administrator | Launch as administrator allow management of System variables. If disabled, only profile and User variables can be modified. Environment Variables is started as administrator by default. |
+| Open as administrator | Allow management of System variables. If disabled, only profile and User variables can be modified. Environment Variables is opened as administrator by default. |

--- a/hub/powertoys/fancyzones.md
+++ b/hub/powertoys/fancyzones.md
@@ -74,7 +74,7 @@ FancyZones includes an editor to give you more control over your window layouts 
 
 ### Open the layout editor
 
-Open the layout editor by selecting **Launch layout editor** or by <kbd>Win</kbd>+<kbd>Shift</kbd>+<kbd>`</kbd> ("back-tick" or "accent grave"). You can change the FancyZones layout editor shortcut in PowerToys Settings.
+Open the layout editor by selecting **Launch layout editor** or with <kbd>Win</kbd>+<kbd>Shift</kbd>+<kbd>`</kbd> ("back-tick" or "accent grave"). You can change the FancyZones layout editor shortcut in PowerToys Settings.
 
 ![FancyZones Settings UI](../images/pt-fancyzones-settings.png)
 

--- a/hub/powertoys/fancyzones.md
+++ b/hub/powertoys/fancyzones.md
@@ -9,7 +9,8 @@ no-loc: [PowerToys, Windows, FancyZones, Fancy, Zone, Zones, Win]
 
 # FancyZones utility
 
-FancyZones is a window manager utility for arranging and snapping windows into efficient layouts to improve your workflow and restore layouts quickly. You can define a set of zone locations to use as targets for windows on your desktop. When you drag a window into a zone, or enter the associated keyboard shortcut, the window is resized and repositioned to fill that zone.
+FancyZones is a window manager utility for arranging and snapping windows into efficient layouts to improve your workflow and restore layouts quickly.
+You can define a set of zone locations to use as targets for windows on your desktop. When you drag a window into a zone, or enter the associated keyboard shortcut, the window is resized and repositioned to fill that zone.
 
 ## Snapping to a single zone with mouse
 
@@ -19,13 +20,13 @@ You can also trigger zone selection mode by using a non-primary mouse button if 
 
 If both **Hold Shift key to activate zones while dragging** and **Use non-primary mouse button to toggle zone activation** are cleared, zones will appear immediately after you start dragging the window.
 
-![FancyZones in action screenshot.](../images/pt-fancy-zones2.png)
+![FancyZones in action screenshot](../images/pt-fancy-zones2.png)
 
 ## Snapping to a single zone with keyboard
 
 Select **Override Windows Snap** in the FancyZones settings. Use <kbd>Win</kbd>+[arrow keys] to snap a window to a zone. Use **Move windows based on** to choose whether to move windows based the zone index or a window's relative position.
 
-![Settings for Snapping to Multiple Zones via Keyboard.](../images/pt-window-snap-multiple-zones-w-keyboard-settings.png)
+![Settings for Snapping to Multiple Zones via Keyboard](../images/pt-window-snap-multiple-zones-w-keyboard-settings.png)
 
 ## Snapping to multiple zones
 
@@ -39,23 +40,23 @@ If two zones are adjacent, you can snap a window to the sum of their area (round
 
 Drag the window until one zone is activated, then press and hold the <kbd>Ctrl</kbd> key while dragging the window to select multiple zones.
 
-![Two Zones Activation screenshot.](../images/pt-fancyzones-twozones.png)
+![Two Zones Activation screenshot](../images/pt-fancyzones-twozones.png)
 
 ### Snapping to multiple zones with only the keyboard
 
 Turn on the **Override Windows Snap** toggle and select **Move windows based on: Relative position**. Use <kbd>Win</kbd>+<kbd>Ctrl</kbd>+<kbd>Alt</kbd>+[arrow keys] to expand the window to multiple zones.
 
-![Settings for Snapping to Multiple Zones via Keyboard.](../images/pt-window-snap-multiple-zones-w-keyboard-settings.png)
+![Settings for Snapping to Multiple Zones via Keyboard](../images/pt-window-snap-multiple-zones-w-keyboard-settings.png)
 
 ### Window switching
 
-When two or more windows are snapped in the same zone, you can cycle between the snapped windows in that zone by using the shortcut <kbd>Win</kbd>+<kbd>PgUp/PgDn</kbd>.
+When two or more windows are snapped in the same zone, cycle between the snapped windows in that zone by using the shortcut <kbd>Win</kbd>+<kbd>PgUp/PgDn</kbd>.
 
 ### Shortcut keys
 
 | Shortcut | Action |
 | --- | --- |
-| <kbd>⊞ Win</kbd>+<kbd>Shift</kbd>+<kbd>\`</kbd> | Launches the editor (this shortcut can be changed in the Settings window) |
+| <kbd>⊞ Win</kbd>+<kbd>Shift</kbd>+<kbd>\`</kbd> | Opens the editor (this shortcut can be changed in the Settings window) |
 | <kbd>⊞ Win</kbd>+<kbd>Left/Right</kbd> | Move focused window between zones (only if **Override Windows Snap hotkeys** is selected and **Zone index** is chosen; in that case only the <kbd>⊞ Win</kbd>+<kbd>Left</kbd> and <kbd>⊞ Win</kbd>+<kbd>Right</kbd> are overridden, while the <kbd>⊞ Win</kbd>+<kbd>Up</kbd> and <kbd>⊞ Win</kbd>+<kbd>Down</kbd> keep working as usual) |
 | <kbd>⊞ Win</kbd>+<kbd>Left/Right/Up/Down</kbd> | Move focused window between zones (only if **Override Windows Snap hotkeys** is selected and **Relative position** is chosen; in that case all the <kbd>⊞ Win</kbd>+<kbd>Left</kbd>, <kbd>⊞ Win</kbd>+<kbd>Right</kbd>, <kbd>⊞ Win</kbd>+<kbd>Up</kbd> and <kbd>⊞ Win</kbd>+<kbd>Down</kbd> are overridden) |
 | <kbd>⊞ Win</kbd>+<kbd>PgUp/PgDn</kbd> | Cycle between windows snapped to the same zone |
@@ -73,15 +74,15 @@ FancyZones includes an editor to give you more control over your window layouts 
 
 ### Open the layout editor
 
-Open the layout editor by selecting **Launch layout editor** or by pressing <kbd>Win</kbd>+<kbd>Shift</kbd>+<kbd>`</kbd> ("back-tick" or "accent grave"). You can change the FancyZones layout editor shortcut in PowerToys Settings.
+Open the layout editor by selecting **Launch layout editor** or by <kbd>Win</kbd>+<kbd>Shift</kbd>+<kbd>`</kbd> ("back-tick" or "accent grave"). You can change the FancyZones layout editor shortcut in PowerToys Settings.
 
-![FancyZones Settings UI.](../images/pt-fancyzones-settings.png)
+![FancyZones Settings UI](../images/pt-fancyzones-settings.png)
 
 ### Layout Editor: Choose your layout
 
-When you first launch the layout editor, you'll see a list of layouts that can be adjusted by how many windows are on the monitor. Selecting a layout shows a preview of that layout on the screen. The selected layout is applied automatically. Double-clicking a layout will apply it and close the editor. The editor will detect and display the available monitors. Select a monitor, and it becomes the target of the selected layout.
+When you first open the layout editor, you'll see a list of layouts that can be adjusted by how many windows are on the monitor. Selecting a layout shows a preview of that layout on the screen. The selected layout is applied automatically. Double-clicking a layout will apply it and close the editor. The editor will detect and display the available monitors. Select a monitor, and it becomes the target of the selected layout.
 
-![FancyZones Picker Multiple Monitors.](../images/pt-fancyzones-multimon.png)
+![FancyZones Picker Multiple Monitors](../images/pt-fancyzones-multimon.png)
 
 #### Space around zones
 
@@ -91,15 +92,15 @@ When you first launch the layout editor, you'll see a list of layouts that can b
 
 **Default layout for horizontal monitor orientation** and **Default layout for vertical monitor orientation** set which layout to use as the default when the display configuration is changed in the system (for example, if you add a new display).
 
-![FancyZones space around zones screenshot.](../images/pt-fancyzones-spacearound.png)
+![FancyZones space around zones screenshot](../images/pt-fancyzones-spacearound.png)
 
 ### Creating a custom layout
 
-Select **+ Create new layout** at the bottom.
+Select **Create new layout** at the bottom.
 
 There are two styles of custom zone layouts: **Grid** and **Canvas**.
 
-The **Grid** model starts with a three column grid and allows zones to be created by splitting and merging zones, moving the gutter between zones as desired. This is a relative layout and will resize with different screen sizes. You can edit the layout using mouse or using keyboard.
+The **Grid** model starts with a three column grid and allows zones to be created by splitting and merging zones, moving the gutter between zones as desired. This is a relative layout and will resize with different screen sizes. You can edit the layout using mouse or keyboard.
 
 #### Mouse
 
@@ -114,24 +115,24 @@ The **Grid** model starts with a three column grid and allows zones to be create
 - To move a divider: focus the divider and press arrow keys to move it.
 - To merge/delete zones: focus the divider between zones and press <kbd>Delete</kbd>. All zones adjacent to deleted divider will be merged into one zone.
 
-![FancyZones Table Editor Mode.](../images/pt-fancyzones-grideditor.png)
+![FancyZones Table Editor Mode](../images/pt-fancyzones-grideditor.png)
 
 The **Canvas** model starts with one zone and supports adding zones that can be moved and resized, similar to windows. Zones in the canvas model may be overlapping.
 
 Canvas layout also has keyboard support for zone editing. Use the arrow keys (Left, Right, Up, Down) to move a zone by 10 pixels, or <kbd>Ctrl</kbd>+arrow to move a zone by 1 pixel. Use the <kbd>Shift</kbd>+arrow keys to resize a zone by 10 pixels (5 per edge), or <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+arrow to resize a zone by 2 pixels (1 per edge). To switch between the editor and dialog, press the <kbd>Ctrl</kbd>+<kbd>Tab</kbd> keys.
 
-![FancyZones Window Editor Mode.](../images/pt-fancyzones-canvaseditor.png)
+![FancyZones Window Editor Mode](../images/pt-fancyzones-canvaseditor.png)
 
 ### Quickly changing between custom layouts
 
 > [!NOTE]
-> Turn on the **Enable quick layout switch** toggle to use this feature.
+> Select **Enable quick layout switch** to use this feature.
 
 A custom layout can be configured to have a user-defined hotkey to quickly apply it to the active screen. The hotkey can be set by opening the custom layout's edit dialog. Once set, the custom layout can be applied by pressing the <kbd>Win</kbd>+<kbd>Ctrl</kbd>+<kbd>Alt</kbd>+[number] binding. The layout can also be applied by pressing the hotkey when dragging a window.
 
 In the demo below, we start with a default template applied to the screen and two custom layouts that we assign hotkeys for. We then use the <kbd>Win</kbd>+<kbd>Ctrl</kbd>+<kbd>Alt</kbd>+[number] binding to apply the first custom layout and snap a window to it. Finally, we apply the second custom layout while dragging a window and snap the window to it.
 
-![FancyZones Quick-Swap Layouts settings and usage.](../images/pt-fancyzones-quickswap.gif)
+![FancyZones Quick-Swap Layouts settings and usage](../images/pt-fancyzones-quickswap.gif)
 
 > [!TIP]
 > The settings for custom zone layouts are saved in the file `%LocalAppData%\Microsoft\PowerToys\FancyZones\custom-layouts.json`. This file can be manually changed to tweak zones, and exported to share layouts across devices. Other json files in the same directory can be modified to alter settings for monitors, layout hotkeys, etc. Be warned that editing these files is not recommended as it may cause other issues with FancyZones functionality.
@@ -174,4 +175,4 @@ In the demo below, we start with a default template applied to the screen and tw
 | Flash zones when switching layout | The zones will flash when a layout is selected via the shortcut. |
 | Exclude applications from snapping to zones | Add an application's name, or part of the name, one per line (e.g. adding `Notepad` will match both `Notepad.exe` and `Notepad++.exe`; to match only `Notepad.exe` add the `.exe` extension) |
 
-![FancyZones Settings bottom screenshot.](../images/pt-fancyzones-settings2.png)
+![FancyZones Settings bottom screenshot](../images/pt-fancyzones-settings2.png)

--- a/hub/powertoys/file-explorer.md
+++ b/hub/powertoys/file-explorer.md
@@ -39,7 +39,7 @@ Expand the **Source code files (Monaco)** section to change the following settin
 
 To enable preview support, set the extension to **On**.
 
-![PowerToys Settings Enable File Explorer screenshot.](../images/powertoys-settings-fileexplorer.png)
+![PowerToys Settings Enable File Explorer screenshot](../images/powertoys-settings-fileexplorer.png)
 
 If the preview pane does not appear to work after setting the extension to **On**, there is an advanced setting in Windows that may be blocking the preview handler. Open the **Options** menu in Windows File Explorer and select the **View** tab. Under the **View** tab, you will see a list of **Advanced settings**. Ensure that **Show preview handlers in preview pane** has a check next to it in order for the preview pane to display.
 
@@ -47,13 +47,13 @@ If the preview pane does not appear to work after setting the extension to **On*
 
 Open Windows File Explorer, select the **View** menu in the Explorer ribbon. Hover over **Show**, and then select **Preview pane**.
 
-![PowerToys Preview Pane demo for Windows 11.](../images/powertoys-fileexplorer-win11.gif)
+![PowerToys Preview Pane demo for Windows 11](../images/powertoys-fileexplorer-win11.gif)
 
 ### Enabling the Explorer pane in Windows 10
 
 Open Windows File Explorer, select the **View** tab in the Explorer ribbon, and then select **Preview Pane**.
 
-![PowerToys Preview Pane demo for Windows 10.](../images/powertoys-fileexplorer.gif)
+![PowerToys Preview Pane demo for Windows 10](../images/powertoys-fileexplorer.gif)
 
 > [!NOTE]
 > It is not possible to change the background color of the preview pane, so if you are working with transparent images with white shapes, you may not be able to see them in the preview.

--- a/hub/powertoys/file-locksmith.md
+++ b/hub/powertoys/file-locksmith.md
@@ -10,15 +10,16 @@ no-loc: [PowerToys, Windows, File Locksmith, Win]
 
 File Locksmith is a Windows shell extension for checking which files are in use and by which processes.
 
-![File Locksmith Demo.](../images/powertoys-file-locksmith.gif)
+![File Locksmith Demo](../images/powertoys-file-locksmith.gif)
 
 ## How to activate and use File Locksmith
 
-To activate File Locksmith, open PowerToys and turn on the **Enable File Locksmith** toggle. Select one or more files or directories in Windows File Explorer. If a directory is selected, all of its files and subdirectories will be scanned as well. Right-click on the selected file(s), select **Show more options** from the menu to expand your list of menu options, then select **Unlock with File Locksmith** to open File Locksmith and see which processes are using the file(s).
+To activate File Locksmith, open PowerToys and turn on the **Enable File Locksmith** toggle. Select one or more files or directories in Windows File Explorer. If a directory is selected, all of its files and subdirectories will be scanned as well.
+Right-click on the selected file(s), select **Show more options** from the menu to expand the list of menu options, then select **Unlock with File Locksmith** to open File Locksmith and see which processes are using the file(s).
 
 When File Locksmith is activated, it will scan all of the running processes that it can access, checking which files the processes are using. Processes that are being run by a different user cannot be accessed and may be missing from the list of results. To scan all processes, select **Restart as administrator**.
 
-![Restart File Locksmith as administrator.](../images/powertoys-file-locksmith-restart-as-admin.png)
+![Restart File Locksmith as administrator](../images/powertoys-file-locksmith-restart-as-admin.png)
 
 After scanning, a list of processes will be displayed. Select **End task** to terminate the process, or select the expander to show more information.
 File Locksmith will automatically remove terminated processes from the list, whether or not this action was done via File Locksmith. To manually refresh the list of processes, select **Reload**.

--- a/hub/powertoys/general.md
+++ b/hub/powertoys/general.md
@@ -14,7 +14,7 @@ The general section of Microsoft PowerToys contains the following settings:
 
 ## Version
 
-Here you can check for new updates and if a new update is available, you can download and install it.
+Here you can check for new updates and if one is available, you can download and install it.
 
 You can set if updates should be downloaded automatically.
 
@@ -26,7 +26,7 @@ Read more about the administrator mode in the [PowerToys running with administra
 
 ### App theme
 
-Here you can set the theme of the PowerToys settings app and the PowerToys flyout. You can set it to Windows default, light or dark.
+Here you can set the theme of the PowerToys settings app and the PowerToys flyout: **Dark**, **Light**, or **Windows default**.
 
 ### Run at startup
 

--- a/hub/powertoys/grouppolicy.md
+++ b/hub/powertoys/grouppolicy.md
@@ -14,23 +14,23 @@ Since version 0.64, PowerToys is released on GitHub with Administrative Template
 
 ### Download
 
-You can find the latest administrative templates (ADMX files) in the assets section of our newest PowerToys release on <github.com/microsoft/PowerToys/releases>. The file is named `GroupPolicyObjectsFiles-<Version>.zip`.
+You can find the latest administrative templates (ADMX files) in the assets section of our newest PowerToys release on [GitHub](https://github.com/microsoft/PowerToys/releases). The file is named `GroupPolicyObjectsFiles-<Version>.zip`.
 
 ### Add the administrative template to an individual computer
 
-1. Copy the "PowerToys.admx" file to your Policy Definition template folder. (Example: C:\Windows\PolicyDefinitions)
-2. Copy the "PowerToys.adml" file to the matching language folder in your Policy Definition folder. (Example: C:\Windows\PolicyDefinitions\en-US)
+1. Copy the _PowerToys.admx_ file to your Policy Definition template folder. (Example: _C:\Windows\PolicyDefinitions_)
+2. Copy the _PowerToys.adml_ file to the matching language folder in your Policy Definition folder. (Example: _C:\Windows\PolicyDefinitions\en-US_)
 
 ### Add the administrative template to Active Directory
 
-1. On a domain controller or workstation with RSAT, go to the **PolicyDefinition** folder (also known as the *Central Store*) on any domain controller for your domain. For older versions of Windows Server, you might need to create the **PolicyDefinition** folder. For more information, see [How to create and manage the Central Store for Group Policy Administrative Templates in Windows](https://support.microsoft.com/help/3087759/how-to-create-and-manage-the-central-store-for-group-policy-administra).
-2. Copy the "PowerToys.admx" file to the PolicyDefinition folder. (Example: %systemroot%\sysvol\domain\policies\PolicyDefinitions)
-3. Copy the "PowerToys.adml" file to the matching language folder in the PolicyDefinition folder. Create the folder if it doesn't already exist. (Example: %systemroot%\sysvol\domain\policies\PolicyDefinitions\EN-US)
+1. On a domain controller or workstation with RSAT, go to the **PolicyDefinition** folder (also known as the _Central Store_) on any domain controller for your domain. For older versions of Windows Server, you might need to create the **PolicyDefinition** folder. For more information, see [How to create and manage the Central Store for Group Policy Administrative Templates in Windows](https://support.microsoft.com/help/3087759/how-to-create-and-manage-the-central-store-for-group-policy-administra).
+2. Copy the _PowerToys.admx_ file to the PolicyDefinition folder. (Example: _%systemroot%\sysvol\domain\policies\PolicyDefinitions_)
+3. Copy the _PowerToys.adml_ file to the matching language folder in the PolicyDefinition folder. Create the folder if it doesn't already exist. (Example: _%systemroot%\sysvol\domain\policies\PolicyDefinitions\EN-US_)
 4. If your domain has more than one domain controller, the new ADMX files will be replicated to them at the next domain replication interval.
 
 ### Import the administrative template in Intune
 
-You can find all instructions on how to import the administrative templates in Intune [here](/mem/intune/configuration/administrative-templates-import-custom#add-the-admx-and-adml-files).
+You can find all instructions on how to import the administrative templates in Intune on [this page](/mem/intune/configuration/administrative-templates-import-custom#add-the-admx-and-adml-files).
 
 ### Scope
 
@@ -44,7 +44,7 @@ The syntax of OMA-URI is the following: ./Device/Vendor/MSFT/Policy/Config/Power
 
 ### Configure global utility enabled state
 
-> Supported on PowerToys 0.75.0 or later.
+Supported on PowerToys 0.75.0 or later.
 
 This policy configures the enabled state for all PowerToys utilities.
 
@@ -60,7 +60,7 @@ The individual enabled state policies for the utilities will override this polic
 - GP name: Configure global utility enabled state
 - GP path: Administrative Templates/Microsoft PowerToys
 - GP scope: Computer and user
-- ADMX file name: PowerToys.admx
+- ADMX file name: _PowerToys.admx_
 
 #### Registry information
 
@@ -76,15 +76,15 @@ The individual enabled state policies for the utilities will override this polic
 
 ### Configure enabled state for individual utilities
 
-> Supported on PowerToys 0.64.0 or later depending on the utility.
+Supported on PowerToys 0.64.0 or later, depending on the utility.
 
 For each utility shipped with PowerToys, there's a "Configure enabled state" policy, which forces an enabled state for the utility.
 
-- If you enable this setting, the utility will be always enabled and the user won't be able to disable it.
-- If you disable this setting, the utility will be always disabled and the user won't be able to enable it.
+- If you enable this setting, the utility will be always enabled and the user won't be able to disable them.
+- If you disable this setting, the utility will be always disabled and the user won't be able to enable them.
 - If you don't configure this setting, users are able to enable or disable the utility.
 
-These policies have a higher priority than the policy "Configure global utility enabled state" and override it.
+These policies have a higher priority than, and will override, the policy "Configure global utility enabled state".
 
 > [!NOTE]
 > PDF file preview: There have been reports of incompatibility between the PDF Preview Handler and Outlook.
@@ -137,7 +137,7 @@ These policies have a higher priority than the policy "Configure global utility 
 - GP name: See the table above.
 - GP path: Administrative Templates/Microsoft PowerToys
 - GP scope: Computer and user
-- ADMX file name: PowerToys.admx
+- ADMX file name: _PowerToys.admx_
 
 #### Registry information
 
@@ -150,14 +150,14 @@ These policies have a higher priority than the policy "Configure global utility 
 
 - OMA-URI: `./Device/Vendor/MSFT/Policy/Config/PowerToys~Policy~PowerToys/<PolicyID>`
 
-    > [!Note]
-    > Please see the table above for the *PolicyID* value.
+> [!Note]
+> Please see the table above for the __PolicyID_ value.
 
 - Example value: `<disabled/>`
 
 ### Allow experimentation
 
-> Supported on PowerToys 0.68.0 or later.
+Supported on PowerToys 0.68.0 or later.
 
 This policy configures whether PowerToys experimentation is allowed. With experimentation allowed the user sees the new features being experimented if it gets selected as part of the test group. (Experimentation will only happen on Windows Insider builds.)
 
@@ -170,7 +170,7 @@ This policy configures whether PowerToys experimentation is allowed. With experi
 - GP name: Allow experimentation
 - GP path: Administrative Templates/Microsoft PowerToys
 - GP scope: Computer and user
-- ADMX file name: PowerToys.admx
+- ADMX file name: _PowerToys.admx_
 
 #### Registry information
 
@@ -188,7 +188,7 @@ This policy configures whether PowerToys experimentation is allowed. With experi
 
 #### Disable per-user installation
 
-> Supported on PowerToys 0.68.0 or later.
+Supported on PowerToys 0.68.0 or later.
 
 This policy configures whether PowerToys per-user installation is allowed or not.
 
@@ -204,7 +204,7 @@ This policy configures whether PowerToys per-user installation is allowed or not
 - GP name: Disable per-user installation
 - GP path: Administrative Templates/Microsoft PowerToys/Installer and Updates
 - GP scope: Computer only
-- ADMX file name: PowerToys.admx
+- ADMX file name: _PowerToys.admx_
 
 ##### Registry information
 
@@ -220,7 +220,7 @@ This policy configures whether PowerToys per-user installation is allowed or not
 
 #### Disable automatic downloads
 
-> Supported on PowerToys 0.68.0 or later.
+Supported on PowerToys 0.68.0 or later.
 
 This policy configures whether the automatic download and installation of available updates is disabled or not. (On metered connections updates are never downloaded.)
 
@@ -233,7 +233,7 @@ This policy configures whether the automatic download and installation of availa
 - GP name: Disable automatic downloads
 - GP path: Administrative Templates/Microsoft PowerToys/Installer and Updates
 - GP scope: Computer and user
-- ADMX file name: PowerToys.admx
+- ADMX file name: _PowerToys.admx_
 
 ##### Registry information
 
@@ -249,7 +249,7 @@ This policy configures whether the automatic download and installation of availa
 
 #### Suspend Action Center notification for new updates
 
-> Supported on PowerToys 0.68.0 or later.
+Supported on PowerToys 0.68.0 or later.
 
 This policy configures whether the action center notification for new updates is suspended for 2 minor releases. (Example: if the installed version is v0.60.0, then the next notification is shown for the v0.63.* release.)
 
@@ -265,7 +265,7 @@ This policy configures whether the action center notification for new updates is
 - GP name: Suspend Action Center notification for new updates
 - GP path: Administrative Templates/Microsoft PowerToys/Installer and Updates
 - GP scope: Computer and user
-- ADMX file name: PowerToys.admx
+- ADMX file name: _PowerToys.admx_
 
 ##### Registry information
 
@@ -281,7 +281,7 @@ This policy configures whether the action center notification for new updates is
 
 #### Disable Action Center notification for new updates
 
-> Supported on PowerToys 0.78.0 or later.
+Supported on PowerToys 0.78.0 or later.
 
 This policy configures whether the action center notification for new updates is shown or not.
 
@@ -294,7 +294,7 @@ This policy configures whether the action center notification for new updates is
 - GP name: Disable Action Center notification for new updates
 - GP path: Administrative Templates/Microsoft PowerToys/Installer and Updates
 - GP scope: Computer and user
-- ADMX file name: PowerToys.admx
+- ADMX file name: _PowerToys.admx_
 
 ##### Registry information
 
@@ -310,7 +310,7 @@ This policy configures whether the action center notification for new updates is
 
 #### Do not show the release notes after updates
 
-> Supported on PowerToys 0.78.0 or later.
+Supported on PowerToys 0.78.0 or later.
 
 This policy allows you to configure if the window with the release notes is shown after updates.
 
@@ -323,7 +323,7 @@ This policy allows you to configure if the window with the release notes is show
 - GP name: Disable Action Center notification for new updates
 - GP path: Administrative Templates/Microsoft PowerToys/Installer and Updates
 - GP scope: Computer and user
-- ADMX file name: PowerToys.admx
+- ADMX file name: _PowerToys.admx_
 
 ##### Registry information
 
@@ -341,7 +341,7 @@ This policy allows you to configure if the window with the release notes is show
 
 #### Configure enabled state for all plugins
 
-> Supported on PowerToys 0.75.0 or later.
+Supported on PowerToys 0.75.0 or later.
 
 This policy configures the enabled state for all PowerToys Run plugins. All plugins will have the same state.
 
@@ -360,7 +360,7 @@ You can override this policy for individual plugins using the policy "Configure 
 - GP name: Configure enabled state for all plugins
 - GP path: Administrative Templates/Microsoft PowerToys/PowerToys Run
 - GP scope: Computer and user
-- ADMX file name: PowerToys.admx
+- ADMX file name: _PowerToys.admx_
 
 ##### Registry information
 
@@ -376,7 +376,7 @@ You can override this policy for individual plugins using the policy "Configure 
 
 #### Configure enabled state for individual plugins
 
-> Supported on PowerToys 0.75.0 or later.
+Supported on PowerToys 0.75.0 or later.
 
 With this policy you can configure an individual enabled state for each PowerToys Run plugin that you add to the list.
 
@@ -399,14 +399,14 @@ You can set the enabled state for all plugins not controlled by this policy usin
 - GP name: Configure enabled state for individual plugins
 - GP path: Administrative Templates/Microsoft PowerToys/PowerToys Run
 - GP scope: Computer and user
-- ADMX file name: PowerToys.admx
+- ADMX file name: _PowerToys.admx_
 
 ##### Registry information
 
 - Path: Software\Policies\PowerToys\PowerLauncherIndividualPluginEnabledList
 - Name: The plugin ID from the `plugin.json` file.
 - Type: STRING
-- Example value:
+- Example values:
 
     ```
     Software\Policies\PowerToys\0778F0C264114FEC8A3DF59447CF0A74 = 2 (=> User can enable/disable the OneNote plugin.)
@@ -419,11 +419,10 @@ You can set the enabled state for all plugins not controlled by this policy usin
 - OMA-URI: `./Device/Vendor/MSFT/Policy/Config/PowerToys~Policy~PowerToys~PowerToysRun/PowerToysRunIndividualPluginEnabledState`
 - Example value:
 
-    > [!NOTE]
-    > Syntax for the :::no-loc text="value"::: property from the :::no-loc text="data"::: element:
-    > `<PluginID>&#xF000;<Number>&#xF000;<PluginID>&#xF000;<Number>`
-
     ```
     <enabled/>
     <data id="PowerToysRunIndividualPluginEnabledList" value="0778F0C264114FEC8A3DF59447CF0A74&#xF000;2&#xF000;791FC278BA414111B8D1886DFE447410&#xF000;0&#xF000;CEA0FDFC6D3B4085823D60DC76F28855&#xF000;1"/>
     ```
+    > [!NOTE]
+    > Syntax for the :::no-loc text="value"::: property from the :::no-loc text="data"::: element:
+    > `<PluginID>&#xF000;<Number>&#xF000;<PluginID>&#xF000;<Number>`

--- a/hub/powertoys/grouppolicy.md
+++ b/hub/powertoys/grouppolicy.md
@@ -151,7 +151,7 @@ These policies have a higher priority than, and will override, the policy "Confi
 - OMA-URI: `./Device/Vendor/MSFT/Policy/Config/PowerToys~Policy~PowerToys/<PolicyID>`
 
 > [!Note]
-> Please see the table above for the __PolicyID_ value.
+> Please see the table above for the _PolicyID_ value.
 
 - Example value: `<disabled/>`
 

--- a/hub/powertoys/hosts-file-editor.md
+++ b/hub/powertoys/hosts-file-editor.md
@@ -42,7 +42,7 @@ From the Settings menu, the following options can be configured:
 
 | Setting | Description |
 | :--- | :--- |
-| Launch as administrator | Launch as administrator to be able edit the hosts file. If disabled, the editor is run in read-only mode. Hosts File Editor is started as administrator by default. |
+| Launch as administrator | Open as administrator to be able edit the hosts file. If disabled, the editor is run in read-only mode. Hosts File Editor is started as administrator by default. |
 | Show a warning at startup | Warns that editing hosts can change DNS names resolution. Enabled by default. |
 | Additional lines position | Default value is **Top**. If **Bottom** is selected, the file header is moved below hosts settings to the bottom. |
 | Consider loopback addresses as duplicates | Loopback addresses (like 127.0.0.1 and ::1) are considered as duplicates. |

--- a/hub/powertoys/image-resizer.md
+++ b/hub/powertoys/image-resizer.md
@@ -63,3 +63,9 @@ You can specify a directory in the filename format to group resized images into 
 [Characters that are illegal in file names](/windows/win32/fileio/naming-a-file#file-and-directory-names) will be replaced by an underscore `_`.
 
 You can choose to retain the original _last modified_ date on the resized image or reset it at time of the resizing action.
+
+## See also
+
+- [Microsoft PowerToys overview](index.md)
+- [Installing PowerToys](install.md)
+- [General settings for PowerToys](general.md)

--- a/hub/powertoys/image-resizer.md
+++ b/hub/powertoys/image-resizer.md
@@ -11,11 +11,11 @@ no-loc: [PowerToys, Windows, File Explorer, Image Resizer]
 
 Image Resizer is a Windows shell extension for bulk image-resizing. After installing PowerToys, right-click on one or more selected image files in File Explorer, and select **Resize with ImageResizer** from the menu.
 
-![Image Resizer Demo.](../images/powertoys-resize-images.gif)
+![Image Resizer Demo](../images/powertoys-resize-images.gif)
 
 Image Resizer allows you to resize images by dragging and dropping your selected files with the right mouse button. This way, resized pictures can quickly be saved in a different folder.
 
-![Image Resizer Drag And Drop Demo.](../images/powertoys-resize-drag-drop.gif)
+![Image Resizer Drag And Drop Demo](../images/powertoys-resize-drag-drop.gif)
 
 > [!NOTE]
 > If **Ignore the orientation of pictures** is selected, the width and height of the specified size _may_ be swapped to match the orientation (portrait/landscape) of the current image. In other words: If selected, the **smallest** number (in width/height) in the settings will be applied to the **smallest** dimension of the picture. Regardless if this is declared as width or height. The idea is that different photos with different orientations will still be the same size.
@@ -24,7 +24,7 @@ Image Resizer allows you to resize images by dragging and dropping your selected
 
 On the **Image Resizer** tab, configure the following settings.
 
-![PowerToys Image Resizer Settings.](../images/powertoys-imageresize-settings.png)
+![PowerToys Image Resizer Settings](../images/powertoys-imageresize-settings.png)
 
 ### Sizes
 
@@ -63,9 +63,3 @@ You can specify a directory in the filename format to group resized images into 
 [Characters that are illegal in file names](/windows/win32/fileio/naming-a-file#file-and-directory-names) will be replaced by an underscore `_`.
 
 You can choose to retain the original _last modified_ date on the resized image or reset it at time of the resizing action.
-
-## See also
-
-- [Microsoft PowerToys overview](index.md)
-- [Installing PowerToys](install.md)
-- [General settings for PowerToys](general.md)

--- a/hub/powertoys/index.md
+++ b/hub/powertoys/index.md
@@ -28,7 +28,7 @@ The currently available utilities include:
 
 :::row:::
     :::column:::
-        [![Always On Top screenshot.](../images/pt-always-on-top-menu.png)](always-on-top.md)
+        [![Always On Top screenshot](../images/pt-always-on-top-menu.png)](always-on-top.md)
     :::column-end:::
     :::column span="2":::
         [Always On Top](always-on-top.md) enables you to pin windows above other windows with a quick key shortcut (<kbd>⊞ Win</kbd>+<kbd>Ctrl</kbd>+<kbd>T</kbd>).
@@ -39,7 +39,7 @@ The currently available utilities include:
 
 :::row:::
     :::column:::
-        [![PowerToys Awake screenshot.](../images/pt-awake-menu.png)](awake.md)
+        [![PowerToys Awake screenshot](../images/pt-awake-menu.png)](awake.md)
     :::column-end:::
     :::column span="2":::
         [PowerToys Awake](awake.md) is designed to keep a computer awake without having to manage its power & sleep settings. This behavior can be helpful when running time-consuming tasks, ensuring that the computer does not go to sleep or turns off its displays.
@@ -50,7 +50,7 @@ The currently available utilities include:
 
 :::row:::
     :::column:::
-        [![Color Picker screenshot.](../images/pt-color-picker.png)](color-picker.md)
+        [![Color Picker screenshot](../images/pt-color-picker.png)](color-picker.md)
     :::column-end:::
     :::column span="2":::
         [Color Picker](color-picker.md) is a system-wide color picking utility activated with <kbd>⊞ Win</kbd>+<kbd>Shift</kbd>+<kbd>C</kbd>. Pick colors from anywhere on the screen, the picker automatically copies the color into your clipboard in a set format.
@@ -62,7 +62,7 @@ The currently available utilities include:
 
 :::row:::
     :::column:::
-        [![Command Not Found screenshot.](../images/pt-cmd-not-found.png)](cmd-not-found.md)
+        [![Command Not Found screenshot](../images/pt-cmd-not-found.png)](cmd-not-found.md)
     :::column-end:::
     :::column span="2":::
         [Command Not Found](cmd-not-found.md) is a PowerShell 7 module that detects an error thrown by a command and suggests a relevant WinGet package to install, if available.
@@ -74,7 +74,7 @@ The currently available utilities include:
 
 :::row:::
     :::column:::
-        [![Crop And Lock screenshot.](../images/powertoys-crop-and-lock.png)](crop-and-lock.md)
+        [![Crop And Lock screenshot](../images/powertoys-crop-and-lock.png)](crop-and-lock.md)
     :::column-end:::
     :::column span="2":::
         [Crop And Lock](crop-and-lock.md) is a utility that creates a new window that's a crop or a thumbnail of another window.
@@ -85,7 +85,7 @@ The currently available utilities include:
 
 :::row:::
     :::column:::
-        [![Environment Variables screenshot.](../images/powertoys-environment-variables.png)](environment-variables.md)
+        [![Environment Variables screenshot](../images/powertoys-environment-variables.png)](environment-variables.md)
     :::column-end:::
     :::column span="2":::
         [Environment Variables](environment-variables.md) offers an easy and convenient way to manage environment variables. It also allows you to create profiles for managing a set of variables together.
@@ -96,7 +96,7 @@ The currently available utilities include:
 
 :::row:::
     :::column:::
-        [![FancyZones screenshot.](../images/pt-fancy-zones.png)](fancyzones.md)
+        [![FancyZones screenshot](../images/pt-fancy-zones.png)](fancyzones.md)
     :::column-end:::
     :::column span="2":::
         [FancyZones](fancyzones.md) is a window manager that makes it easy to create complex window layouts and quickly position windows into those layouts.
@@ -107,7 +107,7 @@ The currently available utilities include:
 
 :::row:::
     :::column:::
-        [![File Explorer screenshot.](../images/pt-file-explorer.png)](file-explorer.md)
+        [![File Explorer screenshot](../images/pt-file-explorer.png)](file-explorer.md)
     :::column-end:::
     :::column span="2":::
         [File Explorer add-ons](file-explorer.md) enable Preview pane and thumbnail rendering in File Explorer to display a variety of file types. To enable the Preview pane, select the "View" tab in File Explorer, then select "Preview Pane".
@@ -118,7 +118,7 @@ The currently available utilities include:
 
 :::row:::
     :::column:::
-        [![File Locksmith screenshot.](../images/powertoys-file-locksmith.png)](file-locksmith.md)
+        [![File Locksmith screenshot](../images/powertoys-file-locksmith.png)](file-locksmith.md)
     :::column-end:::
     :::column span="2":::
         [File Locksmith](file-locksmith.md) is a Windows shell extension to check which files are in use and by which processes. Right-click on one or more selected files in File Explorer, and then select **Unlock with File Locksmith**.
@@ -129,7 +129,7 @@ The currently available utilities include:
 
 :::row:::
     :::column:::
-        [![Hosts File Editor screenshot.](../images/pt-hosts-file-editor-facade.png)](hosts-file-editor.md)
+        [![Hosts File Editor screenshot](../images/pt-hosts-file-editor-facade.png)](hosts-file-editor.md)
     :::column-end:::
     :::column span="2":::
         [Hosts File Editor](hosts-file-editor.md) is a convenient way to edit the 'Hosts' file that contains domain names and matching IP addresses, acting as a map to identify and locate hosts on IP networks.
@@ -140,7 +140,7 @@ The currently available utilities include:
 
 :::row:::
     :::column:::
-        [![Image Resizer screenshot.](../images/pt-image-resizer.png)](image-resizer.md)
+        [![Image Resizer screenshot](../images/pt-image-resizer.png)](image-resizer.md)
     :::column-end:::
     :::column span="2":::
         [Image Resizer](image-resizer.md) is a Windows Shell extension for quickly resizing images. With a simple right click from File Explorer, resize one or many images instantly. This code is based on [Brice Lambson's Image Resizer](https://github.com/bricelam/ImageResizer).
@@ -151,7 +151,7 @@ The currently available utilities include:
 
 :::row:::
     :::column:::
-        [![Keyboard Manager screenshot.](../images/pt-keyboard-manager.png)](keyboard-manager.md)
+        [![Keyboard Manager screenshot](../images/pt-keyboard-manager.png)](keyboard-manager.md)
     :::column-end:::
     :::column span="2":::
         [Keyboard Manager](keyboard-manager.md) allows you to customize the keyboard to be more productive by remapping keys and creating your own keyboard shortcuts.
@@ -162,7 +162,7 @@ The currently available utilities include:
 
 :::row:::
     :::column:::
-        [![Mouse utilities screenshot.](../images/pt-mouse-utils.png)](mouse-utilities.md)
+        [![Mouse utilities screenshot](../images/pt-mouse-utils.png)](mouse-utilities.md)
     :::column-end:::
     :::column span="2":::
         [Mouse utilities](mouse-utilities.md) add functionality to enhance your mouse and cursor. With Find My Mouse, quickly locate your mouse's position with a spotlight that focuses on your cursor. This feature is based on source code developed by [Raymond Chen](https://github.com/oldnewthing). Mouse Highlighter displays visual indicators when the left or right mouse buttons are clicked. Mouse Jump allows a quick jump on large displays. Mouse Pointer Crosshairs draws crosshairs centered on the mouse pointer.
@@ -173,7 +173,7 @@ The currently available utilities include:
 
 :::row:::
     :::column:::
-        [![Mouse without Borders screenshot.](../images/pt-mouse-without-borders.png)](mouse-without-borders.md)
+        [![Mouse without Borders screenshot](../images/pt-mouse-without-borders.png)](mouse-without-borders.md)
     :::column-end:::
     :::column span="2":::
         [Mouse Without Borders](mouse-without-borders.md) enables you to interact with multiple computers from the same keyboard and mouse, sharing clipboard contents and files between the machines seamlessly.
@@ -184,7 +184,7 @@ The currently available utilities include:
 
 :::row:::
     :::column:::
-        [![Paste As Plain Text screenshot.](../images/pt-paste-as-plain-text.png)](paste-as-plain-text.md)
+        [![Paste As Plain Text screenshot](../images/pt-paste-as-plain-text.png)](paste-as-plain-text.md)
     :::column-end:::
     :::column span="2":::
         [Paste As Plain Text](paste-as-plain-text.md) allows you to paste text from your clipboard, excluding text-formatting, with a quick key shortcut (<kbd>⊞ Win</kbd>+<kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>V</kbd>).
@@ -195,7 +195,7 @@ The currently available utilities include:
 
 :::row:::
     :::column:::
-        [![Peek screenshot.](../images/powertoys-peek.png)](peek.md)
+        [![Peek screenshot](../images/powertoys-peek.png)](peek.md)
     :::column-end:::
     :::column span="2":::
         [Peek](peek.md) allows you to preview file content without the need to open multiple applications or interrupt your workflow. Simply select the file and use the shortcut (<kbd>Ctrl</kbd>+<kbd>Space</kbd>)
@@ -206,7 +206,7 @@ The currently available utilities include:
 
 :::row:::
     :::column:::
-        [![PowerRename screenshot.](../images/pt-rename.png)](powerrename.md)
+        [![PowerRename screenshot](../images/pt-rename.png)](powerrename.md)
     :::column-end:::
     :::column span="2":::
         [PowerRename](powerrename.md) enables you to perform bulk renaming, searching and replacing file names. It includes advanced features, such as using regular expressions, targeting specific file types, previewing expected results, and the ability to undo changes. This code is based on [Chris Davis's SmartRename](https://github.com/chrdavis/SmartRename).
@@ -217,10 +217,10 @@ The currently available utilities include:
 
 :::row:::
     :::column:::
-        [![PowerToys Run screenshot.](../images/pt-run.png)](run.md)
+        [![PowerToys Run screenshot](../images/pt-run.png)](run.md)
     :::column-end:::
     :::column span="2":::
-        [PowerToys Run](run.md) can help you search and launch your app instantly. To open, use the shortcut <kbd>Alt</kbd>+<kbd>Space</kbd> and start typing. It is open source and modular for additional plugins.
+        [PowerToys Run](run.md) can help you search and open your app instantly. To open, use the shortcut <kbd>Alt</kbd>+<kbd>Space</kbd> and start typing. It is open source and modular for additional plugins.
     :::column-end:::
 :::row-end:::
 
@@ -228,7 +228,7 @@ The currently available utilities include:
 
 :::row:::
     :::column:::
-        [![Quick Accent screenshot.](../images/pt-keyboard-accent.png)](Quick-accent.md)
+        [![Quick Accent screenshot](../images/pt-keyboard-accent.png)](Quick-accent.md)
     :::column-end:::
     :::column span="2":::
         [Quick Accent](Quick-accent.md) is an alternative way to type accented characters, useful for when a keyboard doesn't support that specific accent with a quick key combo.
@@ -239,7 +239,7 @@ The currently available utilities include:
 
 :::row:::
     :::column:::
-        [![Registry Preview screenshot.](../images/pt-registrypreview.png)](registry-preview.md)
+        [![Registry Preview screenshot](../images/pt-registrypreview.png)](registry-preview.md)
     :::column-end:::
     :::column span="2":::
         [Registry Preview](registry-preview.md) is a utility to visualize and edit Windows Registry files.
@@ -250,7 +250,7 @@ The currently available utilities include:
 
 :::row:::
     :::column:::
-        [![Screen Ruler screenshot.](../images/pt-screen-ruler.png)](screen-ruler.md)
+        [![Screen Ruler screenshot](../images/pt-screen-ruler.png)](screen-ruler.md)
     :::column-end:::
     :::column span="2":::
         [Screen Ruler](screen-ruler.md) allows you to quickly measure pixels on your screen based with image edge detection. To activate, use the shortcut <kbd>⊞ Win</kbd>+<kbd>Shift</kbd>+<kbd>M</kbd>. This was inspired by [Pete Blois's Rooler](https://github.com/peteblois/rooler).
@@ -261,10 +261,10 @@ The currently available utilities include:
 
 :::row:::
     :::column:::
-        [![Shortcut Guide screenshot.](../images/pt-shortcut-guide.png)](shortcut-guide.md)
+        [![Shortcut Guide screenshot](../images/pt-shortcut-guide.png)](shortcut-guide.md)
     :::column-end:::
     :::column span="2":::
-        [Windows key shortcut guide](shortcut-guide.md) appears when you press <kbd>⊞ Win</kbd>+<kbd>Shift</kbd>+<kbd>/</kbd> (or as we like to think, <kbd>⊞ Win</kbd>+<kbd>?</kbd>) and shows the available shortcuts for the current state of the desktop. You can also change this setting and press and hold <kbd>⊞ Win</kbd>.
+        [Windows key shortcut guide](shortcut-guide.md) appears when you press <kbd>⊞ Win</kbd>+<kbd>Shift</kbd>+<kbd>/</kbd> (or as we like to think, <kbd>⊞ Win</kbd>+<kbd>?</kbd>) and shows the available shortcuts for the current state of the desktop. You can also use press and hold <kbd>⊞ Win</kbd>.
     :::column-end:::
 :::row-end:::
 
@@ -272,7 +272,7 @@ The currently available utilities include:
 
 :::row:::
     :::column:::
-        [![Text Extractor screenshot.](../images/pt-image-to-text.png)](text-extractor.md)
+        [![Text Extractor screenshot](../images/pt-image-to-text.png)](text-extractor.md)
     :::column-end:::
     :::column span="2":::
         [Text Extractor](text-extractor.md) is a convenient way to copy text from anywhere on your screen. To activate, use the shortcut <kbd>⊞ Win</kbd>+<kbd>Shift</kbd>+<kbd>T</kbd>. This code is based on [Joe Finney's Text Grab](https://github.com/TheJoeFin/Text-Grab).
@@ -283,7 +283,7 @@ The currently available utilities include:
 
 :::row:::
     :::column:::
-        [![Video Conference Mute screenshot.](../images/pt-video-conference-mute.png)](video-conference-mute.md)
+        [![Video Conference Mute screenshot](../images/pt-video-conference-mute.png)](video-conference-mute.md)
     :::column-end:::
     :::column span="2":::
         [Video Conference Mute](video-conference-mute.md) is a quick way to globally "mute" both your microphone and camera using <kbd>⊞ Win</kbd>+<kbd>Shift</kbd>+<kbd>Q</kbd> while on a conference call, regardless of the application that currently has focus.
@@ -300,7 +300,7 @@ _Note that new elements of the app might sometimes not yet be translated in the 
 
 In this video, Clint Rutkas (PM for PowerToys) walks through how to install and use the various utilities available, in addition to sharing some tips, info on how to contribute, and more.
 
-> [!VIDEO https://learn.microsoft.com/shows/Tabs-vs-Spaces/PowerToys-Utilities-to-customize-Windows-10/player?format=ny]
+[!VIDEO https://learn.microsoft.com/shows/Tabs-vs-Spaces/PowerToys-Utilities-to-customize-Windows-10/player?format=ny]
 
 ## Known issues
 
@@ -324,7 +324,7 @@ PowerToys [release notes](https://github.com/microsoft/PowerToys/releases/) are 
 
 ## PowerToys history
 
-Inspired by the [Windows 95 era PowerToys project](https://en.wikipedia.org/wiki/Microsoft_PowerToys), this reboot provides power users with ways to squeeze more efficiency out of the Windows shell and customize it for individual workflows. An overview of the original PowerToys can be found here: [Using Windows 95 PowerToys](https://socket3.wordpress.com/2016/10/22/using-windows-95-powertoys/).
+Inspired by the [Windows 95 era PowerToys project](https://wikipedia.org/wiki/Microsoft_PowerToys), this reboot provides power users with ways to squeeze more efficiency out of the Windows shell and customize it for individual workflows. An overview of the original PowerToys can be found here: [Using Windows 95 PowerToys](https://socket3.wordpress.com/2016/10/22/using-windows-95-powertoys/).
 
 ## PowerToys roadmap
 

--- a/hub/powertoys/install.md
+++ b/hub/powertoys/install.md
@@ -21,7 +21,7 @@ We recommend installing PowerToys via GitHub or Microsoft Store, but alternative
 - Our installer will install the following runtimes:
   - [Microsoft Edge WebView2 Runtime](https://go.microsoft.com/fwlink/p/?LinkId=2124703) bootstrapper (this will always install the latest version available)
 
-To ensure that your machine meets these requirements, check your Windows version and build number by pressing <kbd>⊞ Win</kbd>+<kbd>R</kbd>, then type `winver` and press <kbd>OK</kbd>. Or enter the `ver` command in Windows Command Prompt. You can [update to the latest Windows version](ms-settings:windowsupdate) in the **Windows Settings**.
+To ensure that your machine meets these requirements, check your Windows version and build number by pressing <kbd>⊞ Win</kbd>+<kbd>R</kbd>, then type `winver` and press <kbd>OK</kbd>. Or enter the `ver` command in Windows Command Prompt. You can [update to the latest Windows version](ms-settings:windowsupdate) in **Windows Update**.
 
 ## Installing with Windows executable file via GitHub
 
@@ -57,11 +57,11 @@ Here are the common commands you may want:
 
 | Command  | Abbreviation | Function     |
 |----------|--------------| ------------ |
-| **/quiet**   | **/q**       | Silent install |
-| **/silent**  | **/s**       | Silent install |
-| **/passive** |              | progress bar only install |
-| **/layout**  |              | create a local image of the bootstrapper |
-| **/log**     | **/l**       | log to a specific file |
+| /quiet   | /q       | Silent install |
+| /silent  | /s       | Silent install |
+| /passive |          | progress bar only install |
+| /layout  |          | create a local image of the bootstrapper |
+| /log     | /l       | log to a specific file |
 
 ### Extracting the MSI from the bundle
 
@@ -134,4 +134,4 @@ After successfully installing PowerToys, an overview window will display with in
 
 PowerToys uses an auto-updater that checks for new versions when the app is running. If enabled, a toast notification will appear when an update is available. Updates can also be checked for manually from the PowerToys Settings, under the General page.
 
-![PowerToys Update.](../images/powertoys-updates.png)
+![PowerToys Update](../images/powertoys-updates.png)

--- a/hub/powertoys/keyboard-manager.md
+++ b/hub/powertoys/keyboard-manager.md
@@ -13,7 +13,7 @@ The PowerToys Keyboard Manager enables you to redefine keys on your keyboard.
 
 For example, you can exchange the letter <kbd>A</kbd> for the letter <kbd>B</kbd> on your keyboard. When you press the <kbd>A</kbd> key, a `B` will be inserted.
 
-![PowerToys Keyboard Manager remap keys screenshot.](../images/powertoys-keyboard-remap.png)
+![PowerToys Keyboard Manager remap keys screenshot](../images/powertoys-keyboard-remap.png)
 
 You can exchange shortcut key combinations. For example: The shortcut key <kbd>Ctrl</kbd>+<kbd>C</kbd> will copy text in many applications. With PowerToys Keyboard Manager utility, you can swap that shortcut for <kbd>⊞ Win</kbd>+<kbd>C</kbd>. Now, <kbd>⊞ Win</kbd>+<kbd>C</kbd> will copy text. If you do not specify a targeted application in PowerToys Keyboard Manager, the shortcut exchange will be applied globally across Windows.
 
@@ -22,7 +22,7 @@ Also, you can exchange key or shortcut to arbitrary unicode text sequence. For e
 PowerToys Keyboard Manager must be enabled (with PowerToys running in the background) for remapped keys and shortcuts to be applied. If PowerToys is not running, key remapping will no longer be applied.
 
 > [!IMPORTANT]
-> There are some shortcut keys that are reserved for the operating system or cannot be replaced. Keys that cannot be remapped include:
+> There are some shortcut keys that are reserved by the operating system or cannot be replaced. Keys that cannot be remapped include:
 >
 > - <kbd>⊞ Win</kbd>+<kbd>L</kbd> and <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>Del</kbd> cannot be remapped as they are reserved by the Windows OS.
 > - The <kbd>Fn</kbd> (function) key cannot be remapped (in most cases). The <kbd>F1</kbd> ~ <kbd>F12</kbd> (and <kbd>F13</kbd> ~ <kbd>F24</kbd>) keys can be mapped.
@@ -31,14 +31,14 @@ PowerToys Keyboard Manager must be enabled (with PowerToys running in the backgr
 
 ## Settings
 
-To create mappings with Keyboard Manager, open the PowerToys Settings. Inside PowerToys Settings, on the Keyboard Manager tab, you will see options to:
+To create mappings with Keyboard Manager, open the PowerToys Settings. In PowerToys Settings, on the Keyboard Manager tab, you will see options to:
 
-- Launch the Remap Keys settings window by selecting **Remap a key**
-- Launch the Remap Shortcuts settings window by selecting **Remap a shortcut**
+- Open the Remap Keys settings window by selecting **Remap a key**
+- Open the Remap Shortcuts settings window by selecting **Remap a shortcut**
 
 ### Remapping keys
 
-To remap a key, changing it to a new value, launch the Remap Keyboard settings window with **Remap a Key**. When first launched, no predefined mappings will be displayed. Select **&#9547; Add key remapping** to add a new remap.
+To remap a key, changing it to a new value, open the Remap Keyboard settings window with **Remap a Key**. When first opened, no predefined mappings will be displayed. Select **Add key remapping** to add a new remap.
 
 Once a new remap row appears, select the input key whose output you want to _change_ in the “Select” column. Select the new key, shortcut or text value to assign in the “To send” column.
 
@@ -54,7 +54,7 @@ To swap key positions between the <kbd>A</kbd> and <kbd>B</kbd> keys, add anothe
 | :--- | :--- |
 | `B` | `A` |
 
-![Keyboard Remap Keys screenshot.](../images/powertoys-keyboard-remap-a-b.png)
+![Keyboard Remap Keys screenshot](../images/powertoys-keyboard-remap-a-b.png)
 
 ### Remapping a key to a shortcut
 
@@ -81,9 +81,9 @@ For example, to press the <kbd>H</kbd> key and have it result in `Hello!`:
 
 ### Remapping shortcuts
 
-To remap a shortcut key combination, like <kbd>Ctrl</kbd>+<kbd>C</kbd>, select **Remap a shortcut** to launch the Remap Shortcuts settings window.
+To remap a shortcut key combination, like <kbd>Ctrl</kbd>+<kbd>C</kbd>, select **Remap a shortcut** to open the Remap Shortcuts settings window.
 
-When first launched, no predefined mappings will be displayed. Select **+ Add shortcut remapping** to add a new remap.
+When first opened, no predefined mappings will be displayed. Select **Add shortcut remapping** to add a new remap.
 
 Once a new remap row appears, select the input keys whose output you want to _change_ in the “Select” column. Select the new shortcut value to assign in the “To send” column.
 
@@ -93,7 +93,7 @@ For example, the shortcut <kbd>Ctrl</kbd>+<kbd>C</kbd> copies selected text. To 
 | :--- | :--- |
 | `Alt` + `C` | `Ctrl` + `C` |
 
-![Keyboard Remap Shortcut screenshot.](../images/powertoys-keyboard-remap-shortcut.png)
+![Keyboard Remap Shortcut screenshot](../images/powertoys-keyboard-remap-shortcut.png)
 
 There are a few rules to follow when remapping shortcuts. These rules only apply to the "Shortcut" column.
 
@@ -103,12 +103,13 @@ There are a few rules to follow when remapping shortcuts. These rules only apply
 
 #### Shortcuts with chords
 
-Shortcuts can be created with one or more modifiers and two non-modifier keys. These are called 'chords.' In order to create a chord, you need to use the edit button to open the modal to record the shortcut using the keyboard. Once this is open, you need to toggle on the 'Allow chords' switch. Doing this allows you to enter two non-modifier keys. For example, you can create shortcuts using a chord based on 'V' for **V**olume **U**p and **V**olume **D**own like this:
+Shortcuts can be created with one or more modifiers and two non-modifier keys. These are called "chords". In order to create a chord, select **Edit**  to open the dialog to record the shortcut using the keyboard. Once opened, toggle on the **Allow chords** switch. This allows you to enter two non-modifier keys.
+For example, you can create shortcuts using a chord based on 'V' for **V**olume **U**p and **V**olume **D**own like this:
 
 | Select: | To send: |
 | :--- | :--- |
-| `Shift`+`Ctrl` + `V` \, `U` | `Volume Up` |
-| `Shift`+`Ctrl` + `V` \, `D` | `Volume Down` |
+| `Shift` + `Ctrl` + `V` , `U` | `Volume Up` |
+| `Shift` + `Ctrl` + `V` , `D` | `Volume Down` |
 
 Chords are handy if you have a number of shortcuts that are similar, and so it makes sense to have them all start with the same non-modifier key.
 
@@ -187,7 +188,7 @@ Using the drop-down menu, you can search with the key name and additional drop-d
 
 Orphaning a key means that you mapped it to another key and no longer have anything mapped to it. For example, if the key is remapped from `A` to `B`, then a key no longer exists on your keyboard that results in `A`. To ensure this does not happen by accident, a warning will display for any orphaned keys. To fix this, select **&#9547;** to create another remapped key that is mapped to result in `A`.
 
-![PowerToys Keyboard Manager orphaned key.](../images/powertoys-keyboard-remap-orphaned.png)
+![PowerToys Keyboard Manager orphaned key](../images/powertoys-keyboard-remap-orphaned.png)
 
 ## Frequently asked questions
 
@@ -223,7 +224,7 @@ Currently no. We are not aware of an API where we can see the input and which de
 
 Keyboard Manager lists mappings for all known physical keyboard keys. Some of these mappings may not be available on your keyboard as there may not be a physical key that it corresponds to. For instance: the <kbd>Start App 1</kbd> option shown below is only available on keyboards that physically have a <kbd>Start App 1</kbd> key. Trying to map to and from this key on a keyboard that does not support the <kbd>Start App 1</kbd> key will result in undefined behavior.
 
-![PowerToys Keyboard Manager List of Keys.](../images/pt-key-remap-drop-down.png)
+![PowerToys Keyboard Manager List of Keys](../images/pt-key-remap-drop-down.png)
 
 ## Troubleshooting
 

--- a/hub/powertoys/mouse-utilities.md
+++ b/hub/powertoys/mouse-utilities.md
@@ -13,9 +13,10 @@ Mouse utilities is a collection of features that enhance mouse and cursor functi
 
 ## Find my mouse
 
-Activate a spotlight that focuses on the cursor's position pressing the <kbd>Ctrl</kbd> key twice, using a custom shortcut or shaking the mouse. Click the mouse or press any keyboard key to dismiss it. If you move the mouse while the spotlight is active, the spotlight will dismiss on its own shortly after the mouse stops moving.
+Activate a spotlight that focuses on the cursor's position pressing the <kbd>Ctrl</kbd> key twice, using a custom shortcut or shaking the mouse. Click the mouse or press any keyboard key to dismiss it.
+If you move the mouse while the spotlight is active, the spotlight will dismiss on its own shortly after the mouse stops moving.
 
-![Screenshot of Find my mouse.](../images/pt-mouse-utilities-find-my-mouse.gif)
+![Screenshot of Find my mouse](../images/pt-mouse-utilities-find-my-mouse.gif)
 
 ### Settings
 
@@ -41,7 +42,7 @@ Display visual indicators when the left or right mouse buttons are clicked. By d
 
 ### Settings
 
-![Screenshot of Mouse highlighter.](../images/pt-mouse-highlighter.gif)
+![Screenshot of Mouse highlighter](../images/pt-mouse-highlighter.gif)
 
 From the settings page, the following options can be configured:
 
@@ -58,7 +59,7 @@ From the settings page, the following options can be configured:
 
 ## Mouse jump
 
-![Screenshot of Mouse jump.](../images/pt-mouse-jump.gif)
+![Screenshot of Mouse jump](../images/pt-mouse-jump.gif)
 
 Mouse jump allows moving the mouse pointer long distances on a single screen or across multiple screens.
 
@@ -68,7 +69,7 @@ Mouse jump allows moving the mouse pointer long distances on a single screen or 
 
 ## Mouse pointer Crosshairs
 
-![Screenshot of Crosshairs.](../images/pt-mouseutilities-crosshairs.png)
+![Screenshot of Crosshairs](../images/pt-mouseutilities-crosshairs.png)
 
 Mouse Pointer Crosshairs draws crosshairs centered on the mouse pointer.
 

--- a/hub/powertoys/mouse-without-borders.md
+++ b/hub/powertoys/mouse-without-borders.md
@@ -26,19 +26,19 @@ With the latest version of PowerToys installed, you will see Mouse Without Borde
 
 2. On the first computer, select **New Key** to generate a security key for connecting.
 
-    ![Screenshot of Mouse Without Borders settings after pressing New Key.](../images/powertoys-mouse-without-borders-press-new-key.png)
+    ![Screenshot of Mouse Without Borders settings after pressing New Key](../images/powertoys-mouse-without-borders-press-new-key.png)
 
 3. On the second computer, enter the security key that was generated on the first computer and the name of the first computer. Then select **Connect**.
 
-    ![Screenshot of Mouse Without Borders settings after entering the first computer information.](../images/powertoys-mouse-without-borders-enter-security-key.png)
+    ![Screenshot of Mouse Without Borders settings after entering the first computer information](../images/powertoys-mouse-without-borders-enter-security-key.png)
 
 4. Once the computers are connected, you will be able to switch between them by moving your mouse cursor beyond the edge of the screen, transitioning between computers.
 
-    ![Screenshot of Mouse Without Borders settings on the second computer after connecting.](../images/powertoys-mouse-without-borders-after-connect-2.png)
+    ![Screenshot of Mouse Without Borders settings on the second computer after connecting](../images/powertoys-mouse-without-borders-after-connect-2.png)
 
 It's possible to switch the order of the devices by dragging the device icon to a new position in the layout.
 
-   ![Animation of Mouse Without Borders settings configuring device layout.](../images/powertoys-mouse-without-borders-drag-device-layout.gif)
+   ![Animation of Mouse Without Borders settings configuring device layout](../images/powertoys-mouse-without-borders-drag-device-layout.gif)
 
 ### Install Mouse Without Borders as a service
 
@@ -83,11 +83,12 @@ To enable the service mode, run PowerToys in administrator mode and turn on the 
 | Show the original Mouse Without Borders UI | Show the original UI from Mouse Without Borders through the original tray icon. Mouse Without Borders needs to be restarted for it to take effect. |
 
 ## Status Colors
+
 The following colors are used to indicate the connection status to the user when trying to connect to another computer:
 
 | Connection Status | Color    | Hex Code    |
-| :-----: | :---: | :---: |
-| NA | Dark Grey   | `#00717171`  |
+| :--- | :--- | :--- |
+| N/A | Dark Grey   | `#00717171`  |
 | Resolving | Yellow   | `#FFFFFF00`   |
 | Connecting | Orange   | `#FFFFA500`   |
 | Handshaking | Blue   | `#FF0000FF`   |
@@ -97,7 +98,6 @@ The following colors are used to indicate the connection status to the user when
 | Timeout | Pink   | `#FFFFC0CB`   |
 | SendError | Maroon   | `#FF800000`   |
 | Connected | Green   | `#FF008000`   |
-
 
 ## Troubleshooting
 

--- a/hub/powertoys/paste-as-plain-text.md
+++ b/hub/powertoys/paste-as-plain-text.md
@@ -11,7 +11,7 @@ no-loc: [PowerToys, Windows, Paste as Plain Text, Win]
 
 PowerToys **Paste as Plain Text** enables you to paste text stored in your clipboard, excluding any text-formatting, using a quick key shortcut. Any formatting included with the clipboard text will be replaced with an unformatted version of the text.
 
-![Paste as Plain Text screenshot.](../images/pt-paste-as-plain-text.png)
+![Paste as Plain Text screenshot](../images/pt-paste-as-plain-text.png)
 
 ## Getting started
 

--- a/hub/powertoys/peek.md
+++ b/hub/powertoys/peek.md
@@ -10,7 +10,7 @@ no-loc: [PowerToys, Windows, Peek, Win]
 
 A system-wide utility for Windows that allows you to preview file content without the need to open multiple applications or interrupt your workflow. It offers a seamless and quick file preview experience for various file types, including images, Office documents, web pages, Markdown files, text files, and developer files.
 
-![Screenshot of PowerToys Peek utility.](../images/powertoys-peek.png)
+![Screenshot of PowerToys Peek utility](../images/powertoys-peek.png)
 
 ## Preview a file
 
@@ -21,9 +21,7 @@ Using <kbd>Left</kbd> and <kbd>Right</kbd> or <kbd>Up</kbd> and <kbd>Down</kbd>,
 ## Pin preview window position and size
 
 The Peek window adjusts its size based on the dimensions of the images being previewed. However, if you prefer to keep the window's size and position, you can utilize the pinning feature.
-
 By selecting the pinning button located in the top right corner of the Peek window, the window will preserve the current size and position.
-
 Selecting the pinning button again will unpin the window. When unpinned, the Peek window will return to the default position and size when previewing the next file.
 
 ## Open file with the default program

--- a/hub/powertoys/powerrename.md
+++ b/hub/powertoys/powerrename.md
@@ -21,13 +21,13 @@ PowerRename is a bulk renaming tool that enables you to:
 
 In this demo, all instances of the file name "foo" are replaced with "foobar". Since all of the files are uniquely named, this would have taken a long time to complete manually one-by-one. PowerRename enables a single bulk rename. Notice that the Explorer's "Undo Rename" (Ctrl+Z) command makes it possible to undo the last change.
 
-![PowerRename Demo.](../images/powerrename-demo.gif)
+![PowerRename Demo](../images/powerrename-demo.gif)
 
 ## PowerRename window
 
 After selecting files in Windows File Explorer, right-click and select **Resize with PowerRename** (which will appear only if enabled in PowerToys). The selected items will be displayed, along with search and replace values, a list of options, and a preview pane displaying results of the search and replace values entered.
 
-![PowerRename Menu screenshot.](../images/powerrename-menu.png)
+![PowerRename Menu screenshot](../images/powerrename-menu.png)
 
 ### Search for
 
@@ -35,7 +35,7 @@ Enter text or a [regular expression](https://wikipedia.org/wiki/Regular_expressi
 
 ### Replace with
 
-Enter text to replace the _Search for_ value entered previously. You can view the original file name and renamed file name in the _Preview_ pane.
+Enter text to replace the _Search for_ value entered previously. You can see the original file name and renamed file name in the _Preview_ pane.
 
 ### Use regular expressions
 
@@ -213,7 +213,7 @@ Filters can be used in PowerRename to narrow the results of the rename. Use the 
   - The default preview will show all selected files, with only files matching the _Search for_ criteria displaying the updated rename value.
   - Selecting the _Renamed_ header will toggle the preview to only display files that will be renamed. Other selected files from your original selection will not be visible.
 
-![PowerToys PowerRename Filter demo.](../images/powerrename-demo2.gif)
+![PowerToys PowerRename Filter demo](../images/powerrename-demo2.gif)
 
 ## Settings
 

--- a/hub/powertoys/registry-preview.md
+++ b/hub/powertoys/registry-preview.md
@@ -11,7 +11,7 @@ no-loc: [PowerToys, Windows, Registry Preview, Win]
 
 PowerToys **Registry Preview** simplifies the process of visualizing and editing complex Windows Registry files. It can also write changes to the Windows Registry.
 
-![Registry Preview screenshot.](../images/pt-registrypreview.png)
+![Registry Preview screenshot](../images/pt-registrypreview.png)
 
 ## Getting started
 

--- a/hub/powertoys/run.md
+++ b/hub/powertoys/run.md
@@ -16,7 +16,7 @@ To use PowerToys Run, select <kbd>Alt</kbd>+<kbd>Space</kbd> and start typing! _
 > [!IMPORTANT]
 > PowerToys must be running in the background and Run must be enabled for this utility to work.
 
-![PowerToys Run demo opening apps.](../images/pt-powerrun-demo.gif)
+![PowerToys Run demo opening apps](../images/pt-powerrun-demo.gif)
 
 ## Features
 
@@ -47,20 +47,21 @@ The following general options are available on the PowerToys Run settings page.
 | Immediate plugins | How many milliseconds a plugin that makes the UI wait should wait before showing results |
 | Background execution plugins | How many milliseconds a plugin that executes in the background should wait before showing results |
 | Maximum number of results before scrolling | Maximum number of results shown without scrolling |
-| Clear the previous query on launch | When launched, previous searches will not be highlighted |
+| Clear the previous query on launch | When opened, previous searches will not be highlighted |
 | Results order tuning | Fine tunes the ordering of the displayed results |
 | Selected item weight | Use a higher number to get selected results to rise faster (Default: 5, 0 to disable) |
 | Wait for slower plugin results before selecting top item in results | Selecting this can help preselect the top, more relevant result, but at the risk of jumpiness |
 | Tab through context buttons | When enabled, you can tab through the context buttons before tabbing to the next result |
 | Generate thumbnails for files | When enabled, thumbnails will be generated for files in the results list (Disabling this can increase speed and stability) |
-| Preferred monitor position | If multiple displays are in use, PowerToys Run can be launched on:<br />• Primary display<br />• Display with mouse cursor<br />• Display with focused window |
+| Preferred monitor position | If multiple displays are in use, PowerToys Run can be opened on:<br />• Primary display<br />• Display with mouse cursor<br />• Display with focused window |
 | App theme | Change the color theme used by PowerToys Run |
 
 ### Plugin manager
 
-PowerToys Run uses a plugin system to provide different types of results. The settings page includes a plugin manager that allows you to enable/disable the various available plugins. By selecting and expanding the sections, you can customize the direct activation commands used by each plugin. In addition, you can select whether a plugin appears in global results and set additional plugin options where available.
+PowerToys Run uses a plugin system to provide different types of results. The settings page includes a plugin manager that allows you to enable/disable the various available plugins.
+By selecting and expanding the sections, you can customize the direct activation commands used by each plugin. In addition, you can select whether a plugin appears in global results and set additional plugin options where available.
 
-![PowerToys Run Plugin Manager.](../images/pt-run-plugin-manager.png)
+![PowerToys Run Plugin Manager](../images/pt-run-plugin-manager.png)
 
 #### Direct activation commands
 
@@ -91,10 +92,10 @@ The plugins can be activated with a direct activation command so that PowerToys 
 | [Time and date](#time-and-date-plugin) | `)` | `) time and date` shows the current time and date in different formats.<br />`) calendar week::04/01/2022` shows the calendar week for the date '04/01/2022'. |
 | [Unit converter](#unit-converter-plugin) | `%%` | `%% 10 ft in m` to calculate the number of meters in 10 feet. |
 | [Value Generator](#value-generator-plugin) | `#` | `# guid3 ns:URL www.microsoft.com` to generate the GUIDv3 for the URL namespace using the URL namespace. <br />`# sha1 abc` to calculate the SHA1 hash for the string 'abc'. <br />`# base64 abc` to encode the string 'abc' to base64.  |
-| URI-handler | `//` | `//` to launch your default browser.<br />`// learn.microsoft.com` to have your default browser go to Microsoft Learn.<br />`mailto:` and `ms-settings:` links are supported. |
+| URI-handler | `//` | `//` to open your default browser.<br />`// learn.microsoft.com` to have your default browser go to Microsoft Learn.<br />`mailto:` and `ms-settings:` links are supported. |
 | Visual Studio Code | `{` | `{ powertoys` to search for previously opened workspaces, remote machines and containers that contain 'powertoys' in their paths. |
-| Web search | `??` | `??` to launch your default browser's search page.<br />`?? What is the answer to life` to search with your default browser's search engine. |
-| [Windows settings](#windows-settings-plugin) | `$` | `$ Add/Remove Programs` to launch the Windows settings page for managing installed programs.<br />`$ Device:` to list all settings with 'device' in their area/category name.<br />`$ control>system>admin` shows all settings of the path 'Control Panel > System and Security > Administrative Tools'. |
+| Web search | `??` | `??` to open your default browser's search page.<br />`?? What is the answer to life` to search with your default browser's search engine. |
+| [Windows settings](#windows-settings-plugin) | `$` | `$ Add/Remove Programs` to open the Windows settings page for managing installed programs.<br />`$ Device:` to list all settings with 'device' in their area/category name.<br />`$ control>system>admin` shows all settings of the path 'Control Panel > System and Security > Administrative Tools'. |
 | Windows Terminal profiles | `_` | `_ powershell` to list all profiles that contains 'powershell' in their name. |
 | [Window Walker](#window-walker-plugin) | `<` | `< outlook` to find all open windows that contain 'outlook' in their name or the name of their process. |
 
@@ -136,11 +137,12 @@ _*) This command may take some time to provide the results._
 
 ### Program plugin
 
-The **Program** plugin can launch software applications (such as Win32 or packaged programs). The plugin works by scanning common install locations, like the start menu and desktops that you have access to, looking for executable files (.exe) or shortcut files (such as `.lnk` or `.url`). On occasion, a program may not be found by the program plugin scan and you may want to manually create a shortcut in the directory containing the program you want to access.
+The **Program** plugin can open software applications (such as Win32 or packaged programs). The plugin works by scanning common install locations, like the start menu and desktops that you have access to, looking for executable files (.exe) or shortcut files (such as .lnk or .url).
+On occasion, a program may not be found by the program plugin scan and you may want to manually create a shortcut in the directory containing the program you want to access.
 
 #### Program parameters
 
-The Program plugin allows for program arguments to be added when launching an application. The program arguments must follow the expected format as defined by the program's command line interface.
+The Program plugin allows for program arguments to be added when opening an application. The program arguments must follow the expected format as defined by the program's command line interface.
 
 > [!NOTE]
 > To input valid search queries, the first element after the program name has to be one of the following possibilities:
@@ -150,7 +152,7 @@ The Program plugin allows for program arguments to be added when launching an ap
 > - A parameter that starts with `--`.
 > - A parameter that starts with `/`.
 
-For example, when launching Visual Studio Code, you can specify the folder to be opened with:
+For example, when opening Visual Studio Code, specify the folder to be opened with:
 
 `Visual Studio Code -- C:\myFolder`
 
@@ -166,7 +168,7 @@ If the program plugin's option "Include in global result" is not selected, inclu
 
 > [!IMPORTANT]
 > Please be aware of the different decimal and thousand delimiters in different locals.
-> The Calculator plugin respects the number format settings of your system. If you prefer the English (United States) number format, you can change the behavior for the query input and the result output in the [plugin manager](#plugin-manager).
+> The Calculator plugin respects the number format settings of your system. If you prefer the English (United States) number format, change the behavior for the query input and the result output in the [plugin manager](#plugin-manager).
 > If your system's number format uses the comma (`,`) as the decimal delimiter, you have to write a space between the number(s) and comma(s) on operations with multiple parameters. The input has to look like this: `min( 1,2 , 3 , 5,7)` or `min( 1.2 , 3 , 5.7)`.
 
 > [!TIP]
@@ -360,9 +362,9 @@ In the Folder plugin you can filter the results by using some special characters
 
 | Character sequence | Result | Example |
 | :--- | :--- | :--- |
-| `>` | Search inside the folder. | `C:\Users\tom\Documents\>` |
-| `*` | Search files by mask. | `C:\Users\tom\Documents\*.doc` |
-| `>*` | Search files inside the folder by mask. | `C:\Users\tom\Documents\>*.doc` |
+| `>` | Search inside the folder | `C:\Users\tom\Documents\>` |
+| `*` | Search files by mask | `C:\Users\tom\Documents\*.doc` |
+| `>*` | Search files inside the folder by mask | `C:\Users\tom\Documents\>*.doc` |
 
 ### Windows Settings plugin
 
@@ -371,7 +373,7 @@ The Windows Settings plugin allows you to search for Windows settings. You can s
 To search by location you can use the following syntax:
 
 - `$ device:` to list all settings with 'device' in the area name.
-- `$ control>system>admin` shows all settings of the path Control Panel > System and Security > Administrative Tools.
+- `$ control>system>admin` to show all settings of the path Control Panel > System and Security > Administrative Tools.
 
 ### Service plugin
 
@@ -405,33 +407,33 @@ With the Window Walker plugin you can kill the process of a window if it stops r
 
 If the File Explorer settings in Windows are not set to open each window in a separate process, you will see the following message when searching for open Explorer windows:
 
-![Explorer Process Info in PowerToys Run.](../images/pt-run-explorer-info.png)
+![Explorer Process Info in PowerToys Run](../images/pt-run-explorer-info.png)
 
 You can turn off the message in the PowerToys Run plugin manager options for Window Walker, or select the message to change the File Explorer settings. On the **Folder options** window, select **Launch folder windows in a separate process**.
 
-![Folder Options Window.](../images/pt-run-folder-options.png)
+![Folder Options Window](../images/pt-run-folder-options.png)
 
 ### Windows Search plugin
 
-With the Windows Search plugin you can search for files and folders that are index by the `Windows Search Index` service.
+With the Windows Search plugin you can search for files and folders that are index by the **Windows Search Index** service.
 
 #### Windows Search settings
 
 If the indexing settings for Windows Search are not set to cover all drives, you will see the following warning when using the Windows Search plugin:
 
-![PowerToys Run Indexer Warning.](../images/pt-run-indexer-warning.png)
+![PowerToys Run Indexer Warning](../images/pt-run-indexer-warning.png)
 
-You can turn off the warning in the PowerToys Run plugin manager options for Windows Search, or select the warning to expand which drives are being indexed. After selecting the warning, the Windows settings page with the "Searching Windows" options will open.
+You can turn off the warning in the PowerToys Run plugin manager options for Windows Search, or select the warning to expand which drives are being indexed. After selecting the warning, the Windows settings page **Searching Windows** will open.
 
-![Indexing Settings.](../images/pt-run-indexing.png)
+![Indexing Settings](../images/pt-run-indexing.png)
 
-On the "Searching Windows" page, you can:
+On the **Searching Windows** page, you can:
 
 - Select **Enhanced** mode to enable indexing across all of the drives on your Windows machine.
 - Specify folder paths to exclude.
-- Select the **Advanced Search Indexer Settings** (near the bottom of the menu options) to set advanced index settings, add or remove search locations, index encrypted files, etc.
+- Select **Advanced Search Indexer Settings** to set advanced index settings, add or remove search locations, index encrypted files, etc.
 
-![Advanced Indexing Settings.](../images/pt-run-indexing-advanced.png)
+![Advanced Indexing Settings](../images/pt-run-indexing-advanced.png)
 
 ## Known issues
 

--- a/hub/powertoys/screen-ruler.md
+++ b/hub/powertoys/screen-ruler.md
@@ -14,14 +14,14 @@ Screen ruler allows you to quickly measure pixels on your screen based on image 
 
 ## How to activate
 
-Press <kbd>⊞ Win</kbd>+<kbd>Shift</kbd>+<kbd>M</kbd> to activate and then select which tool you want to measure with. To exit, press <kbd>Esc</kbd> or click &#9587; in the toolbar.
+Press <kbd>⊞ Win</kbd>+<kbd>Shift</kbd>+<kbd>M</kbd> to activate and then select which tool you want to measure with. To exit, press <kbd>Esc</kbd> or select &#9587; in the toolbar.
 
 ## How to use
 
-- Bounds (Dashed square symbol): This is a bounding box. Click and drag with your mouse. If you hold <kbd>Shift</kbd>, the box(es) will stay in place until you cancel the interaction.
-- Spacing (&#9547;): This will measure horizontal and vertical spacing at the same time.  Click the symbol and move your mouse to your target location.
-- Horizontal (&#9473;): This will measure only horizontal spacing. Click the symbol and move your mouse pointer to your target location.
-- Vertical (&#9475;): This will measure only vertical spacing. Click the symbol and move your mouse pointer to your target location.
+- Bounds (dashed square symbol): This is a bounding box. Click and drag with your mouse. If you hold <kbd>Shift</kbd>, the box(es) will stay in place until you cancel the interaction.
+- Spacing (&#9547;): This will measure horizontal and vertical spacing at the same time. Select the symbol and move your mouse to your target location.
+- Horizontal (&#9473;): This will measure only horizontal spacing. Select the symbol and move your mouse pointer to your target location.
+- Vertical (&#9475;): This will measure only vertical spacing. Select the symbol and move your mouse pointer to your target location.
 - Cancel interaction: <kbd>Esc</kbd>, &#9587; or mouse click. Upon clicking the primary mouse button, the measurement is copied to the clipboard.
 
 The controls on the toolbar can also be selected via <kbd>Ctrl</kbd>+<kbd>1</kbd>/<kbd>2</kbd>/<kbd>3</kbd>/<kbd>4</kbd>.

--- a/hub/powertoys/shortcut-guide.md
+++ b/hub/powertoys/shortcut-guide.md
@@ -19,7 +19,7 @@ Open the shortcut guide with the shortcut key combination: <kbd>⊞ Win</kbd>+<k
 - shortcuts for changing the position of the active window
 - taskbar shortcuts
 
-![Screenshot of shortcut overlay.](../images/pt-shortcut-guide-large.png)
+![Screenshot of shortcut overlay](../images/pt-shortcut-guide-large.png)
 
 Keyboard shortcuts using the Windows key <kbd>⊞ Win</kbd> can be used while the guide is displayed. The result of those shortcuts (active window moved, arrow shortcut behavior changes etc.) will be displayed in the guide.
 
@@ -37,10 +37,10 @@ These configurations can be edited from the PowerToys Settings:
 | Setting | Description |
 | :--- | :--- |
 | Activation method | Choose your own shortcut or use the <kbd>⊞ Win</kbd> key |
-| Activation shortcut | The custom shortcut used to launch the shortcut guide |
+| Activation shortcut | The custom shortcut used to open the shortcut guide |
 | Press duration | Time (in milliseconds) to hold down the <kbd>⊞ Win</kbd> key in order to open global Windows shortcuts or taskbar icon shortcuts |
 | App theme | Light, dark or Windows theme |
 | Opacity of background | Opacity of the Shortcut Guide overlay |
 | Excluded apps | Ignores Shortcut Guide when these apps are in focus. Add an application's name, or part of the name, one per line (e.g. adding `Notepad` will match both `Notepad.exe` and `Notepad++.exe`; to match only `Notepad.exe` add the `.exe` extension). |
 
-![Shortcut Guide settings.](../images/pt-shortcut-guide-settings.png)
+![Shortcut Guide settings](../images/pt-shortcut-guide-settings.png)

--- a/hub/powertoys/text-extractor.md
+++ b/hub/powertoys/text-extractor.md
@@ -16,7 +16,7 @@ With the activation shortcut (default: <kbd>⊞ Win</kbd>+<kbd>Shift</kbd>+<kbd>
 
 ## How to deactivate
 
-Capture mode is deactivated immediately after text in the selected region is recognized and copied to the clipboard. You can exit capture mode by pressing <kbd>Esc</kbd> at any moment.
+Capture mode is deactivated immediately after text in the selected region is recognized and copied to the clipboard. Exit capture mode with <kbd>Esc</kbd> at any moment.
 
 ## Adjust while trying to capture
 
@@ -26,7 +26,7 @@ By holding <kbd>Shift</kbd>, you will change from adjusting the capture region's
 >
 > 1. The produced text may not be perfect, so you have to do a quick proof read of the output.
 > 2. This tool uses OCR (Optical Character Recognition) to read text on the screen.
-> 3. The default language used will be based on your [Windows system language > keyboard settings](https://support.microsoft.com/windows/manage-the-input-and-display-language-settings-in-windows-12a10cb4-8626-9b77-0ccb-5013e0c7c7a2) (OCR language packs are available for install).
+> 3. The default language used will be based on your [Windows system language > Keyboard settings](https://support.microsoft.com/windows/manage-the-input-and-display-language-settings-in-windows-12a10cb4-8626-9b77-0ccb-5013e0c7c7a2). OCR language packs are available for installation.
 
 ## Settings
 
@@ -107,7 +107,7 @@ $Capability | Remove-WindowsCapability -Online
 
 This section will list possible errors and solutions.
 
-### "No Possible OCR languages are installed."
+### "No Possible OCR languages are installed"
 
 This message is shown when there are no available languages for recognition.
 

--- a/hub/powertoys/video-conference-mute.md
+++ b/hub/powertoys/video-conference-mute.md
@@ -10,7 +10,7 @@ no-loc: [PowerToys, Windows, File Explorer, Video Conference Mute, Shift]
 # Video Conference Mute
 
 > [!NOTE]
-> VCM is moving into legacy mode. Please find more about what this means [in our dedicated discussion issue](https://github.com/microsoft/PowerToys/issues/21473).
+> VCM is moving into legacy mode. Please find more about what this means [in our dedicated issue](https://github.com/microsoft/PowerToys/issues/21473).
 
 Quickly mute your microphone (audio) and turn off your camera (video) with a single keystroke while on a conference call, regardless of what application has focus on your computer.
 
@@ -23,13 +23,13 @@ The default shortcuts to use Video Conference Mute are:
 - <kbd>⊞ Win</kbd>+<kbd>Shift</kbd>+<kbd>I</kbd> to toggle microphone until key release
 - <kbd>⊞ Win</kbd>+<kbd>Shift</kbd>+<kbd>O</kbd> to toggle camera
 
-When using the microphone and/or camera toggle shortcut keys, you will see a small toolbar letting you know whether your microphone and camera are set to on, off, or not in use. You can set the position of this toolbar in the Video Conference Mute tab of PowerToys settings.
+When using the microphone and/or camera toggle shortcut keys, you'll see a small toolbar letting you know whether your microphone and camera are set to on, off, or not in use. Set the position of this toolbar in the Video Conference Mute tab of PowerToys settings.
 
-![Audio and Video mute notification screenshot.](../images/pt-video-audio-mute-notification.png)
+![Audio and Video mute notification screenshot](../images/pt-video-audio-mute-notification.png)
 
 To use this module, it must be selected as the _source_ in the apps that are using camera and/or microphone. Go to the settings and select PowerToys VCM.
 
-![Video Conference Mute selected as source in Skype.](../images/pt-vcm-source-in-app.png)
+![Video Conference Mute selected as source in Skype](../images/pt-vcm-source-in-app.png)
 
 ## Settings
 
@@ -46,7 +46,7 @@ The Video Conference Mute page in Settings provides the following options:
 | Show toolbar on | Select whether you prefer the toolbar to be displayed on the main monitor only (default) or on all monitors. |
 | Hide toolbar when both camera and microphone are unmuted | |
 
-![Video Conference Mute options in PowerToys settings.](../images/pt-video-conference-mute-settings.png)
+![Video Conference Mute options in PowerToys settings](../images/pt-video-conference-mute-settings.png)
 
 ## How this works under the hood
 


### PR DESCRIPTION
Did a rather general pass on these docs to improve some formatting. Also adjusted some text here and there, but all in small changes.
Changed a number of "launch" words to "open", but excluded the words that are still in the UI.

Question for a (possible) future PR: I see both "powertoys-" and "pt-" prefixes are used in the file names for images. Should we use one and the same? And if so, which one?