### PR TITLE
fix: use package id instead of display name in winget dsc example

### DIFF
--- a/hub/powertoys/dsc-configure.md
+++ b/hub/powertoys/dsc-configure.md
@@ -43,7 +43,7 @@ properties:
         description: Install PowerToys
         allowPrerelease: true
       settings:
-        id: PowerToys (Preview)
+        id: Microsoft.PowerToys
         source: winget
 
     - resource: PowerToysConfigure


### PR DESCRIPTION
I tried to use the example in the doc but got this error:

![image](https://github.com/MicrosoftDocs/windows-dev-docs/assets/39483124/5ff93347-bf24-4d5a-ba6b-2c829cf0c6f6)

I realised this is due to the DSC file calling for an ID and the example uses the package's display name instead. I found the correct ID with `winget search powertoys`:

![image](https://github.com/MicrosoftDocs/windows-dev-docs/assets/39483124/46c510f1-052f-475b-8f44-37015a61ba37)

Replaced it in the example and it works as expected. 

![image](https://github.com/MicrosoftDocs/windows-dev-docs/assets/39483124/2434c686-9a26-4406-806a-400460b7cfd4)
