### PR TITLE
[PowerToys]Deprecate VCM

### DIFF
--- a/hub/powertoys/index.md
+++ b/hub/powertoys/index.md
@@ -294,17 +294,6 @@ The currently available utilities include:
     :::column-end:::
 :::row-end:::
 
-### Video Conference Mute
-
-:::row:::
-    :::column:::
-        [![Video Conference Mute screenshot](../images/pt-video-conference-mute.png)](video-conference-mute.md)
-    :::column-end:::
-    :::column span="2":::
-        [Video Conference Mute](video-conference-mute.md) is a quick way to globally "mute" both your microphone and camera using <kbd>⊞ Win</kbd>+<kbd>Shift</kbd>+<kbd>Q</kbd> while on a conference call, regardless of the application that currently has focus.
-    :::column-end:::
-:::row-end:::
-
 ## Languages
 
 PowerToys is currently available in the following languages: Arabic (Saudi Arabia), Chinese (simplified), Chinese (traditional), Czech, Dutch, English, French, German, Hebrew, Hungarian, Italian, Japanese, Korean, Persian, Polish, Portuguese, Portuguese (Brazil), Russian, Spanish, Turkish, Ukrainian.
@@ -345,3 +334,18 @@ PowerToys is a rapid-incubation, open source team aimed at providing power users
 
 - [New specs for possible PowerToys](https://github.com/microsoft/PowerToys/wiki/Specs)
 - [Backlog priority list](https://github.com/microsoft/PowerToys/wiki/Roadmap#backlog-priority-list-in-order)
+
+## Deprecated PowerToy utilities
+
+These utilities have been deprecated and removed from PowerToys:
+
+### Video Conference Mute (Deprecated and removed on PowerToys 0.88)
+
+:::row:::
+    :::column:::
+        [![Video Conference Mute screenshot](../images/pt-video-conference-mute.png)](video-conference-mute.md)
+    :::column-end:::
+    :::column span="2":::
+        [Video Conference Mute](video-conference-mute.md) is a quick way to globally "mute" both your microphone and camera using <kbd>⊞ Win</kbd>+<kbd>Shift</kbd>+<kbd>Q</kbd> while on a conference call, regardless of the application that currently has focus.
+    :::column-end:::
+:::row-end:::

--- a/hub/powertoys/video-conference-mute.md
+++ b/hub/powertoys/video-conference-mute.md
@@ -7,10 +7,10 @@ ms.localizationpriority: medium
 no-loc: [PowerToys, Windows, File Explorer, Video Conference Mute, Shift]
 ---
 
-# Video Conference Mute
+# Video Conference Mute (Deprecated)
 
 > [!NOTE]
-> VCM is moving into legacy mode. Please find more about what this means [in our dedicated issue](https://github.com/microsoft/PowerToys/issues/21473).
+> VCM has been deprecated and removed on PowerToys version 0.88.0. This page is being kept for users that are still using it on older versions of PowerToys.
 
 Quickly mute your microphone (audio) and turn off your camera (video) with a single keystroke while on a conference call, regardless of what application has focus on your computer.
 


### PR DESCRIPTION
This PR adds a section for deprecated utilities at the bottom of the index page. It also makes it clearer that Video Conference Mute has been deprecated.
This should only be merged after PowerToys 0.88 is released.