### PR TITLE
Fix: SDK overview and downloads page corrections

### DIFF
--- a/hub/apps/windows-sdk/downloads.md
+++ b/hub/apps/windows-sdk/downloads.md
@@ -18,7 +18,7 @@ For older versions, see the [Windows SDK download archive](downloads-archive.md)
 | Release  | Downloads |
 | ----- | -------------------------------------- |
 | **Windows SDK for Windows 11 (10.0.26100.7705)** <br/> February 2026 <br/> [Release notes](./release-notes.md#build-100261007705) | [Installer](https://go.microsoft.com/fwlink/?linkid=2349110) <br/> [ISO](https://go.microsoft.com/fwlink/?linkid=2348707) |
-| **Windows SDK for Windows 11 (10.0.26100.7627)** <br/> January 2026 <br/> [Release notes](./release-notes.md#build-100261007627) | [Installer]( https://go.microsoft.com/fwlink/?linkid=2347650) <br/> [ISO](https://go.microsoft.com/fwlink/?linkid=2347553) |
+| **Windows SDK for Windows 11 (10.0.26100.7627)** <br/> January 2026 <br/> [Release notes](./release-notes.md#build-100261007627) | [Installer](https://go.microsoft.com/fwlink/?linkid=2347650) <br/> [ISO](https://go.microsoft.com/fwlink/?linkid=2347553) |
 | **Windows SDK for Windows 11 (10.0.26100.7463)** <br/> December 2025 <br/> [Release notes](./release-notes.md#build-100261007463) | [Installer](https://go.microsoft.com/fwlink/?linkid=2346012) <br/> [ISO](https://go.microsoft.com/fwlink/?linkid=2345534) |
 | **Windows SDK for Windows 11 (10.0.26100.7175)** <br/> November 2025 <br/> [Release notes](./release-notes.md#build-100261007175) | [Installer](//go.microsoft.com/fwlink/?linkid=2342616) <br/> [ISO](//go.microsoft.com/fwlink/?linkid=2342518) |
 | **Windows SDK for Windows 11 26H1 for OEMs and Partners (10.0.28000.1)** <br/> November 2025 | [Installer](//go.microsoft.com/fwlink/?linkid=2342535) <br/> [ISO](//go.microsoft.com/fwlink/?linkid=2343616) |

--- a/hub/apps/windows-sdk/release-notes.md
+++ b/hub/apps/windows-sdk/release-notes.md
@@ -10,9 +10,9 @@ ms.localizationpriority: medium
 # What's new in the Windows SDK
 
 In a new or existing Windows app, you can get the Windows SDK in several ways: install it from the installer or ISO, in the Visual Studio 2022 Installer, or by downloading the NuGet package.
-You can update the SDK by manually installing the new build, updating in Visual Studio or update the Nuget package
+You can update the SDK by manually installing the new build, updating in Visual Studio, or updating the NuGet package.
 
-For the the latest builds, see [Downloads for the Windows SDK](./downloads.md).
+For the latest builds, see [Downloads for the Windows SDK](./downloads.md).
 
 ## Build 10.0.26100.7705
 


### PR DESCRIPTION
## Summary
Fixes minor issues in the Windows SDK downloads and release-notes pages.

## Changes
- **downloads.md**: Remove extraneous space in installer URL for Windows SDK 10.0.26100.7627
- **release-notes.md**: Fix duplicated word ('the the' → 'the')
- **release-notes.md**: Fix grammar in introduction paragraph (parallel structure, missing period, NuGet capitalization)

cc @Karl-Bridge-Microsoft