### PR TITLE
Fix inverted WidgetId and WidgetName

### DIFF
--- a/hub/apps/develop/widgets/implement-widget-provider-cs.md
+++ b/hub/apps/develop/widgets/implement-widget-provider-cs.md
@@ -426,7 +426,7 @@ public WidgetProvider()
         var customState = widgetInfo.CustomState;
         if (!RunningWidgets.ContainsKey(widgetId))
         {
-            CompactWidgetInfo runningWidgetInfo = new CompactWidgetInfo() { widgetId = widgetName, widgetName = widgetId };
+            CompactWidgetInfo runningWidgetInfo = new CompactWidgetInfo() { widgetId = widgetId, widgetName = widgetName };
             try
             {
                 // If we had any save state (in this case we might have some state saved for Counting widget)


### PR DESCRIPTION
The `widgetId` and `widgetName` are inverted; This gave me really some headache