### PR TITLE
Add Serbian Cyrillic to Power Accent supported character sets

### DIFF
--- a/hub/powertoys/quick-accent.md
+++ b/hub/powertoys/quick-accent.md
@@ -56,6 +56,7 @@ You can limit the available characters by selecting a character set from the set
 * Slovenian
 * Spanish
 * Serbian
+* Serbian Cyrillic
 * Swedish
 * Turkish
 * Welsh


### PR DESCRIPTION
* Add "Serbian Cyrillic" to the list of supported character sets in `hub/powertoys/quick-accent.md`

Documentation for this [PR](https://github.com/microsoft/PowerToys/pull/35500)