### PR TITLE
Replace &mdash; with '—' in title

### DIFF
--- a/hub/apps/develop/platform/csharp-winrt/create-windows-runtime-component-cswinrt.md
+++ b/hub/apps/develop/platform/csharp-winrt/create-windows-runtime-component-cswinrt.md
@@ -1,5 +1,5 @@
 ---
-title: Walkthrough&mdash;Create a C#/WinRT component, and consume it from C++/WinRT
+title: Walkthrough—Create a C#/WinRT component, and consume it from C++/WinRT
 description: Author a Windows Runtime component with C#/WinRT, and consume it from a native application.
 ms.date: 03/15/2022
 ms.topic: article

--- a/hub/apps/develop/platform/csharp-winrt/create-winrt-component-winui-cswinrt.md
+++ b/hub/apps/develop/platform/csharp-winrt/create-winrt-component-winui-cswinrt.md
@@ -1,5 +1,5 @@
 ---
-title: Walkthrough&mdash;Create a C# component with WinUI 3 controls, and consume it from a C++/WinRT app that uses the Windows App SDK
+title: Walkthrough—Create a C# component with WinUI 3 controls, and consume it from a C++/WinRT app that uses the Windows App SDK
 description: Author a Windows Runtime component with C#/WinRT with WinUI controls, and consume it from any Windows App SDK app.
 ms.date: 03/15/2022
 ms.topic: article


### PR DESCRIPTION
&mdash; can't be encoded in the title metadata