### PR TITLE
fix(sandbox): add -AllUsers to Repair-WinGetPackageManager

### DIFF
--- a/hub/package-manager/winget/index.md
+++ b/hub/package-manager/winget/index.md
@@ -39,7 +39,7 @@ Write-Host "Installing WinGet PowerShell module from PSGallery..."
 Install-PackageProvider -Name NuGet -Force | Out-Null
 Install-Module -Name Microsoft.WinGet.Client -Force -Repository PSGallery | Out-Null
 Write-Host "Using Repair-WinGetPackageManager cmdlet to bootstrap WinGet..."
-Repair-WinGetPackageManager
+Repair-WinGetPackageManager -AllUsers
 Write-Host "Done."
 ```
 


### PR DESCRIPTION
Without -AllUsers the command fails with the following error message
<details>
  <summary>Click to expand</summary>

>   PS C:\Users\WDAGUtilityAccount> Install-PackageProvider -Name NuGet -Force | Out-Null                                   PS C:\Users\WDAGUtilityAccount> Install-Module -Name Microsoft.WinGet.Client -Force -Repository PSGallery | Out-Null    PS C:\Users\WDAGUtilityAccount> Repair-WinGetPackageManager                                                             Repair-WinGetPackageManager : Deployment failed with HRESULT: 0x80073CF9, Fehler bei der Installation. Wenden Sie sich  an den Softwarehersteller.                                                                                              Der Bereitstellungsvorgang "Add" mit Zielvolume "C:" für das Paket                                                      "Microsoft.DesktopAppInstaller_2025.228.315.0_neutral_~_8wekyb3d8bbwe" von "                                            (Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle) " ist mit dem Fehler 0x80D02002 fehlgeschlagen. Weitere        Informationen zum Diagnostizieren von Problemen bei der Bereitstellung von Apps finden Sie unter
> "http://go.microsoft.com/fwlink/?LinkId=235160".
> NOTE: For additional information, look for [ActivityId] 48b6168e-a0cd-0006-fe51-b648cda0db01 in the Event Log or use
> the command line Get-AppPackageLog -ActivityID 48b6168e-a0cd-0006-fe51-b648cda0db01
> At line:1 char:1
> + Repair-WinGetPackageManager
> + ~~~~~~~~~~~~~~~~~~~~~~~~~~~
>     + CategoryInfo          : WriteError: (https://github....bbwe.msixbundle:String) [Repair-WinGetPackageManager], IO
>    Exception
>     + FullyQualifiedErrorId : DeploymentError,Microsoft.WinGet.Client.Commands.RepairWinGetPackageManagerCmdlet
> 
> Repair-WinGetPackageManager : Deployment failed with HRESULT: 0x80073CF9, Fehler bei der Installation. Wenden Sie sich
> an den Softwarehersteller.
> Der Bereitstellungsvorgang "Add" mit Zielvolume "C:" für das Paket
> "Microsoft.DesktopAppInstaller_2025.228.315.0_neutral_~_8wekyb3d8bbwe" von "
> (Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle) " ist mit dem Fehler 0x80D02002 fehlgeschlagen. Weitere
> Informationen zum Diagnostizieren von Problemen bei der Bereitstellung von Apps finden Sie unter
> "http://go.microsoft.com/fwlink/?LinkId=235160".
> NOTE: For additional information, look for [ActivityId] 48b6168e-a0cd-0006-fe51-b648cda0db01 in the Event Log or use
> the command line Get-AppPackageLog -ActivityID 48b6168e-a0cd-0006-fe51-b648cda0db01
> At line:1 char:1
> + Repair-WinGetPackageManager
> + ~~~~~~~~~~~~~~~~~~~~~~~~~~~
>     + CategoryInfo          : WriteError: (https://github....bbwe.msixbundle:String) [Repair-WinGetPackageManager], IO
>    Exception
>     + FullyQualifiedErrorId : DeploymentError,Microsoft.WinGet.Client.Commands.RepairWinGetPackageManagerCmdlet
> 
> PS C:\Users\WDAGUtilityAccount>

</details>
