### PR TITLE
Update system-backdrop-controller.md - Add a note that materials with customized properties do not react to theme changes

### DIFF
--- a/hub/apps/windows-app-sdk/system-backdrop-controller.md
+++ b/hub/apps/windows-app-sdk/system-backdrop-controller.md
@@ -217,7 +217,7 @@ The controller reacts to the system Light and Dark themes by default. To overrid
 
 > [!NOTE]
 >
-> After customizing any of the controller’s four properties, it no longer applies default Light or Dark values when the associated [SystemBackdropConfiguration.Theme](/windows/windows-app-sdk/api/winrt/microsoft.ui.composition.systembackdrops.systembackdropconfiguration.theme?view=windows-app-sdk-1.6#microsoft-ui-composition-systembackdrops-systembackdropconfiguration-theme) changes. You need to manually update those properties to match the new theme.
+> After customizing any of the controller’s four properties, it no longer applies default Light or Dark values when the associated [SystemBackdropConfiguration.Theme](/windows/windows-app-sdk/api/winrt/microsoft.ui.composition.systembackdrops.systembackdropconfiguration.theme) changes. You need to manually update those properties to match the new theme.
 
 In order to use the backdrop material in your app, the following items are required:
 

--- a/hub/apps/windows-app-sdk/system-backdrop-controller.md
+++ b/hub/apps/windows-app-sdk/system-backdrop-controller.md
@@ -215,6 +215,10 @@ The controller reacts to the system Light and Dark themes by default. To overrid
 - [TintColor](/windows/windows-app-sdk/api/winrt/microsoft.ui.composition.systembackdrops.micacontroller.tintcolor)
 - [TintOpacity](/windows/windows-app-sdk/api/winrt/microsoft.ui.composition.systembackdrops.micacontroller.tintopacity)
 
+> [!NOTE]
+>
+> After customizing any of the controller’s four properties, it no longer applies default Light or Dark values when the associated [SystemBackdropConfiguration.Theme](/windows/windows-app-sdk/api/winrt/microsoft.ui.composition.systembackdrops.systembackdropconfiguration.theme?view=windows-app-sdk-1.6#microsoft-ui-composition-systembackdrops-systembackdropconfiguration-theme) changes. You need to manually update those properties to match the new theme.
+
 In order to use the backdrop material in your app, the following items are required:
 
 - **System support**


### PR DESCRIPTION
Add a note on materials with customized controller properties will no longer reacts to Light/Dark theme changes.

Doc change request based on community reported issue for Windows App SDK: https://github.com/microsoft/WindowsAppSDK/issues/3589 and https://github.com/microsoft/WindowsAppSDK/issues/3589, where the developer was confused when, after flipping theme between Dark and Light, materials with non-default controller properties fail to automatically make corresponding changes.