### PR TITLE
Update download.md - Fixed code typo.

### DIFF
--- a/hub/package-manager/winget/download.md
+++ b/hub/package-manager/winget/download.md
@@ -80,7 +80,7 @@ winget download --id Microsoft.WingetCreate --installer-type msix
 The following example downloads an application by architecture and scope to a specific download directory.
 
 ```CMD
-winget install --id Microsoft.PowerToys --scope machine --architecture x64 --download-directory <Path>
+winget download --id Microsoft.PowerToys --scope machine --architecture x64 --download-directory <Path>
 ```
 
 


### PR DESCRIPTION
The last code example on this page shows how to download an installer to a specific folder location, but the example incorrectly specifies 'winget install' instead of 'winget download'.