### PR TITLE
#32527 - Running with Administrator Permissions documentation is missing Mouse without Borders

### DIFF
--- a/hub/powertoys/administrator.md
+++ b/hub/powertoys/administrator.md
@@ -33,22 +33,24 @@ Admin mode permissions may be required in the following scenarios:
 
 - Always On Top
   - Pin windows that are elevated
-- File Locksmith
-  - End elevated processes
 - FancyZones
   - Snapping an elevated window (e.g. Task Manager) into a Fancy Zone
   - Moving the elevated window to a different zone
+- File Locksmith
+  - End elevated processes
 - Hosts file editor
-- Shortcut guide
-  - Display shortcut
 - Keyboard remapper
   - Key to key remapping
   - Global level shortcuts remapping
   - App-targeted shortcuts remapping
+- Mouse without Borders
+  - Use Service
 - PowerToys Run
   - Use shortcut
 - Registry Preview
   - Write keys to the registry
+- Shortcut guide
+  - Display shortcut
 - Video Conference Mute
 
 ## Run as administrator: elevated processes explained


### PR DESCRIPTION
Added Mouse without Borders to Affected PowerToys Utilities. Also made two small changes to fix the alpha sort of the PowerToys in the list.