### PR TITLE
Update WinUI 3 Gallery links

### DIFF
--- a/hub/apps/design/controls/animated-icon.md
+++ b/hub/apps/design/controls/animated-icon.md
@@ -59,7 +59,7 @@ Defining a color property in your Lottie animation named "Foreground" lets you t
 > - **Important APIs:** [AnimatedIcon class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.animatedicon)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app to see AnimatedIcon in action](winui3gallery:/item/AnimatedIcon)
+> [Open the WinUI 3 Gallery app to see AnimatedIcon in action](winui3gallery://item/AnimatedIcon)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/annotated-scrollbar.md
+++ b/hub/apps/design/controls/annotated-scrollbar.md
@@ -50,7 +50,7 @@ For collections that only have a few items or that only require a small amount o
 > - **Important APIs:** [AnnotatedScrollBar class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.annotatedscrollbar), [ScrollView class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.scrollview), [IScrollController interface](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.primitives.iscrollcontroller)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the AnnotatedScrollBar in action](winui3gallery:/item/AnnotatedScrollBar)
+> [Open the WinUI 3 Gallery app and see the AnnotatedScrollBar in action](winui3gallery://item/AnnotatedScrollBar)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/auto-suggest-box.md
+++ b/hub/apps/design/controls/auto-suggest-box.md
@@ -45,7 +45,7 @@ The auto-suggest results list populates automatically once the user starts to en
 > - **Important APIs:** [AutoSuggestBox class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestbox), [TextChanged event](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestbox.textchanged), [SuggestionChose event](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestbox.suggestionchosen), [QuerySubmitted event](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestbox.querysubmitted)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the AutoSuggestBox in action](winui3gallery:/item/AutoSuggestBox)
+> [Open the WinUI 3 Gallery app and see the AutoSuggestBox in action](winui3gallery://item/AutoSuggestBox)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/breadcrumbbar.md
+++ b/hub/apps/design/controls/breadcrumbbar.md
@@ -49,7 +49,7 @@ The image below shows the parts of the `BreadcrumbBar` control. You can modify t
 > - **Important APIs:** [BreadcrumbBar class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.button)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the BreadcrumbBar in action](winui3gallery:/item/BreadcrumbBar)
+> [Open the WinUI 3 Gallery app and see the BreadcrumbBar in action](winui3gallery://item/BreadcrumbBar)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/buttons.md
+++ b/hub/apps/design/controls/buttons.md
@@ -120,7 +120,7 @@ This example uses three buttons, **Save**, **Don't Save**, and **Cancel**, in a 
 > - **Important APIs:** [Button class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.button), [Click event](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.primitives.buttonbase.click), [Command property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.primitives.buttonbase.command), [Content property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.contentcontrol.content)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the Buttons in action](winui3gallery:/item/Button)
+> [Open the WinUI 3 Gallery app and see the Buttons in action](winui3gallery://item/Button)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 
@@ -200,7 +200,7 @@ The button looks like this.
 > - **Important APIs:** [RepeatButton class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.primitives.repeatbutton), [Click event](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.primitives.buttonbase.click), [Content property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.contentcontrol.content)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the RepeatButton in action](winui3gallery:/item/RepeatButton)
+> [Open the WinUI 3 Gallery app and see the RepeatButton in action](winui3gallery://item/RepeatButton)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 
@@ -241,7 +241,7 @@ private void Decrease_Click(object sender, RoutedEventArgs e)
 > - **Important APIs**: [DropDownButton class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.button), [Flyout property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.button.flyout)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the DropdownButton in action](winui3gallery:/item/DropdownButton)
+> [Open the WinUI 3 Gallery app and see the DropdownButton in action](winui3gallery://item/DropdownButton)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 
@@ -305,7 +305,7 @@ private void AlignmentMenuFlyoutItem_Click(object sender, RoutedEventArgs e)
 > - **Important APIs**: [SplitButton class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.splitbutton), [Click event](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.primitives.buttonbase.click), [Flyout property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.button.flyout)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the SplitButton in action](winui3gallery:/item/SplitButton)
+> [Open the WinUI 3 Gallery app and see the SplitButton in action](winui3gallery://item/SplitButton)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 
@@ -421,7 +421,7 @@ public sealed partial class MainPage : Page
 > - **Important APIs**: [ToggleSplitButton class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.togglesplitbutton), [IsCheckedChanged event](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.togglesplitbutton.ischeckedchanged), [IsChecked property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.togglesplitbutton.ischecked)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ToggleSplitButton in action](winui3gallery:/item/ToggleSplitButton)
+> [Open the WinUI 3 Gallery app and see the ToggleSplitButton in action](winui3gallery://item/ToggleSplitButton)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/calendar-date-picker.md
+++ b/hub/apps/design/controls/calendar-date-picker.md
@@ -34,7 +34,7 @@ The entry point displays placeholder text if a date has not been set; otherwise,
 > - **Important APIs:** [CalendarDatePicker class](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Controls.CalendarDatePicker), [Date property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.calendardatepicker.date), [DateChanged event](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.calendardatepicker.datechanged)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the CalendarDatePicker in action](winui3gallery:/item/CalendarDatePicker)
+> [Open the WinUI 3 Gallery app and see the CalendarDatePicker in action](winui3gallery://item/CalendarDatePicker)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/calendar-view.md
+++ b/hub/apps/design/controls/calendar-view.md
@@ -36,7 +36,7 @@ Users click the header in the month view to open the year view, and click the he
 > - **Important APIs:** [CalendarView class](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Controls.CalendarView), [SelectedDatesChanged event](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.calendarview.selecteddateschanged)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the CalendarView in action](winui3gallery:/item/CalendarView)
+> [Open the WinUI 3 Gallery app and see the CalendarView in action](winui3gallery://item/CalendarView)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/checkbox.md
+++ b/hub/apps/design/controls/checkbox.md
@@ -63,7 +63,7 @@ Both **check box** and **radio button** controls let the user select from a list
 > - **Important APIs**: [CheckBox class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.checkbox), [Checked event](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.primitives.togglebutton.checked), [IsChecked property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.primitives.togglebutton.ischecked), [Content property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.contentcontrol.content)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the CheckBox in action](winui3gallery:/item/CheckBox)
+> [Open the WinUI 3 Gallery app and see the CheckBox in action](winui3gallery://item/CheckBox)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/color-picker.md
+++ b/hub/apps/design/controls/color-picker.md
@@ -35,7 +35,7 @@ If your app is for drawing or similar tasks using pen, consider using [Inking co
 > - **Important APIs:** [ColorPicker class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.colorpicker), [Color property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.colorpicker.Color), [ColorChanged event](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.colorpicker.ColorChanged)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ColorPicker in action](winui3gallery:/item/ColorPicker)
+> [Open the WinUI 3 Gallery app and see the ColorPicker in action](winui3gallery://item/ColorPicker)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/combo-box.md
+++ b/hub/apps/design/controls/combo-box.md
@@ -75,7 +75,7 @@ A list box allows the user to choose either a single item or multiple items from
 > - **Important APIs**: [ComboBox class](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Controls.ComboBox), [IsEditable property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.combobox.iseditable), [Text property](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Controls.ComboBox), [TextSubmitted event](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Controls.ComboBox), [ListBox class](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Controls.ListBox)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ComboBox in action](winui3gallery:/item/ComboBox)
+> [Open the WinUI 3 Gallery app and see the ComboBox in action](winui3gallery://item/ComboBox)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/command-bar-flyout.md
+++ b/hub/apps/design/controls/command-bar-flyout.md
@@ -47,7 +47,7 @@ You can use the CommandBarFlyout in either way, or even a mixture of the two.
 > - **Important APIs:** [CommandBarFlyout class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.commandbarflyout), [TextCommandBarFlyout class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.textcommandbarflyout), [AppBarButton class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.appbarbutton), [AppBarToggleButton class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.appbartogglebutton), [AppBarSeparator class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.appbarseparator)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the CommandBarFlyout in action](winui3gallery:/item/CommandBarFlyout)
+> [Open the WinUI 3 Gallery app and see the CommandBarFlyout in action](winui3gallery://item/CommandBarFlyout)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/command-bar.md
+++ b/hub/apps/design/controls/command-bar.md
@@ -70,7 +70,7 @@ Command bars can be placed in the following screen regions on single-view screen
 > - **Important APIs:** [CommandBar class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.commandbar), [AppBarButton class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.appbarbutton), [AppBarToggleButton class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.appbartogglebutton), [AppBarSeparator class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.appbarseparator)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the CommandBar in action](winui3gallery:/item/CommandBar)
+> [Open the WinUI 3 Gallery app and see the CommandBar in action](winui3gallery://item/CommandBar)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 This example creates the command bar shown previously.

--- a/hub/apps/design/controls/date-picker.md
+++ b/hub/apps/design/controls/date-picker.md
@@ -37,7 +37,7 @@ The entry point displays the chosen date, and when the user selects the entry po
 > - **Important APIs:** [DatePicker class](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Controls.DatePicker), [SelectedDate property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.datepicker.selecteddate)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the DatePicker in action](winui3gallery:/item/DatePicker)
+> [Open the WinUI 3 Gallery app and see the DatePicker in action](winui3gallery://item/DatePicker)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/dialogs-and-flyouts/dialogs.md
+++ b/hub/apps/design/controls/dialogs-and-flyouts/dialogs.md
@@ -48,7 +48,7 @@ For recommendations on when to use a dialog vs. when to use a flyout (a similar 
 > - **Important APIs**: [ContentDialog class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.contentdialog)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ContentDialog in action](winui3gallery:/item/ContentDialog)
+> [Open the WinUI 3 Gallery app and see the ContentDialog in action](winui3gallery://item/ContentDialog)
 
 [!INCLUDE [winui-3-gallery](../../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/dialogs-and-flyouts/flyouts.md
+++ b/hub/apps/design/controls/dialogs-and-flyouts/flyouts.md
@@ -25,7 +25,7 @@ For recommendations on when to use a flyout vs. when to use a dialog (a similar 
 > - **Important APIs**: [Flyout class](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Controls.Flyout), [Button.Flyout property](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Controls.Button.Flyout)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the Flyout in action](winui3gallery:/item/Flyout)
+> [Open the WinUI 3 Gallery app and see the Flyout in action](winui3gallery://item/Flyout)
 
 [!INCLUDE [winui-3-gallery](../../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/dialogs-and-flyouts/index.md
+++ b/hub/apps/design/controls/dialogs-and-flyouts/index.md
@@ -62,7 +62,7 @@ Dialogs are frequently used to confirm an action (such as deleting a file) befor
 >
 > - **Important APIs**: [ContentDialog class](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Controls.ContentDialog), [Flyout class](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Controls.Flyout)
 
-> - If you have the **WinUI 3 Gallery** app installed, click here to open the app and see the [ContentDialog](winui3gallery:/item/ContentDialog) or [Flyout](winui3gallery:/item/Flyout) in action. Get the app from the [Microsoft Store](https://apps.microsoft.com/detail/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery/tree/main).
+> - If you have the **WinUI 3 Gallery** app installed, click here to open the app and see the [ContentDialog](winui3gallery://item/ContentDialog) or [Flyout](winui3gallery://item/Flyout) in action. Get the app from the [Microsoft Store](https://apps.microsoft.com/detail/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery/tree/main).
 
 ## How to create a dialog
 

--- a/hub/apps/design/controls/dialogs-and-flyouts/teaching-tip.md
+++ b/hub/apps/design/controls/dialogs-and-flyouts/teaching-tip.md
@@ -56,7 +56,7 @@ A teaching tip can require the user to dismiss it via an "X" button in a top cor
 > - **Important APIs:** [TeachingTip class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.teachingtip)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TeachingTip in action](winui3gallery:/item/TeachingTip)
+> [Open the WinUI 3 Gallery app and see the TeachingTip in action](winui3gallery://item/TeachingTip)
 
 [!INCLUDE [winui-3-gallery](../../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/expander.md
+++ b/hub/apps/design/controls/expander.md
@@ -27,7 +27,7 @@ Use an `Expander` when some primary content should always be visible, but relate
 > - **Important APIs:** [Expander class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.expander), [Header property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.expander.header), [Content property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.contentcontrol.content)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the Expander in action](winui3gallery:/item/Expander)
+> [Open the WinUI 3 Gallery app and see the Expander in action](winui3gallery://item/Expander)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/flipview.md
+++ b/hub/apps/design/controls/flipview.md
@@ -43,7 +43,7 @@ A flip view can also be browsed vertically:
 > - **Important APIs**: [FlipView class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.flipview), [ItemsSource property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.itemscontrol.itemssource), [ItemTemplate property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.itemscontrol.itemtemplate)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the FlipView in action](winui3gallery:/item/FlipView)
+> [Open the WinUI 3 Gallery app and see the FlipView in action](winui3gallery://item/FlipView)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/hyperlinks.md
+++ b/hub/apps/design/controls/hyperlinks.md
@@ -63,7 +63,7 @@ The hyperlink appears inline and flows with the surrounding text:
 > - **Important APIs**: [HyperlinkButton control](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Controls.HyperlinkButton)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the Hyperlinks in action](winui3gallery:/item/HyperlinkButton)
+> [Open the WinUI 3 Gallery app and see the Hyperlinks in action](winui3gallery://item/HyperlinkButton)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/images-imagebrushes.md
+++ b/hub/apps/design/controls/images-imagebrushes.md
@@ -25,7 +25,7 @@ Use an **ImageBrush** to apply an image to another object. Uses for an ImageBrus
 > - **Important APIs:** [Image class](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Controls.Image), [Source property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.image.source), [ImageBrush class](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Media.ImageBrush), [ImageSource property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.media.imagebrush.imagesource)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see ImageBrushes in action](winui3gallery:/item/Image)
+> [Open the WinUI 3 Gallery app and see ImageBrushes in action](winui3gallery://item/Image)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/info-badge.md
+++ b/hub/apps/design/controls/info-badge.md
@@ -155,7 +155,7 @@ The info badge comes at a default size that meets accessibility requirements. Yo
 > - **Important APIs:** [InfoBadge class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.infobadge), [IconSource property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.infobadge.iconsource), [Value property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.infobadge.value)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the InfoBadge in action](winui3gallery:/item/InfoBadge)
+> [Open the WinUI 3 Gallery app and see the InfoBadge in action](winui3gallery://item/InfoBadge)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/infobar.md
+++ b/hub/apps/design/controls/infobar.md
@@ -113,7 +113,7 @@ Please view the guidance for [Adjust layout and fonts, and support RTL](../globa
 > - **Important APIs:** [InfoBar class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.infobar)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the InfoBar in action](winui3gallery:/item/InfoBar)
+> [Open the WinUI 3 Gallery app and see the InfoBar in action](winui3gallery://item/InfoBar)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/items-repeater.md
+++ b/hub/apps/design/controls/items-repeater.md
@@ -54,7 +54,7 @@ When you use an **ItemsRepeater**, you should provide scrolling functionality by
 > - **Important APIs**: [ItemsRepeater class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.itemsrepeater), [ScrollViewer class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.scrollviewer)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ItemsRepeater in action](winui3gallery:/item/ItemsRepeater)
+> [Open the WinUI 3 Gallery app and see the ItemsRepeater in action](winui3gallery://item/ItemsRepeater)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/itemsview.md
+++ b/hub/apps/design/controls/itemsview.md
@@ -36,7 +36,7 @@ Use an items view to:
 > - Important APIs: [ItemsView class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.itemsview), [ItemsSource property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.itemsview.itemssource), [ItemTemplate property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.itemsview.itemtemplate), [LinedFlowLayout](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.linedflowlayout), [StackLayout](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.stacklayout), [UniformGridLayout](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.uniformgridlayout)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ItemsView in action](winui3gallery:/item/ItemsView)
+> [Open the WinUI 3 Gallery app and see the ItemsView in action](winui3gallery://item/ItemsView)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 
@@ -243,7 +243,7 @@ UniformGridLayout provides properties to control:
 - the arrangement of items ([ItemsJustification](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.uniformgridlayout.itemsjustification), [ItemsStretch](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.uniformgridlayout.itemsstretch))
 
 > [!TIP]
-> Use the interactive demo in the [WinUI 3 Gallery app](winui3gallery:/item/ItemsView) to see the effect of these properties in real time.
+> Use the interactive demo in the [WinUI 3 Gallery app](winui3gallery://item/ItemsView) to see the effect of these properties in real time.
 
 ## Item selection and interaction
 

--- a/hub/apps/design/controls/listview-and-gridview.md
+++ b/hub/apps/design/controls/listview-and-gridview.md
@@ -56,7 +56,7 @@ Learn more about ItemsRepeater by reading its [Guidelines](./items-repeater.md) 
 > - **Important APIs**: [ListView class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.listview), [GridView class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.gridview), [ItemsSource property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.itemscontrol.itemssource), [Items property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.itemscontrol.items)
 
 > [!div class="nextstepaction"]
-> Open the WinUI 3 Gallery app and see the [ListView](winui3gallery:/item/ListView) or the [GridView](winui3gallery:/item/GridView) in action.
+> Open the WinUI 3 Gallery app and see the [ListView](winui3gallery://item/ListView) or the [GridView](winui3gallery://item/GridView) in action.
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/listview-filtering.md
+++ b/hub/apps/design/controls/listview-filtering.md
@@ -153,7 +153,7 @@ Now, as the user types in their filtering string in the `FilterByLastName` TextB
 ## Get the sample code
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ListView in action](winui3gallery:/item/ItemsView)
+> [Open the WinUI 3 Gallery app and see the ListView in action](winui3gallery://item/ItemsView)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/media-playback.md
+++ b/hub/apps/design/controls/media-playback.md
@@ -39,7 +39,7 @@ The default controls have been optimized for media playback, however you have th
 > - **Important APIs**: [MediaPlayerElement class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.mediaplayerelement), [MediaTransportControls class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.mediatransportcontrols)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the MediaPlayerElement in action](winui3gallery:/item/MediaPlayerElement)
+> [Open the WinUI 3 Gallery app and see the MediaPlayerElement in action](winui3gallery://item/MediaPlayerElement)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/menus.md
+++ b/hub/apps/design/controls/menus.md
@@ -159,7 +159,7 @@ Light dismiss controls such as menus, context menus, and other flyouts, trap key
 > - **Important APIs:** [MenuBar class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.menubar). [MenuBarItem class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.menubaritem)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see MenuBar in action](winui3gallery:/item/MenuBar)
+> [Open the WinUI 3 Gallery app and see MenuBar in action](winui3gallery://item/MenuBar)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/navigationview.md
+++ b/hub/apps/design/controls/navigationview.md
@@ -37,7 +37,7 @@ For other navigation patterns, see [Navigation design basics](../basics/navigati
 > - **Important APIs:** [NavigationView class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView)
+> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery://item/NavigationView)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/number-box.md
+++ b/hub/apps/design/controls/number-box.md
@@ -30,7 +30,7 @@ You can use a NumberBox control to capture and display mathematic input. If you 
 > - **Important APIs:** [NumberBox class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.NumberBox)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see NumberBox in action](winui3gallery:/item/NumberBox)
+> [Open the WinUI 3 Gallery app and see NumberBox in action](winui3gallery://item/NumberBox)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/password-box.md
+++ b/hub/apps/design/controls/password-box.md
@@ -57,7 +57,7 @@ Pressing the "reveal" button on the right gives a peek at the password text bein
 > - **Important APIs:** [PasswordBox class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.passwordbox), [Password property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.passwordbox.password), [PasswordChar property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.passwordbox.passwordchar), [PasswordRevealMode property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.passwordbox.passwordrevealmode), [PasswordChanged event](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.passwordbox.passwordchanged)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see PasswordBox in action](winui3gallery:/item/PasswordBox)
+> [Open the WinUI 3 Gallery app and see PasswordBox in action](winui3gallery://item/PasswordBox)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/person-picture.md
+++ b/hub/apps/design/controls/person-picture.md
@@ -35,7 +35,7 @@ The illustration shows the person picture control in a list of contacts:
 > - **Important APIs:** [PersonPicture class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.personpicture)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see PersonPicture in action](winui3gallery:/item/PersonPicture)
+> [Open the WinUI 3 Gallery app and see PersonPicture in action](winui3gallery://item/PersonPicture)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/pipspager.md
+++ b/hub/apps/design/controls/pipspager.md
@@ -37,7 +37,7 @@ This UI is commonly used in apps such as photo viewers and app lists, where disp
 > - **Important APIs**: [PipsPager class](/uwp/api/microsoft.ui.xaml.controls.pipspager)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the PipsPager in action](winui3gallery:/item/PipsPager)
+> [Open the WinUI 3 Gallery app and see the PipsPager in action](winui3gallery://item/PipsPager)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/progress-controls.md
+++ b/hub/apps/design/controls/progress-controls.md
@@ -127,7 +127,7 @@ When the duration of the operation is known and the ring visual is desired, when
 > - **Important APIs:** [ProgressBar class](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Controls.ProgressBar), [IsIndeterminate property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.progressbar.isindeterminate), [ProgressRing class](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Controls.ProgressRing), [IsActive property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.progressring.isactive)
 
 > [!div class="nextstepaction"]
-> Open the WinUI 3 Gallery app and see the [ProgressBar](winui3gallery:/item/ProgressBar) or [ProgressRing](winui3gallery:/item/ProgressRing).
+> Open the WinUI 3 Gallery app and see the [ProgressBar](winui3gallery://item/ProgressBar) or [ProgressRing](winui3gallery://item/ProgressRing).
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/pull-to-refresh.md
+++ b/hub/apps/design/controls/pull-to-refresh.md
@@ -100,7 +100,7 @@ When you change the pull direction, the starting position of the visualizer's pr
 > - **Important APIs**: [RefreshContainer](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.refreshcontainer), [RefreshVisualizer](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.refreshvisualizer)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see PullToRefresh in action](winui3gallery:/item/PullToRefresh)
+> [Open the WinUI 3 Gallery app and see PullToRefresh in action](winui3gallery://item/PullToRefresh)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/radio-button.md
+++ b/hub/apps/design/controls/radio-button.md
@@ -246,7 +246,7 @@ The following table describes how Narrator handles a `RadioButtons` group and wh
 > - **Important APIs**: [RadioButtons class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.radiobuttons), [SelectedItem property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.radiobuttons.selecteditem), [SelectedIndex property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.radiobuttons.selectedindex), [SelectionChanged event](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.radiobuttons.selectionchanged), [RadioButton class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.radiobutton), [IsChecked property](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Controls.Primitives.ToggleButton.IsChecked), [Checked event](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Controls.Primitives.ToggleButton.Checked)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the RadioButton in action](winui3gallery:/item/RadioButton)
+> [Open the WinUI 3 Gallery app and see the RadioButton in action](winui3gallery://item/RadioButton)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/rating.md
+++ b/hub/apps/design/controls/rating.md
@@ -43,7 +43,7 @@ The read only mode is also the recommended way of using the rating control when 
 > - **Important APIs**: [RatingControl class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.ratingcontrol)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see RatingControl in action](winui3gallery:/item/RatingControl)
+> [Open the WinUI 3 Gallery app and see RatingControl in action](winui3gallery://item/RatingControl)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/rich-edit-box.md
+++ b/hub/apps/design/controls/rich-edit-box.md
@@ -46,7 +46,7 @@ This rich edit box has a rich text document open in it. The formatting and file 
 > - **Important APIs:** [RichEditBox class](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Controls.RichEditBox), [Document property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.richeditbox.document), [IsReadOnly property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.richeditbox.isreadonly), [IsSpellCheckEnabled property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.richeditbox.isspellcheckenabled)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the RichEditBox in action](winui3gallery:/item/RichEditBox)
+> [Open the WinUI 3 Gallery app and see the RichEditBox in action](winui3gallery://item/RichEditBox)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/rich-text-block.md
+++ b/hub/apps/design/controls/rich-text-block.md
@@ -32,7 +32,7 @@ See Typography and Guidelines for fonts.
 > - **Important APIs:** [RichTextBlock class](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Controls.RichTextBlock), [RichTextBlockOverflow class](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Controls.RichTextBlockOverflow), [Paragraph class](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Documents.Paragraph), [Typography class](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Documents.Typography)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the RichTextBlock in action](winui3gallery:/item/RichTextBlock)
+> [Open the WinUI 3 Gallery app and see the RichTextBlock in action](winui3gallery://item/RichTextBlock)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/scroll-controls.md
+++ b/hub/apps/design/controls/scroll-controls.md
@@ -74,9 +74,9 @@ Various APIs are available that let you get the height and width of these region
 > - **Important APIs:** [ScrollView class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.scrollview), [ScrollViewer class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.scrollviewer), [ScrollBar class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.primitives.scrollbar)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ScrollView in action](winui3gallery:/item/ScrollView)
+> [Open the WinUI 3 Gallery app and see the ScrollView in action](winui3gallery://item/ScrollView)
 >
-> [Open the WinUI 3 Gallery app and see the ScrollViewer in action](winui3gallery:/item/ScrollViewer)
+> [Open the WinUI 3 Gallery app and see the ScrollViewer in action](winui3gallery://item/ScrollViewer)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/selector-bar.md
+++ b/hub/apps/design/controls/selector-bar.md
@@ -46,7 +46,7 @@ There are some scenarios where another control may be more appropriate to use.
 > - **Important APIs**: [SelectorBar class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.selectorbar), [Items property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.selectorbar.items), [SelectionChanged event](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.selectorbar.selectionchanged),  [SelectorBarItem class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.selectorbaritem)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the SelectorBar in action](winui3gallery:/item/SelectorBar)
+> [Open the WinUI 3 Gallery app and see the SelectorBar in action](winui3gallery://item/SelectorBar)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 
@@ -127,7 +127,7 @@ When a user selects an item, you typically change the view by either navigating 
 ### Navigate with transition animations
 
 > [!TIP]
-> You can find these examples in the [SelectorBar page of the WinUI Gallery app](winui3gallery:/item/SelectorBar). Use the WinUI Gallery app to run and view the full code.
+> You can find these examples in the [SelectorBar page of the WinUI Gallery app](winui3gallery://item/SelectorBar). Use the WinUI Gallery app to run and view the full code.
 
 This example demonstrates handling the [SelectionChanged](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.selectorbar.selectionchanged) event to navigate between different pages. The navigation uses the [SlideNavigationTransitionEffect](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.media.animation.slidenavigationtransitioneffect) to slide the pages in from the left or right, as appropriate.
 

--- a/hub/apps/design/controls/semantic-zoom.md
+++ b/hub/apps/design/controls/semantic-zoom.md
@@ -60,7 +60,7 @@ Here's a semantic zoom used in the Photos app. Photos are grouped by month. Sele
 > - **Important APIs:** [SemanticZoom class](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Controls.SemanticZoom), [ListView class](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Controls.ListView), [GridView class](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Controls.GridView)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see SemanticZoom in action](winui3gallery:/item/SemanticZoom)
+> [Open the WinUI 3 Gallery app and see SemanticZoom in action](winui3gallery://item/SemanticZoom)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/slider.md
+++ b/hub/apps/design/controls/slider.md
@@ -126,7 +126,7 @@ A slider with tick marks at 10 point intervals from 0 to 100.
 > - **Important APIs**: [Slider class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.slider), [Value property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.primitives.rangebase.value), [ValueChanged event](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.primitives.rangebase.valuechanged)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the Slider in action](winui3gallery:/item/Slider)
+> [Open the WinUI 3 Gallery app and see the Slider in action](winui3gallery://item/Slider)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/swipe.md
+++ b/hub/apps/design/controls/swipe.md
@@ -77,7 +77,7 @@ For example, you cannot have two [LeftItems](/windows/windows-app-sdk/api/winrt/
 > - **Important APIs**: [SwipeControl](/uwp/api/microsoft.ui.xaml.controls.swipecontrol), [SwipeItem](/uwp/api/microsoft.ui.xaml.controls.swipeitem), [ListView class](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Controls.ListView)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see SwipeControl in action](winui3gallery:/item/SwipeControl)
+> [Open the WinUI 3 Gallery app and see SwipeControl in action](winui3gallery://item/SwipeControl)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/text-block.md
+++ b/hub/apps/design/controls/text-block.md
@@ -30,7 +30,7 @@ For more info about choosing the right text control, see the [Text controls](tex
 > - **Important APIs:** [TextBlock class](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Controls.TextBlock), [Text property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.textblock.text), [Inlines property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.textblock.inlines)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TextBlock in action](winui3gallery:/item/TextBlock)
+> [Open the WinUI 3 Gallery app and see the TextBlock in action](winui3gallery://item/TextBlock)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/text-box.md
+++ b/hub/apps/design/controls/text-box.md
@@ -83,7 +83,7 @@ For more info about choosing the right text control, see the [Text controls](tex
 > - **Important APIs:** [TextBox class](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Controls.TextBox), [Text property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.textbox.text)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TextBox in action](winui3gallery:/item/TextBox)
+> [Open the WinUI 3 Gallery app and see the TextBox in action](winui3gallery://item/TextBox)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/time-picker.md
+++ b/hub/apps/design/controls/time-picker.md
@@ -38,7 +38,7 @@ The entry point displays the chosen time, and when the user selects the entry po
 > - **Important APIs:** [TimePicker class](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Controls.TimePicker), [SelectedTime property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.timepicker.selectedtime)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TimePicker in action](winui3gallery:/item/TimePicker)
+> [Open the WinUI 3 Gallery app and see the TimePicker in action](winui3gallery://item/TimePicker)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/title-bar.md
+++ b/hub/apps/design/controls/title-bar.md
@@ -49,7 +49,7 @@ The layout is reversed when the [FlowDirection](/windows/windows-app-sdk/api/win
 > - **Important APIs:** [TitleBar class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.titlebar), [Title property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.titlebar.title)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TitleBar in action](winui3gallery:/item/TitleBar)
+> [Open the WinUI 3 Gallery app and see the TitleBar in action](winui3gallery://item/TitleBar)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/toggles.md
+++ b/hub/apps/design/controls/toggles.md
@@ -53,7 +53,7 @@ For some actions, either a toggle switch or a check box might work. To decide wh
 > - **Important APIs**: [ToggleSwitch class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.toggleswitch), [IsOn property](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.toggleswitch.ison), [Toggled event](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.toggleswitch.toggled)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ToggleSwitch in action](winui3gallery:/item/ToggleSwitch)
+> [Open the WinUI 3 Gallery app and see the ToggleSwitch in action](winui3gallery://item/ToggleSwitch)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/controls/tooltips.md
+++ b/hub/apps/design/controls/tooltips.md
@@ -63,7 +63,7 @@ When should you use a tooltip? To decide, consider these questions:
 > - **Important APIs:** [ToolTip class](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Controls.ToolTip), [ToolTipService class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.tooltipservice)
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ToolTip in action](winui3gallery:/item/ToolTip)
+> [Open the WinUI 3 Gallery app and see the ToolTip in action](winui3gallery://item/ToolTip)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/layout/attached-layouts.md
+++ b/hub/apps/design/layout/attached-layouts.md
@@ -292,7 +292,7 @@ The UI for the Xbox Activity Feed uses a repeating pattern where each line has a
 The code below walks through what a custom virtualizing UI for the activity feed might be to illustrate the general approach you might take for a **data layout**.
 
 > [!TIP]
-> If you have the **WinUI 3 Gallery** app installed, click here to [open the app and see the ItemsRepeater in action](winui3gallery:/item/ItemsRepeater). Get the app from the [Microsoft Store](https://apps.microsoft.com/detail/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
+> If you have the **WinUI 3 Gallery** app installed, click here to [open the app and see the ItemsRepeater in action](winui3gallery://item/ItemsRepeater). Get the app from the [Microsoft Store](https://apps.microsoft.com/detail/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 
 #### Implementation
 

--- a/hub/apps/design/signature-experiences/color.md
+++ b/hub/apps/design/signature-experiences/color.md
@@ -39,7 +39,7 @@ Accent color is used to emphasize important elements in the user interface and t
 ## Examples
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see Color principles in action](winui3gallery:/item/Color)
+> [Open the WinUI 3 Gallery app and see Color principles in action](winui3gallery://item/Color)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/design/signature-experiences/iconography.md
+++ b/hub/apps/design/signature-experiences/iconography.md
@@ -89,6 +89,6 @@ Understand the cultural connotations of symbols. Although iconography doesn't re
 ## Examples
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see Iconography principles in action](winui3gallery:/item/Iconography)
+> [Open the WinUI 3 Gallery app and see Iconography principles in action](winui3gallery://item/Iconography)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]

--- a/hub/apps/design/signature-experiences/typography.md
+++ b/hub/apps/design/signature-experiences/typography.md
@@ -59,7 +59,7 @@ Windows 11 uses Segoe UI Variable with the following attributes based on the con
 ## Examples
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see Typography principles in action](winui3gallery:/item/Typography)
+> [Open the WinUI 3 Gallery app and see Typography principles in action](winui3gallery://item/Typography)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://apps.microsoft.com/detail/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/hub/apps/design/style/icons.md
+++ b/hub/apps/design/style/icons.md
@@ -196,7 +196,7 @@ For more information and examples, see the [FontIcon](/windows/windows-app-sdk/a
 > Use the Iconography page in the WinUI 3 Gallery app to view, search, and copy code for all the icons available in Segoe Fluent Icons.
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app to the Iconography page](winui3gallery:/item/Iconography)
+> [Open the WinUI 3 Gallery app to the Iconography page](winui3gallery://item/Iconography)
 
 ## AnimatedIcon
 
@@ -207,7 +207,7 @@ You can use animated icons to implement lightweight, vector-based icons with mot
 For more information and examples, see [Animated icons](../controls/animated-icon.md) and the [AnimatedIcon](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.animatedicon) class documentation.
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app to see AnimatedIcon in action](winui3gallery:/item/AnimatedIcon)
+> [Open the WinUI 3 Gallery app to see AnimatedIcon in action](winui3gallery://item/AnimatedIcon)
 
 ## PathIcon
 

--- a/hub/apps/design/style/segoe-fluent-icons-font.md
+++ b/hub/apps/design/style/segoe-fluent-icons-font.md
@@ -73,7 +73,7 @@ You can also use the static resource `SymbolThemeFontFamily` to access `Segoe Fl
 ## Examples
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see Iconography principles in action](winui3gallery:/item/Iconography)
+> [Open the WinUI 3 Gallery app and see Iconography principles in action](winui3gallery://item/Iconography)
 
 [!INCLUDE [winui-3-gallery](../../../includes/winui-3-gallery.md)]
 

--- a/hub/apps/winui/winui3/index.md
+++ b/hub/apps/winui/winui3/index.md
@@ -29,7 +29,7 @@ WinUI 3 is the native UI platform component that ships with the [Windows App SDK
 >
 > The **WinUI 3 Gallery** and **WinUI 2 Gallery** apps include interactive examples of most WinUI 3 and WinUI 2 controls, features, and functionality.
 >
-> If installed already, open them by clicking the following links: [**WinUI 3 Gallery**](winui3gallery:/item/AnimatedIcon) or [**WinUI 2 Gallery**](winui2gallery:/item/AnimatedIcon).
+> If installed already, open them by clicking the following links: [**WinUI 3 Gallery**](winui3gallery://item/AnimatedIcon) or [**WinUI 2 Gallery**](winui2gallery:/item/AnimatedIcon).
 >
 > If they are not installed, you can download the [**WinUI 3 Gallery**](https://apps.microsoft.com/detail/9P3JFPWWDZRC) and the [**WinUI 2 Gallery**](https://apps.microsoft.com/detail/9MSVH128X2ZT) from the Microsoft Store.
 >

--- a/uwp/get-started/winui2/release-notes/winui-2.0.md
+++ b/uwp/get-started/winui2/release-notes/winui-2.0.md
@@ -65,7 +65,7 @@ Controls and patterns in this release include:
 >
 > The **WinUI 3 Gallery** and **WinUI 2 Gallery** apps include interactive examples of most WinUI 3 and WinUI 2 controls, features, and functionality.
 >
-> If installed already, open them by clicking the following links: [**WinUI 3 Gallery**](winui3gallery:/item/AnimatedIcon) or [**WinUI 2 Gallery**](winui2gallery:/item/AnimatedIcon).
+> If installed already, open them by clicking the following links: [**WinUI 3 Gallery**](winui3gallery://item/AnimatedIcon) or [**WinUI 2 Gallery**](winui2gallery:/item/AnimatedIcon).
 >
 > If they are not installed, you can download the [**WinUI 3 Gallery**](https://apps.microsoft.com/detail/9P3JFPWWDZRC) and the [**WinUI 2 Gallery**](https://apps.microsoft.com/detail/9MSVH128X2ZT) from the Microsoft Store.
 >


### PR DESCRIPTION
The WinUI 3 Gallery expects links to be of the form "winui3gallery://item..." with two "/". Most of the links only have one "/" resulting in the page not being opened. This PR fixes that so the links properly work.