### PR TITLE
Updated docs to indicate lack of support for school accounts

### DIFF
--- a/hub/apps/distribute-through-store/how-to-use-store-web-installer-for-distribution.md
+++ b/hub/apps/distribute-through-store/how-to-use-store-web-installer-for-distribution.md
@@ -34,7 +34,7 @@ This functionality isn't currently available for the following content types:
 
 - MSIXVC apps published on the Microsoft Store
 - Paid content published on the Microsoft Store
-- Content rated above Everyone/ESRB (or equivalent) while signed in to Windows using an Enterprise account 
+- Content rated above Everyone/ESRB (or equivalent) while signed in to Windows using a School account
 
 ## Enable this feature for your app
 


### PR DESCRIPTION
Changed a word from "Enterprise" to "School" to indicate that the portable web installer is NOT going to run for apps that are >E rating for users using school accounts.