### PR TITLE
Update use-windows-app-sdk-in-existing-project.md

### DIFF
--- a/hub/apps/windows-app-sdk/use-windows-app-sdk-in-existing-project.md
+++ b/hub/apps/windows-app-sdk/use-windows-app-sdk-in-existing-project.md
@@ -26,7 +26,7 @@ If you have a desktop project in which you want to use the Windows App SDK, then
 1. Open an existing project in Visual Studio.
 
     > [!NOTE]
-    > If you have a C# desktop project, then make sure that the **TargetFramework** element in the project file is set to a Windows 10-specific moniker (such as **net6.0-windows10.0.19041.0**) so that you can call Windows Runtime APIs. For more info, see [Call Windows Runtime APIs in desktop apps](../../apps/desktop/modernize/desktop-to-uwp-enhance.md#net-6-and-later-use-the-target-framework-moniker-option). Additionally, you must be targeting **18362** or later, since there's a known issue blocking apps that target **17763** (see [Build errors when using TFM of 17763](https://github.com/microsoft/WindowsAppSDK/issues/921) on GitHub).
+    > If you have a C# desktop project, then make sure that the **TargetFramework** element in the project file is set to a Windows 10-specific moniker (such as **net6.0-windows10.0.19041.0**) so that you can call Windows Runtime APIs. For more info, see [Call Windows Runtime APIs in desktop apps](../../apps/desktop/modernize/desktop-to-uwp-enhance.md#net-6-and-later-use-the-target-framework-moniker-option).
 
 2. Make sure that [package references](/nuget/consume-packages/package-references-in-project-files) are enabled:
 


### PR DESCRIPTION
Remove the restriction of using Windows version 10.0.17763 as the corresponding GitHub issue has been resolved.
I tested TFM like net8.0-windows10.0.17763.0 for C# desktop or console app, and build was successful.