### PR TITLE
Update WinGet Documents with v1.28 Client Changes

### DIFF
--- a/hub/package-manager/package/manifest.md
+++ b/hub/package-manager/package/manifest.md
@@ -1,7 +1,7 @@
 ---
 title: Create your package manifest
 description: If you want to submit a software package to the Windows Package Manager repository, start by creating a package manifest.
-ms.date: 11/01/2023
+ms.date: 03/24/2026
 ms.topic: how-to
 ms.localizationpriority: medium
 ---
@@ -57,7 +57,7 @@ For a complete list and descriptions of items in a manifest, see the [manifest s
 
 ### Minimal required schema
 
-As specified in the [singleton JSON schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.6.0/manifest.singleton.1.6.0.json),
+As specified in the [singleton JSON schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.12.0/manifest.singleton.1.12.0.json),
 only certain fields are required. The minimal supported YAML file would look like the example below. The singleton format is only valid for packages containing a single installer and a single locale. If more than one installer or locale is provided, the multiple YAML file format and schema must be used.
 
 The partitioning scheme was added to help with GitHub's UX. Folders with thousands of children do not render well in the browser.
@@ -74,11 +74,11 @@ License:            # The license of the application.
 ShortDescription:   # The description of the application.
 Installers: 
  - Architecture:    # Enumeration of supported architectures.
-   InstallerType:   # Enumeration of supported installer types (exe, msi, msix, inno, wix, nullsoft, appx).
+   InstallerType:   # Enumeration of supported installer types (exe, msi, msix, inno, wix, nullsoft, appx, font).
    InstallerUrl:    # Path to download installation file.
    InstallerSha256: # SHA256 calculated from installer.
 ManifestType:       # The manifest file type
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0
 ```
 
 #### [Example](#tab/minexample/)
@@ -100,7 +100,7 @@ Installers:
    InstallerSha256: 092aa89b1881e058d31b1a8d88f31bb298b5810afbba25c5cb341cfa4904d843
    SignatureSha256: e53f48473621390c8243ada6345826af7c713cf1f4bbbf0d030599d1e4c175ee
 ManifestType: singleton
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0
 ```
 
 * * *
@@ -110,10 +110,10 @@ ManifestVersion: 1.6.0
 To provide the best user experience, manifests should contain as much meta-data as possible. In order to separate concerns for validating installers
 and providing localized metadata, manifests should be split into multiple files. The minimum number of YAML files for this kind of manifest is three. Additional locales should also be provided.
 
-* A [version](https://github.com/microsoft/winget-pkgs/blob/master/doc/manifest/schema/1.6.0/version.md) ([JSON Schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.6.0/manifest.version.1.6.0.json)) file.
-* The [default locale](https://github.com/microsoft/winget-pkgs/blob/master/doc/manifest/schema/1.6.0/defaultLocale.md) ([JSON Schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.6.0/manifest.defaultLocale.1.6.0.json)) file.
-* An [installer](https://github.com/microsoft/winget-pkgs/blob/master/doc/manifest/schema/1.6.0/installer.md) ([JSON Schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.6.0/manifest.installer.1.6.0.json)) file.
-* Additional [locale](https://github.com/microsoft/winget-pkgs/blob/master/doc/manifest/schema/1.6.0/locale.md) ([JSON Schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.6.0/manifest.locale.1.6.0.json)) files.
+* A [version](https://github.com/microsoft/winget-pkgs/blob/master/doc/manifest/schema/1.12.0/version.md) ([JSON Schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.12.0/manifest.version.1.12.0.json)) file.
+* The [default locale](https://github.com/microsoft/winget-pkgs/blob/master/doc/manifest/schema/1.12.0/defaultLocale.md) ([JSON Schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.12.0/manifest.defaultLocale.1.12.0.json)) file.
+* An [installer](https://github.com/microsoft/winget-pkgs/blob/master/doc/manifest/schema/1.12.0/installer.md) ([JSON Schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.12.0/manifest.installer.1.12.0.json)) file.
+* Additional [locale](https://github.com/microsoft/winget-pkgs/blob/master/doc/manifest/schema/1.12.0/locale.md) ([JSON Schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.12.0/manifest.locale.1.12.0.json)) files.
 
 The example below shows many optional metadata fields and multiple locales. Note the default locale has more requirements than additional locales. In the [show command](../winget/show.md), any required fields that aren't provided for additional locales will display fields from the default locale.
 
@@ -126,7 +126,7 @@ PackageIdentifier: "Microsoft.WindowsTerminal"
 PackageVersion: "1.6.10571.0"
 DefaultLocale: "en-US"
 ManifestType: "version"
-ManifestVersion: "1.6.0"
+ManifestVersion: "1.12.0"
 ```
 
 #### [Default locale file example](#tab/default-locale-example/)
@@ -159,7 +159,7 @@ Tags:
 - "ps"
 - "terminal"
 ManifestType: "defaultLocale"
-ManifestVersion: "1.6.0"
+ManifestVersion: "1.12.0"
 ```
 
 #### [Additional locale file example](#tab/additional-locale-example/)
@@ -173,7 +173,7 @@ PackageLocale: "fr-FR"
 Publisher: "Microsoft"
 ShortDescription: "Le nouveau terminal Windows, une expérience de ligne de commande à onglets pour Windows."
 ManifestType: "locale"
-ManifestVersion: "1.6.0"
+ManifestVersion: "1.12.0"
 ```
 
 #### [Installer file example](#tab/installer-example/)
@@ -204,7 +204,7 @@ Installers:
    InstallerSha256: 092aa89b1881e058d31b1a8d88f31bb298b5810afbba25c5cb341cfa4904d843
    SignatureSha256: e53f48473621390c8243ada6345826af7c713cf1f4bbbf0d030599d1e4c175ee
 ManifestType: "installer"
-ManifestVersion: "1.6.0"
+ManifestVersion: "1.12.0"
 ```
 
 * * *

--- a/hub/package-manager/winget/index.md
+++ b/hub/package-manager/winget/index.md
@@ -1,7 +1,7 @@
 ---
 title: Use WinGet to install and manage applications
 description: The WinGet command line tool enables developers to discover, install, upgrade, remove and configure applications on Windows computers.
-ms.date: 09/15/2025
+ms.date: 03/24/2026
 ms.topic: overview
 ---
 
@@ -69,13 +69,13 @@ Some users have reported [issues](https://github.com/microsoft/winget-cli/issues
 
 ### Commands
 
-The current preview of the **WinGet** tool supports the following commands.
+The current version of the **WinGet** tool supports the following commands.
 
 | Command | Description |
 |---------|-------------|
 | [install](install.md) | Installs the specified application. |
 | [show](show.md) | Displays details for the specified application. |
-| [source](source.md) | Adds, removes, and updates the Windows Package Manager repositories accessed by **WinGet**. |
+| [source](source.md) | Adds, edits, removes, and updates the Windows Package Manager repositories accessed by **WinGet**. |
 | [search](search.md) | Searches for an application. |
 | [list](list.md) | Display installed packages. |
 | [upgrade](upgrade.md) |  Upgrades the given specified application. |
@@ -123,6 +123,7 @@ The **WinGet** tool supports the following options.
 * MSIX
 * BURN
 * PORTABLE
+* FONT
 
 ## Scripting WinGet
 

--- a/hub/package-manager/winget/list.md
+++ b/hub/package-manager/winget/list.md
@@ -1,7 +1,7 @@
 ---
 title: list Command
 description: Displays the list of listed apps and if an update is available.
-ms.date: 07/15/2025
+ms.date: 03/24/2026
 ms.topic: overview
 ---
 
@@ -60,6 +60,7 @@ The options allow you to customize the list experience to meet your needs.
 | **--upgrade-available** | Lists only packages which have an upgrade available. |
 | **-u, --unknown, --include-unknown** | Lists packages even if their current version cannot be determined. |
 | **--pinned, --include-pinned** | Lists packages even if they have a pin that prevents upgrades by WinGet. |
+| **--details** | Displays detailed, `show`-like output for each matched package instead of a table view. |
 | **-?, --help** |  Get additional help on this command. |
 | **--wait** | Prompts the user to press any key before exiting. |
 | **--logs,--open-logs** | Open the default logs location. |

--- a/hub/package-manager/winget/settings.md
+++ b/hub/package-manager/winget/settings.md
@@ -1,7 +1,7 @@
 ---
 title: settings command
 description: Provides customizations for the Windows Package Manager.
-ms.date: 07/08/2025
+ms.date: 03/24/2026
 ms.topic: article
 ---
 
@@ -73,7 +73,7 @@ We have also defined a schema for the settings file. This allows you to use TAB 
 
 ## Updating settings
 
-The following settings are available for the 1.11 release of the Windows Package Manager.
+The following settings are available for the 1.12 release of the Windows Package Manager.
 
 ### source settings
 
@@ -119,7 +119,7 @@ Color of the progress bar that WinGet displays when not specified by arguments.
 
 Replaces some known folder paths with their respective environment variables.
 
-#### enableSizels
+#### enableSixels
 
 Enables output of sixel images in certain contexts.
 
@@ -143,6 +143,39 @@ The following logging levels are available. Defaults to `info` if the value is n
 - warning
 - error
 - critical
+
+#### channels
+
+The `channels` setting restricts logging output to specific log channels. Special values `default` (the default set of channels) and `all` (all channels) are also accepted. Invalid values are ignored.
+
+```json
+"logging": {
+    "channels": ["default"]
+}
+```
+
+#### file
+
+The `file` settings control automatic cleanup of log files in the default log directory. Cleanup runs at the start of each WinGet process and applies only to the default log location.
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `ageLimitInDays` | Maximum age in days of files in the log directory; older files are deleted. Set to `0` to disable. | 7 |
+| `totalSizeLimitInMB` | Maximum total size in megabytes of all files in the log directory; the oldest files are deleted first. Set to `0` to disable. | 128 |
+| `countLimit` | Maximum number of files in the log directory; the oldest files are deleted first. Set to `0` to disable. | 0 (disabled) |
+| `individualSizeLimitInMB` | Maximum size in megabytes of a single log file. If a file would exceed this limit, logs wrap. Set to `0` to disable. | 16 |
+
+```json
+"logging": {
+    "level": "verbose",
+    "file": {
+        "ageLimitInDays": 7,
+        "totalSizeLimitInMB": 128,
+        "countLimit": 0,
+        "individualSizeLimitInMB": 16
+    }
+}
+```
 
 ### preferences and requirements settings
 
@@ -336,3 +369,54 @@ The `Interactivity` setting controls whether interactive prompts are shown by th
 ### Enabling experimental features
 
 To discover which experimental features are available, go to [https://aka.ms/winget-settings](https://aka.ms/winget-settings) where you can see the experimental features available to you.
+
+The `experimentalFeatures` settings involve the configuration of these "experimental" features. Individual features can be enabled under this node:
+
+```json
+"experimentalFeatures": {
+    "directMSI": true,
+    "resume": true
+}
+```
+
+#### directMSI
+
+This feature enables the Windows Package Manager to directly install MSI packages with the MSI APIs rather than through msiexec. Note that when silent installation is used this is already in effect, as MSI packages that require elevation will fail in that scenario without it.
+
+```json
+"experimentalFeatures": {
+    "directMSI": true
+}
+```
+
+#### resume
+
+This feature enables support for some commands to resume after a reboot.
+
+```json
+"experimentalFeatures": {
+    "resume": true
+}
+```
+
+#### fonts
+
+This feature enables support for fonts via `winget settings`. The `winget font list` command will list installed font families and the number of installed font faces.
+
+```json
+"experimentalFeatures": {
+    "fonts": true
+}
+```
+
+#### sourcePriority
+
+This feature enables sources to have a priority value assigned. Sources with a higher priority will appear earlier in search results and will be selected for installing new packages when multiple sources have a matching package.
+
+Note that search result ordering is dependent on several factors, and source priority is the lowest field currently (match quality and field are more important).
+
+```json
+"experimentalFeatures": {
+    "sourcePriority": true
+}
+```

--- a/hub/package-manager/winget/settings.md
+++ b/hub/package-manager/winget/settings.md
@@ -73,7 +73,7 @@ We have also defined a schema for the settings file. This allows you to use TAB 
 
 ## Updating settings
 
-The following settings are available for the 1.12 release of the Windows Package Manager.
+The following settings are available for the 1.28 release of the Windows Package Manager.
 
 ### source settings
 

--- a/hub/package-manager/winget/source.md
+++ b/hub/package-manager/winget/source.md
@@ -1,14 +1,14 @@
 ---
 title: The WinGet source command
 description: Use the WinGet source command and subcommands to list and manage the sources WinGet accesses.
-ms.date: 07/08/2025
+ms.date: 03/24/2026
 ms.topic: reference
 ms.custom: kr2b-contr-experiment
 ---
 
 # The WinGet source command
 
-The [WinGet](index.md) **source** command allows you to manage sources. With the **source** command, you can **add**, **list**, **update**, **remove**, **reset**, or **export** WinGet sources.
+The [WinGet](index.md) **source** command allows you to manage sources. With the **source** command, you can **add**, **edit**, **list**, **update**, **remove**, **reset**, or **export** WinGet sources.
 
 A WinGet source provides the data for you to discover and install applications. Only use secure, trusted sources.
 
@@ -33,6 +33,7 @@ The following arguments are available.
 | Sub-Command  | Description |
 |--------------|-------------|
 | **add** | Adds a new source. |
+| **edit** | Edits an existing source. |
 | **list** | Lists current sources. |
 | **update** | Updates current sources. |
 | **remove** | Removes current sources. |
@@ -83,7 +84,7 @@ The following options are available.
 | **--trust-level** | Trust level of the source (none or trusted). |
 | **--header** | Optional Windows-Package-Manager REST source HTTP header. |
 | **--accept-source-agreements** | Used to accept the source license agreement, and avoid the prompt. |
-| **--explicit** |  |
+| **--explicit** | Marks the source as explicit, requiring commands to directly target it using `--source`. |
 | **-?, --help** |  Get additional help on this command. |
 | **--wait** | Prompts the user to press any key before exiting. |
 | **--logs,--open-logs** | Open the default logs location. |
@@ -103,6 +104,56 @@ The **add** subcommand supports the optional **type** parameter, which tells the
 |--------------|-------------|
 | **Microsoft.PreIndexed.Package** | The default source type. |
 | **Microsoft.Rest** | A Microsoft REST API source. |
+
+### edit
+
+The **edit** subcommand modifies an existing source's configuration. The primary use is to toggle whether a source is **explicit** or **implicit**. When a source is explicit, WinGet commands must directly target it using `--source`. When a source is implicit, it is included in all commands automatically.
+
+Usage:
+
+```cmd
+winget source edit [-n] <name> [<options>]
+```
+
+#### Arguments
+
+The following arguments are available.
+
+| Argument  | Description |
+|--------------|-------------|
+| **-n, --name** | The name of the source to edit. |
+
+#### Options
+
+The following options are available.
+
+| Option  | Description |
+|-------------|-------------|
+| **--explicit** | Sets the source as explicit (`true`) or implicit (`false`). When explicit, commands must directly target the source using `--source`. |
+| **--header** | Optional Windows-Package-Manager REST source HTTP header. |
+| **--accept-source-agreements** | Used to accept the source license agreement, and avoid the prompt. |
+| **-?, --help** | Get additional help on this command. |
+| **--wait** | Prompts the user to press any key before exiting. |
+| **--logs,--open-logs** | Open the default logs location. |
+| **--verbose, --verbose-logs** | Used to override the logging setting and create a verbose log. |
+| **--nowarn,--ignore-warnings** | Suppresses warning outputs. |
+| **--disable-interactivity** | Disable interactive prompts. |
+| **--proxy** | Set a proxy to use for this execution. |
+| **--no-proxy** | Disable the use of proxy for this execution. |
+
+#### Example
+
+The **winget-font** source is explicit by default, meaning commands must target it directly using `--source winget-font`. To reset it to the default (implicit) state so that it is included in all WinGet commands automatically, run:
+
+```cmd
+winget source edit winget-font --explicit false
+```
+
+To set a source as explicit:
+
+```cmd
+winget source edit winget-font --explicit true
+```
 
 ### list
 

--- a/hub/package-manager/winget/troubleshooting.md
+++ b/hub/package-manager/winget/troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 title: Debugging and troubleshooting issues with WinGet
 description: Provides information on logging and WinGet diagnostics.
-ms.date: 07/15/2025
+ms.date: 03/24/2026
 ms.topic: troubleshooting-general
 ---
 
@@ -19,7 +19,7 @@ When WinGet commands are failing, sometimes it is necessary to look at the log f
 
 ## WinGet Logs
 
-Windows Package Manager by default creates log files when executing commands. These logs contain information that can aid in debugging issues with WinGet. There is no maximum size for the log files. They are typically only a few KB in size. When the number of log files in the directory exceeds 100, the oldest log files will begin being deleted. There is no time-based removal of logs and these settings are not configurable. If you have reached the 100 file log capacity, just move any WinGet logs that you wish to preserve into a different directory.
+Windows Package Manager by default creates log files when executing commands. These logs contain information that can aid in debugging issues with WinGet. Log file cleanup behavior is configurable via the [logging settings](./settings.md#logging-settings) in your settings file. By default, log files older than 7 days or exceeding 128 MB total are automatically removed, and individual log files wrap at 16 MB. Use the `logging.file` settings to adjust these limits.
 
 Use the command [`winget --info`](./info.md) to find the directory path to your WinGet log files. The default path for WinGet log files is:
 


### PR DESCRIPTION
This PR updates the documents for WinGet to match the latest features from 1.12 and 1.28. These differences are currently documented mostly in the [Release Notes](https://github.com/microsoft/winget-cli/releases/tag/v1.28.190)

It also updates the example manifests to version 1.12.0 as 1.6.0 is deprecated on the community repository and the 1.28 manifest links are not active yet as they are still under `latest` in the WinGet CLI GitHub

cc @denelon @JohnMcPMS 