### PR TITLE
Added `Microsoft.Rest` type

### DIFF
--- a/hub/package-manager/winget/source.md
+++ b/hub/package-manager/winget/source.md
@@ -106,11 +106,12 @@ For example,  `winget source add --name Contoso https://www.contoso.com/cache` a
 
 #### Optional type parameter
 
-The **add** subcommand supports the optional **type** parameter, which tells the client what type of repository it is connecting to. The following type is supported.
+The **add** subcommand supports the optional **type** parameter, which tells the client what type of repository it is connecting to. The following types are supported.
 
 | Type  | Description |
 |--------------|-------------|
 | **Microsoft.PreIndexed.Package** | The default source type. |
+| **Microsoft.Rest** | A Microsoft REST API source. |
 
 ### list
 


### PR DESCRIPTION
On the winget source documentation page, there is a missing supported source type, namely `Microsoft.Rest`. 

E.g. see the Winget [troubleshooting page](https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting#:~:text=%3E%20winget%20source%20add%20%2Dn%20mysource%20%2Dt%20Microsoft.REST%20%2Da%20https%3A//www.contoso.org%20%2D%2Dverbose) which shows examples of `Microsoft.Rest` usage.

