### PR TITLE
[PowerToys]Update DSC samples

### DIFF
--- a/hub/powertoys/dsc-configure.md
+++ b/hub/powertoys/dsc-configure.md
@@ -39,14 +39,17 @@ However, creating a _configuration.dsc.yaml_ file that contains the required set
 properties:
   resources:
     - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: installPowerToys
       directives:
         description: Install PowerToys
         allowPrerelease: true
       settings:
-        id: PowerToys (Preview)
+        id: Microsoft.PowerToys
         source: winget
 
-    - resource: PowerToysConfigure
+    - resource: Microsoft.PowerToys.Configure/PowerToysConfigure
+      dependsOn:
+        - installPowerToys
       directives:
         description: Configure PowerToys
       settings:


### PR DESCRIPTION
Improve the DSC sample provided in the DSC documentation for PowerToys, according to the changes on https://github.com/microsoft/PowerToys/pull/32494:

- Use the full resource name to improve time for winget to find the resource.
- Make the configure step depend on the install step.
- Use PowerToys package full name for the install step.
