### PR TITLE
[PowerToys] Extract MSI from EXE for WiX v5

### DIFF
--- a/hub/powertoys/install.md
+++ b/hub/powertoys/install.md
@@ -86,7 +86,7 @@ Copilot is powered by AI, so surprises and mistakes are possible. For more infor
 
 ### Extracting the MSI from the bundle for 0.94 and later
 
-Make sure to have [.NET SDK](https://dotnet.microsoft.com/download/) installed.
+Make sure to have the [.NET SDK](https://dotnet.microsoft.com/download/) installed.
 
 In PowerShell, run `dotnet tool install wix --global` to install the latest version of WiX Toolset.
 
@@ -98,7 +98,7 @@ wix burn extract ${Env:\USERPROFILE}"\Desktop\PowerToysSetup-0.94.0-x64.exe" -ou
 
 ### Extracting the MSI from the bundle for 0.93 and earlier
 
-Make sure to have the [WiX Toolset v3](https://docs.firegiant.com/wix/wix3/) installed. The command doesn't work with WiX Toolset v4 and later versions.
+Make sure to have [WiX Toolset v3](https://docs.firegiant.com/wix/wix3/) installed. The command doesn't work with WiX Toolset v4 and later versions.
 
 This PowerShell example assumes the default install location for WiX Toolset and that the PowerToys installer has been downloaded to the Windows desktop.
 

--- a/hub/powertoys/install.md
+++ b/hub/powertoys/install.md
@@ -84,9 +84,21 @@ Generate a `winget` command to install Microsoft PowerToys with arguments to ins
 
 Copilot is powered by AI, so surprises and mistakes are possible. For more information, see [Copilot FAQs](https://www.microsoft.com/microsoft-copilot/learn/).
 
-### Extracting the MSI from the bundle
+### Extracting the MSI from the bundle for 0.94 and later
 
-Make sure to have [WiX Toolset v3](https://docs.firegiant.com/wix/wix3/) installed. The command doesn't work with WiX Toolset v4.
+Make sure to have [.NET SDK](https://dotnet.microsoft.com/download/) installed.
+
+In PowerShell, run `dotnet tool install wix --global` to install the latest version of WiX Toolset.
+
+This PowerShell example assumes that the PowerToys installer has been downloaded to the Windows desktop.
+
+```powershell
+wix burn extract ${Env:\USERPROFILE}"\Desktop\PowerToysSetup-0.94.0-x64.exe" -out ${Env:\USERPROFILE}"\Desktop\extractedPath" -oba ${Env:\USERPROFILE}"\Desktop\extractedPath"
+```
+
+### Extracting the MSI from the bundle for 0.93 and earlier
+
+Make sure to have the [WiX Toolset v3](https://docs.firegiant.com/wix/wix3/) installed. The command doesn't work with WiX Toolset v4 and later versions.
 
 This PowerShell example assumes the default install location for WiX Toolset and that the PowerToys installer has been downloaded to the Windows desktop.
 


### PR DESCRIPTION
Updated the doc with instruction for extracting MSI from EXE for version 0.94 and later (using WiX Toolset v5).

```
PS C:\Users\david> wix burn extract ${Env:\USERPROFILE}"\Desktop\PowerToysSetup-0.94.0-x64.exe" -out ${Env:\USERPROFILE}"\Desktop\extractedPath" -oba ${Env:\USERPROFILE}"\Desktop\extractedPath"
PS C:\Users\david> ls -l ${Env:\USERPROFILE}\Desktop\extractedPath\WixAttachedContainer\PowerToysSetup-0.94.0-wix5-x64.msi

    Directory: C:\Users\david\Desktop\extractedPath\WixAttachedContainer

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a---          29/08/2025    22:01      318943232 PowerToysSetup-0.94.0-wix5-x64.msi
```