### PR TITLE
Update PowerToys index.md - spelling nit and Find My Mouse clarification

### DIFF
--- a/hub/powertoys/index.md
+++ b/hub/powertoys/index.md
@@ -58,7 +58,7 @@ The currently available utilities include:
         [![A screenshot of the PowerToys Awake utility for Windows.](../images/powertoys-awake/pt-awake-menu.png)](awake.md)
     :::column-end:::
     :::column span="2":::
-        [PowerToys Awake](awake.md) is designed to keep a computer awake without having to manage its power & sleep settings. This behavior can be helpful when running time-consuming tasks, ensuring that the computer doesn't go to sleep or turns off its displays.
+        [PowerToys Awake](awake.md) is designed to keep a computer awake without having to manage its power & sleep settings. This behavior can be helpful when running time-consuming tasks, ensuring that the computer doesn't go to sleep or turn off its displays.
     :::column-end:::
 :::row-end:::
 
@@ -192,7 +192,7 @@ The currently available utilities include:
     :::column-end:::
     :::column span="2":::
         [Mouse utilities](mouse-utilities.md) add functionality to enhance your mouse and cursor.
-        - **Find My Mouse**: Quickly locate your mouse's position with a spotlight that focuses on your cursor. This feature is based on source code developed by [Raymond Chen](https://github.com/oldnewthing).
+        - **Find My Mouse**: Quickly locate your mouse pointer with a spotlight that focuses on its current position. This feature is based on source code developed by [Raymond Chen](https://github.com/oldnewthing).
         - **Mouse Highlighter**: Displays visual indicators when basic mouse buttons are clicked.
         - **Mouse Jump**: Allows a quick jump on large displays.
         - **Mouse Pointer Crosshairs**: Draws crosshairs centered on the mouse pointer.


### PR DESCRIPTION
- Correct small pluralisation error in Awake description.
- Remove ambiguity in Find My Mouse description, where mouse pointer and 'cursor' were used interchangeably. The user could be confused between mouse pointer and text caret/cursor.