### PR TITLE
changing message for mapping without azure portal

### DIFF
--- a/hub/apps/windows-app-sdk/notifications/push-notifications/push-quickstart.md
+++ b/hub/apps/windows-app-sdk/notifications/push-notifications/push-quickstart.md
@@ -75,10 +75,7 @@ Navigate to **Certificates & secrets** and select **New client secret**.
 
 ### Step 4: Map your app's Package Family Name to its Azure AppId
 
-> [!IMPORTANT]
-> Windows Push Notification Service (WNS) is now integrated with Azure Portal. The new registration experience is available in preview. If you're a packaged app (including packaged with external location), you can use this flow to map your app's Package Family Name (PFN) and its Azure AppId.
-
-If your app is a packaged Win32 app, then request access to our new Azure Portal *Preview* experience by emailing [Win_App_SDK_Push@microsoft.com](mailto:Win_App_SDK_Push@microsoft.com) with subject line "Windows App SDK Push Notifications Request" and body "Azure Subscription: \[your Azure Subscription ID\]". Requests are completed on a weekly basis. You will be notified once your mapping request has been completed.
+If your app is a packaged Win32 app, then create a Package Family Name (PFN) mapping request by emailing [Win_App_SDK_Push@microsoft.com](mailto:Win_App_SDK_Push@microsoft.com) with subject line "Windows App SDK Push Notifications Request" and body "PFN: \[your PFN\]", AppId: \[your APPId\], ObjectId: \[your ObjectId\]. Mapping requests are completed on a weekly basis. You will be notified once your mapping request has been completed.
 
 ## Configure your app to receive push notifications
 


### PR DESCRIPTION
Azure portal is being decommissioned, so altering public instructions for requesting the PFN mapping