### PR TITLE
Set BindingContext for Data Binding in MainPage Constructor

### DIFF
--- a/hub/apps/windows-dotnet-maui/tutorial-csharp-ui-maui-toolkit.md
+++ b/hub/apps/windows-dotnet-maui/tutorial-csharp-ui-maui-toolkit.md
@@ -140,6 +140,7 @@ Because the UI elements are going to be defined in the C# code, the `InitializeC
 ```csharp
 public MainPage()
 {
+    BindingContext = ViewModel;
     Content = new Grid
     {
         RowDefinitions = Rows.Define(


### PR DESCRIPTION
This ensures that the BindingContext of MainPage is properly set to the corresponding ViewModel instance.