### PR TITLE
Reference the newly introduced title bar control in title bar customization

### DIFF
--- a/hub/apps/develop/title-bar.md
+++ b/hub/apps/develop/title-bar.md
@@ -22,7 +22,7 @@ See the [Title bar](../design/basics/titlebar-design.md) design article for guid
 > This article shows how to customize the title bar for apps that use the Windows App SDK, either with or without WinUI 3. For apps that use UWP and WinUI 2, see [Title bar customization](/windows/uwp/ui-input/title-bar) for UWP.
 
 > [!IMPORTANT]
-> The Windows App SDK has introduced a new [title bar](https://learn.microsoft.com/en-us/windows/apps/design/controls/title-bar) control in version 1.7. It simplifies the process of title bar customization.
+> A new [Title bar](../design/controls/title-bar.md) control has been added in Windows App SDK 1.7. It simplifies the process of title bar customization.
 
 > [!div class="checklist"]
 >
@@ -888,7 +888,9 @@ public sealed partial class MainWindow : Window
 ## Related articles
 
 - [Title bar customization (UWP)](/windows/uwp/ui-input/title-bar)
+- [Title Bar (Control)](../design/controls/title-bar.md)
 - [Acrylic](../design/style/acrylic.md)
 - [Mica](../design/style/mica.md)
 - [Color](../design/style/color.md)
+
 

--- a/hub/apps/develop/title-bar.md
+++ b/hub/apps/develop/title-bar.md
@@ -21,6 +21,9 @@ See the [Title bar](../design/basics/titlebar-design.md) design article for guid
 > [!IMPORTANT]
 > This article shows how to customize the title bar for apps that use the Windows App SDK, either with or without WinUI 3. For apps that use UWP and WinUI 2, see [Title bar customization](/windows/uwp/ui-input/title-bar) for UWP.
 
+> [!IMPORTANT]
+> The Windows App SDK has introduced a new [title bar](https://learn.microsoft.com/en-us/windows/apps/design/controls/title-bar) control in version 1.7. It simplifies the process of title bar customization.
+
 > [!div class="checklist"]
 >
 > - **Applies to**: Windows App SDK, WinUI 3 desktop apps
@@ -888,3 +891,4 @@ public sealed partial class MainWindow : Window
 - [Acrylic](../design/style/acrylic.md)
 - [Mica](../design/style/mica.md)
 - [Color](../design/style/color.md)
+


### PR DESCRIPTION
The Windows App SDK has added the title bar control in version 1.7
Searching "WinUI 3 title bar" still shows the old title bar customization page, with the new title bar control page usually being lower. I added a label to show that it exists.