### PR TITLE
Fixed markdown link on monetize page

### DIFF
--- a/uwp/monetize/index.md
+++ b/uwp/monetize/index.md
@@ -65,7 +65,7 @@ Looking for other ways to increase your monetization? Consider these options.
 
  Topic                | Description                 |
 |--------------------|-----------------------------|
-| [Microsoft Affiliate Program]((https://www.microsoft.com/microsoft-365/business/microsoft-365-affiliate-program) | Earn commissions by linking to Microsoft products from your app, blog, web page or other communications. You can link to apps, games, music, movies, hardware, accessories, and other goods sold in the Microsoft Store.
+| [Microsoft Affiliate Program](https://www.microsoft.com/microsoft-365/business/microsoft-365-affiliate-program) | Earn commissions by linking to Microsoft products from your app, blog, web page or other communications. You can link to apps, games, music, movies, hardware, accessories, and other goods sold in the Microsoft Store.
 | [A/B experimentation](./run-app-experiments-with-a-b-testing.md) | Run A/B tests in your apps to measure the effectiveness of feature changes on some customers before you enable the changes for everyone.
 | [Engage customers with the Microsoft Store Services SDK](microsoft-store-services-sdk.md) | The Microsoft Store Services SDK provides libraries and tools that you can use to add features to your apps that help you engage with your customers. These features include targeted notifications, A/B tests, and launching Feedback Hub from your app.
 | [Launch Feedback Hub from your app](launch-feedback-hub-from-your-app.md) | Add code to your UWP apps to direct your Windows 10 and Windows 11 customers to Feedback Hub, where they can submit problems, suggestions, and upvotes. Then, manage this feedback in the [Feedback report](/windows/apps/publish/feedback-report) in Partner Center. This feature requires the Microsoft Store Services SDK. 
@@ -89,3 +89,4 @@ Keep tabs on how your app is performing in the Store by using these reports.
 - [Create customer segments](/windows/apps/publish/create-customer-segments)
 - [Feedback report](/windows/apps/publish/feedback-report)
 - [Usage report](/windows/apps/publish/usage-report)
+


### PR DESCRIPTION
Really small change, was just on the page and noticed the link format was wrong.