### PR TITLE
Updates for the WinGet configuration sample

### DIFF
--- a/hub/package-manager/configuration/create.md
+++ b/hub/package-manager/configuration/create.md
@@ -62,16 +62,18 @@ properties:
       settings:
         MinVersion: '10.0.22000'
   resources:
-    - resource: Microsoft.Windows.Developer/DeveloperMode
+    - resource: Microsoft.Windows.Settings/WindowsSettings
       directives:
         description: Enable Developer Mode
         allowPrerelease: true
+        securityContext: elevated
       settings:
-        Ensure: Present
+        DeveloperMode: true
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       id: vsPackage
       directives:
         description: Install Visual Studio 2022 Community
+        securityContext: elevated
       settings:
         id: Microsoft.VisualStudio.2022.Community
         source: winget
@@ -81,6 +83,7 @@ properties:
       directives:
         description: Install required VS workloads from vsconfig file
         allowPrerelease: true
+        securityContext: elevated
       settings:
         productId: Microsoft.VisualStudio.Product.Community
         channelId: VisualStudio.17.Release
@@ -99,7 +102,7 @@ The components of this file consist of:
 
 4. **Resources**: Both the `assertions` and `resources` list sections consist of individual `resource` nodes to represent the set up task. The `resource` should be given the name of the PowerShell module followed by the name of the module's DSC resource that will be invoked to apply your desired state: `{ModuleName}/{DscResource}`. Each resource must include `directives` and `settings`. Optionally, it can also include an `id` value. When applying a configuration, WinGet will know to install the module from the [PowerShell Gallery](https://www.powershellgallery.com/packages) and invoke the specified [DSC resource](/powershell/dsc/concepts/resources).
 
-5. **Directives**: The `directives` section provides information about the module and the resource. This section should include a `description` value to describe the configuration task being accomplished by the module. The `allowPrerelease` value enables you to choose whether or not the configuration will be allowed (`true`) to use "Prerelease" modules from the [PowerShell Gallery](https://www.powershellgallery.com/packages).
+5. **Directives**: The `directives` section provides information about the module and the resource. This section should include a `description` value to describe the configuration task being accomplished by the module. The `allowPrerelease` value enables you to choose whether or not the configuration will be allowed (`true`) to use "Prerelease" modules from the [PowerShell Gallery](https://www.powershellgallery.com/packages). Some DSC resources may need to run with administrator privileges. The `securityContext: elevated` field under the directives section of a resource indicates this requirement. When set to `elevated`, WinGet will prompt for one UAC approval at the start of the configuration. WinGet will then launch two processes: one that runs resources with elevated privileges and another that runs resources with the current user's privileges.
 
 6. **Settings**: The `settings` value of a resource represents the collection of name-value pairs being passed to the PowerShell DSC Resource. Settings could represent anything from whether Developer Mode is enabled, to applying a reg key, or to establishing a particular network setting.
 

--- a/hub/package-manager/configuration/index.md
+++ b/hub/package-manager/configuration/index.md
@@ -26,7 +26,7 @@ The benefits of using a WinGet Configuration file include:
 
 ## Use a WinGet Configuration file to configure your machine
 
-To set up your machine using a WinGet Configuration file, use [winget configure](../winget/configure.md) in the command line. To use the `winget configure` command, you must be running WinGet version [v1.6.2631 or later](https://github.com/microsoft/winget-cli/releases).
+To set up your machine using a WinGet Configuration file, download the configuration file and double-click to invoke the configuration. Alternatively, use [winget configure](../winget/configure.md) in the command line. To use the `winget configure` command, you must be running WinGet version [v1.6.2631 or later](https://github.com/microsoft/winget-cli/releases).
 
 ## WinGet Configuration FAQs
 
@@ -61,7 +61,7 @@ A benefit to the declarative (non-sequential) nature of WinGet configuration fil
 
 ### How do I use a WinGet Configuration file?
 
-To run a WinGet Configuration file, use the [`winget configure` command](../winget/configure.md).
+To run a WinGet Configuration file, you can simply double-click to run the file in file explorer. Alternatively, you can use the [`winget configure` command](../winget/configure.md).
 
 ### How do I author a WinGet Configuration?
 


### PR DESCRIPTION
- Use Microsoft.Windows.Settings module for enabling developer mode
- Add securityContext: elevated to resources that require elevation
- Add a note in the Directives section for securityContext
- Update the docs stating that WinGet configuration files can also be run directly through file explorer by double clicking