### PR TITLE
Fixed a missing slash in redirection rules

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -8277,7 +8277,7 @@
     },
     {
       "source_path": "hub/dev-home/project-ironsides.md",
-      "redirect_url": "windows/dev-home/dev-diagnostics",
+      "redirect_url": "/windows/dev-home/dev-diagnostics",
       "redirect_document_id": false
     }
   ]


### PR DESCRIPTION
Fixed a missing slash for the rule "Dev Home --> Dev Diagnostics" to make sure it works properly.