### PR TITLE
Fix: Correct typo in lambda expression

### DIFF
--- a/hub/apps/develop/security/windows-hello-auth-service.md
+++ b/hub/apps/develop/security/windows-hello-auth-service.md
@@ -237,7 +237,7 @@ In this exercise, you start with the Windows Hello application built in the firs
         // If the UserAccountList does not contain the sampleUser Initialize the sample users
         // This is only needed as it in a Hand on Lab to demonstrate a user migrating
         // In the real world user accounts would just be in a database
-        if (!_mockDatabaseUserAccountsList.Any(f = > f.Username.Equals("sampleUsername")))
+        if (!_mockDatabaseUserAccountsList.Any(f => f.Username.Equals("sampleUsername")))
                 {
             //If the list is empty InitializeSampleUserAccountsAsync and return the list
             await InitializeSampleUserAccountsAsync();


### PR DESCRIPTION
This fixes a small typo in a lambda expression.

I couldn't find any other instances of this typo in the repository.