### PR TITLE
Fix typo: change "let's" → "lets" in scroll-controls.md

### DIFF
--- a/hub/apps/design/controls/scroll-controls.md
+++ b/hub/apps/design/controls/scroll-controls.md
@@ -184,7 +184,7 @@ This table describes the visibility options for these properties.
 
 ### Orientation
 
-The ScrollView control has a [ContentOrientation](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.scrollview.contentorientation) property that let's you control the layout of content. This property determines how content can grow when it's not explicitly constrained. If `Height` and `Width` are explicitly set on the content, `ContentOrientation` has no effect.
+The ScrollView control has a [ContentOrientation](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.scrollview.contentorientation) property that lets you control the layout of content. This property determines how content can grow when it's not explicitly constrained. If `Height` and `Width` are explicitly set on the content, `ContentOrientation` has no effect.
 
 This table shows the `ContentOrientation` options for [ScrollView](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.scrollview) and the equivalent settings for [ScrollViewer](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.scrollviewer).
 
@@ -547,3 +547,4 @@ We recommend using the latest [WinUI 2](/windows/uwp/get-started/winui2/) to get
 ## Related topics
 
 - [ScrollViewer class](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Controls.ScrollViewer)
+


### PR DESCRIPTION
This PR fixes a minor typo in the Scroll Controls docs:

Original: "control has a ContentOrientation property that let's you control the ..."  
Corrected: "control has a ContentOrientation property that lets you control the ..."

Previous commits referencing issue #5492 did not fix this.  

Fixes #5492
