### PR TITLE
[PowerToys Awake] Clarify lock screen behavior, add security considerations

### DIFF
--- a/hub/powertoys/awake.md
+++ b/hub/powertoys/awake.md
@@ -16,7 +16,12 @@ PowerToys Awake is a Windows utility that keeps your computer awake without modi
 You can use PowerToys Awake directly from PowerToys Settings or as a standalone executable (`PowerToys.Awake.exe` in the PowerToys installation folder).
 
 > [!NOTE]
+> PowerToys Awake is active only when you are logged in and it is enabled. **Awake does not function when the lock screen is displayed.** Your normal power plan is active at other times.
+>
 > PowerToys Awake does not modify any of the Windows power plan settings and does not depend on a custom power plan configuration. Instead, it spawns background threads that tell Windows that they require a specific state of the machine. Once PowerToys Awake exits, the threads are terminated and the computer will resume its standard power plan behavior.
+
+> [!IMPORTANT]
+> PowerToys Awake temporarily overrides your power plan choices and is intended for use while you are at your computer or in private environments. For persistent keep-awake needs, especially when stepping away in shared environments, configure your Windows power plan settings directly and lock your computer for security.
 
 ## Settings
 
@@ -41,6 +46,11 @@ PowerToys Awake supports a variety of modes that can be used to control computer
 While PowerToys Awake can keep the computer awake indefinitely or temporarily, in its default state the displays connected to the machine will turn off even if the computer stays awake. If you need the displays to be available, use the **Keep screen on** switch, which will keep displays active.
 
 This feature only works when PowerToys Awake is enabled and has one of the custom power states selected. It also does not prevent any user-initiated actions, such as manually putting the computer to sleep or hibernating it.
+
+## Lock screen behavior
+PowerToys Awake does not function when the lock screen is displayed. This is because the lock screen operates in a separate security context from the user session. When you lock your computer, Windows transitions to this secure context, and user-mode applications like PowerToys Awake cannot maintain their power requests.
+
+If you need your computer to stay awake while locked, modify your Windows power plan settings directly instead of using PowerToys Awake.
 
 ## System tray
 

--- a/hub/powertoys/awake.md
+++ b/hub/powertoys/awake.md
@@ -16,9 +16,9 @@ PowerToys Awake is a Windows utility that keeps your computer awake without modi
 You can use PowerToys Awake directly from PowerToys Settings or as a standalone executable (`PowerToys.Awake.exe` in the PowerToys installation folder).
 
 > [!NOTE]
-> PowerToys Awake is active only when you are logged in and it is enabled. **Awake does not function when the lock screen is displayed.** Your normal power plan is active at other times.
+> PowerToys Awake is active only when you are signed in and it is enabled. **Awake doesn't function when the lock screen is displayed.** Your normal power plan is active at other times.
 >
-> PowerToys Awake does not modify any of the Windows power plan settings and does not depend on a custom power plan configuration. Instead, it spawns background threads that tell Windows that they require a specific state of the machine. Once PowerToys Awake exits, the threads are terminated and the computer will resume its standard power plan behavior.
+> PowerToys Awake doesn't modify any of the Windows power plan settings and doesn't depend on a custom power plan configuration. Instead, it spawns background threads that tell Windows that they require a specific state of the machine. Once PowerToys Awake exits, the threads are terminated and the computer resumes its standard power plan behavior.
 
 > [!IMPORTANT]
 > PowerToys Awake temporarily overrides your power plan choices and is intended for use while you are at your computer or in private environments. For persistent keep-awake needs, especially when stepping away in shared environments, configure your Windows power plan settings directly and lock your computer for security.
@@ -48,7 +48,7 @@ While PowerToys Awake can keep the computer awake indefinitely or temporarily, i
 This feature only works when PowerToys Awake is enabled and has one of the custom power states selected. It also does not prevent any user-initiated actions, such as manually putting the computer to sleep or hibernating it.
 
 ## Lock screen behavior
-PowerToys Awake does not function when the lock screen is displayed. This is because the lock screen operates in a separate security context from the user session. When you lock your computer, Windows transitions to this secure context, and user-mode applications like PowerToys Awake cannot maintain their power requests.
+PowerToys Awake doesn't work when the lock screen is displayed. This limitation exists because the lock screen operates in a separate security context from the user session. When you lock your computer, Windows transitions to this secure context, and user-mode applications like PowerToys Awake can't maintain their power requests.
 
 If you need your computer to stay awake while locked, modify your Windows power plan settings directly instead of using PowerToys Awake.
 


### PR DESCRIPTION
Added information about lock screen behavior and its impact on PowerToys Awake functionality. Added specific notes about security considerations from using Awake instead of customizing a Power Plan (as Awake cannot be used while the device is locked).

Created in response to this issue from the PowerToys repo: https://github.com/microsoft/PowerToys/issues/42069