### PR TITLE
Update custom-dependency-properties.md to provide example and more details of proper collection initialization

### DIFF
--- a/uwp/xaml-platform/custom-dependency-properties.md
+++ b/uwp/xaml-platform/custom-dependency-properties.md
@@ -75,7 +75,7 @@ For C++/CX, you have options for how you split the implementation between the he
 
 ```csharp
 public static readonly DependencyProperty LabelProperty = DependencyProperty.Register(
-  "Label",
+  nameof(Label),
   typeof(String),
   typeof(ImageWithLabelControl),
   new PropertyMetadata(null)
@@ -257,7 +257,7 @@ This next example modifies the previously shown [**DependencyProperty.Register**
 
 ```csharp
 public static readonly DependencyProperty LabelProperty = DependencyProperty.Register(
-  "Label",
+  nameof(Label),
   typeof(String),
   typeof(ImageWithLabelControl),
   new PropertyMetadata(null,new PropertyChangedCallback(OnLabelChanged))
@@ -457,6 +457,32 @@ Nevertheless, scenarios for collection-type dependency properties do exist. The 
 ### Initializing the collection
 
 When you create a dependency property, you can establish a default value by means of dependency property metadata. But be careful to not use a singleton static collection as the default value. Instead, you must deliberately set the collection value to a unique (instance) collection as part of class-constructor logic for the owner class of the collection property.
+
+```csharp
+// WARNING - DO NOT DO THIS
+public static readonly DependencyProperty ItemsProperty = DependencyProperty.Register(
+  nameof(Items),
+  typeof(IList<object>),
+  typeof(ImageWithLabelControl),
+  new PropertyMetadata(new List<object>())
+);
+
+// DO THIS Instead
+public static readonly DependencyProperty ItemsProperty = DependencyProperty.Register(
+  nameof(Items),
+  typeof(IList<object>),
+  typeof(ImageWithLabelControl),
+  new PropertyMetadata(null)
+);
+
+public ImageWithLabelControl()
+{
+    // Need to initialize in constructor instead
+    Items = new List<object>();
+}
+```
+
+A DependencyProperty and its PropertyMetadata's default value are part of the static definition of the DependencyProperty. By providing a default collection (or other instanced) value as the default value, it will be shared across all instances of your class instead of each class having its own collection, as would typically be desired.
 
 ### Change notifications
 


### PR DESCRIPTION
This is a common pitfall that I myself have made but that I see others make as well.

As by default you'll initialize it to null...
Then get an error about XAML not being able to add to an uninitialized collection...
So then folks naturally set the default to a new collection...
Which would make sense, except that's not what needs to done as it's static so it then shares that collection across instances.

This is called out in the docs here, but it's not immediate evident that's what this scenario is describing and what it's talking about without an example.

This PR adds the common pattern that's what not to do in contrast with the proper fix as well as more details about what's happening.