### PR TITLE
[ContentDialog] All capital OK label in sample code

### DIFF
--- a/hub/apps/design/controls/dialogs-and-flyouts/dialogs.md
+++ b/hub/apps/design/controls/dialogs-and-flyouts/dialogs.md
@@ -74,7 +74,7 @@ private async void DisplayNoWifiDialog()
     {
         Title = "No wifi connection",
         Content = "Check your connection and try again.",
-        CloseButtonText = "Ok"
+        CloseButtonText = "OK"
     };
 
     ContentDialogResult result = await noWifiDialog.ShowAsync();
@@ -123,7 +123,7 @@ private async void DisplayNoWifiDialog()
     {
         Title = "No wifi connection",
         Content = "Check your connection and try again.",
-        CloseButtonText = "Ok"
+        CloseButtonText = "OK"
     };
 
     ContentDialogResult result = await noWifiDialog.ShowAsync();
@@ -265,7 +265,7 @@ private async void DisplayNoWifiDialog()
     {
         Title = "No wifi connection",
         Content = "Check your connection and try again.",
-        CloseButtonText = "Ok"
+        CloseButtonText = "OK"
     };
 
     // Use this code to associate the dialog to the appropriate AppWindow by setting


### PR DESCRIPTION
In the `Dialog` docs, we explicitly call out the following:

`A confirmation dialog gives users the chance to confirm that they want to perform an action. They can affirm the action, or choose to cancel. A typical confirmation dialog has two buttons: an affirmation ("OK") button and a cancel button.`

However, in the samples we use the string "Ok". Across the Windows OS, we seem to be using `OK` vs `Ok`. This was pointed out as an inconsistency on Twitter: https://x.com/fonssonnemans/status/1795026947824631878