### PR TITLE
Proofread PR 5870 again, and fixed one typo and clarified some sentences

### DIFF
--- a/hub/package-manager/package/repository.md
+++ b/hub/package-manager/package/repository.md
@@ -83,13 +83,13 @@ The `PackageIdentifier` and the `PackageVersion` values in the manifest must mat
 
 Thus to set up sparse checkout for all manifests of a publisher, you'd type:
 
-a. If you are using Git version 2.37.0 or newer, run the following command to set up sparse checkout for your folder.
+* If you are using Git version 2.37.0 or newer, run the following command to set up sparse checkout for your folder.
 
     ```powershell
     git sparse-checkout set manifests\<letter>\<publisher>
     ```
 
-b. If you are using an older version of Git, refer to the [Git documentation](https://git-scm.com/docs/git-sparse-checkout) for how to set up sparse checkout for your local repository.
+* If you are using an older version of Git, refer to the [Git documentation](https://git-scm.com/docs/git-sparse-checkout) for how to set up sparse checkout for your local repository.
 
 Note that the above command will override all current sparse checkout settings and set it up for only that one folder, refer to the [Git documentation](https://git-scm.com/docs/git-sparse-checkout) for setting up sparse checkout with multiple folders.
 
@@ -148,7 +148,7 @@ If there is ever an error during the process, you will be notified and our label
 
 ## Validation process
 
-When you [create a pull request](#step-6-create-a-pull-request) to submit your manifest to the Windows Package Manager repository, this will start an automation process that validates the manifest and processes your pull request. GitHub labels are used to share progress and allow you to communicate with us.
+When you [create a pull request](#step-8-create-a-pull-request) to submit your manifest to the Windows Package Manager repository, this will start an automation process that validates the manifest and processes your pull request. GitHub labels are used to share progress and allow you to communicate with us.
 
 ### Submission expectations
 

--- a/hub/package-manager/package/repository.md
+++ b/hub/package-manager/package/repository.md
@@ -59,13 +59,13 @@ To create a fork of the Windows Package Manager Community repository and clone t
 2. From Windows Command Prompt or PowerShell, use the following command to clone your fork.
 
     ```powershell
-    git clone --no-checkout <your-fork-name>
+    git clone --filter=blob:none --no-checkout <your-fork-name>
     ```
 
 ### Step 4: Setup sparse checkout
 
 Sparse checkout allows you to choose which parts of a repository you want to download, instead of downloading everything.
-In the previous step, `--no-checkout` means that no files have been downloaded yet.
+In the previous step, `--filter=blob:none` means that the commit history has not been downloaded yet, and `--no-checkout` means that no files have been added to the working copy (the index) yet.
 
 Before downloading anything, you'll have to specify filters for sparse checkout to use (stored in `.git/info/sparse-checkout`).
 
@@ -101,7 +101,7 @@ You can now apply the sparse checkout settings by running the normal checkout co
 git checkout
 ```
 
-Even if the folder you want to submit hasn't been committed to the repository yet, you must still run the checkout command, as it will be impossible to push without the Git internals it sets up.
+Even if the folder you want to submit hasn't been committed to the repository yet, you must still run the checkout command, as it will be impossible to add (and thus commit) anything without the Git internals it sets up (the index).
 
 If you are entering multiple submissions, create a branch instead of a fork. We currently allow only one manifest file per submission.
 

--- a/hub/package-manager/package/repository.md
+++ b/hub/package-manager/package/repository.md
@@ -65,10 +65,11 @@ To create a fork of the Windows Package Manager Community repository and clone t
 ### Step 4: Setup sparse checkout
 
 Sparse checkout allows you to choose which parts of a repository you want to download, instead of downloading everything.
-Next you have to specify filters for sparse checkout to use (stored in `.git/info/sparse-checkout`).
+In the previous step, `--no-checkout` means that no files have been downloaded yet.
 
-You must add your manifest files to the repository in the following folder structure:
-To initialize sparse checkout for a repository you must type:
+Before downloading anything, you'll have to specify filters for sparse checkout to use (stored in `.git/info/sparse-checkout`).
+
+First, here is an explanation of what is going to be set up. You must add your manifest files to the repository in the following folder structure:
 
 **manifests** / **letter** / **publisher** / **application** / **version**
 
@@ -82,23 +83,25 @@ The `PackageIdentifier` and the `PackageVersion` values in the manifest must mat
 
 Thus to set up sparse checkout for all manifests of a publisher, you'd type:
 
-1. If you are using Git version 2.37.0 or newer, run the following command to set up sparse checkout for your folder.
+a. If you are using Git version 2.37.0 or newer, run the following command to set up sparse checkout for your folder.
 
     ```powershell
     git sparse-checkout set manifests\<letter>\<publisher>
     ```
 
-    If you are using an older version of Git, refer to the [Git documentation](https://git-scm.com/docs/git-sparse-checkout) for how to set up sparse checkout for your local repository.
+b. If you are using an older version of Git, refer to the [Git documentation](https://git-scm.com/docs/git-sparse-checkout) for how to set up sparse checkout for your local repository.
 
 Note that the above command will override all current sparse checkout settings and set it up for only that one folder, refer to the [Git documentation](https://git-scm.com/docs/git-sparse-checkout) for setting up sparse checkout with multiple folders.
 
 ### Step 5: Checkout the repository
 
-You can now apply the sparse checkout settings by running.
+You can now apply the sparse checkout settings by running the normal checkout command.
 
 ```powershell
 git checkout
 ```
+
+Even if the folder you want to submit hasn't been committed to the repository yet, you must still run the checkout command, as it will be impossible to push without the Git internals it sets up.
 
 If you are entering multiple submissions, create a branch instead of a fork. We currently allow only one manifest file per submission.
 


### PR DESCRIPTION
I saw that there was another typo, the second line here:
> You must add your manifest files to the repository in the following folder structure:
> To initialize sparse checkout for a repository you must type:

This PR fixes that. I also rewrote a few lines to make it clearer (I think). If someone could review whether it is indeed clearer now that would be welcome.

@niels9001
#5870