### PR TITLE
[x:Bind] Document TargetNullValue behavior with functions

### DIFF
--- a/uwp/data-binding/function-bindings.md
+++ b/uwp/data-binding/function-bindings.md
@@ -170,6 +170,9 @@ Multiple function arguments can be specified, separated by comma's (,)
 - Constant Number - for example -123.456
 - Boolean – specified as "x:True" or "x:False"
 
+> [!TIP]
+> [`TargetNullValue`](../xaml-platform/x-bind-markup-extension.md#properties-that-you-can-set-with-xbind) will apply to the result of the function call, not to any bound arguments.
+
 ### Two way function bindings
 
 In a two-way binding scenario, a second function must be specified for the reverse direction of the binding. This is done using the **BindBack** binding property. In the below example, the function should take one argument which is the value that needs to be pushed back to the model.


### PR DESCRIPTION
Today, we don't document how x:Bind behaves when you use functions & `TargetNullValue` together:

```
"{x:Bind local:ConverterFunctions.QualityTypeToColor(ViewModel.QualityType), Mode=OneWay, TargetNullValue='#FF808080'}"
```

This documents that the `TargetNullValue` is applied if the function returns a null, not if the arguments are null.