### PR TITLE
Fix: Glossary, FAQ, and best practices content updates

### DIFF
--- a/hub/apps/get-started/best-practices.md
+++ b/hub/apps/get-started/best-practices.md
@@ -240,7 +240,7 @@ You can build, package, and deliver Windows apps in many ways. The best practice
 People run Windows across conventional devices as well as an increasingly diverse, modern range of devices. Devices today come not only with x86/x64-based, but also Arm-based, architectures; not only with mouse and keyboard but also touch screens, touchpads, and pens; with cameras, GPS, and sensors like gyroscopes; and with graphics and neural processing chipsets that enable not only amazing visuals but also hardware-accelerated artificial intelligence (AI). Customers expect apps to take advantage of the hardware (that they have paid for!) and be cognizant of the device form factor to give them an appropriately optimized experience.
 
 - Support a variety of inputs and interactions - [Input and interactions overview](../develop/input/index.md)
-- Achieve AI powered productivity with Win ML - [Introduction to Windows Machine Learning](/windows/ai/windows-ml/).
+- Achieve AI powered productivity with Win ML - [Introduction to Windows Machine Learning](/windows/ai/new-windows-ml/overview).
 - Use AI models that run locally and power Microsoft Foundry on Windows features on Copilot+ PCs - [What is Windows ML?](/windows/ai/apis/).
 - Use a variety of AI-powered features supported by Windows AI APIs in the Windows App SDK and machine learning (ML) models that run locally on Copilot+ PCs - [What are Windows AI APIs?](/windows/ai/apis/).
 

--- a/hub/apps/get-started/windows-developer-faq.md
+++ b/hub/apps/get-started/windows-developer-faq.md
@@ -85,7 +85,7 @@ Topics covered include:
 
 > Note that [WinUI](../winui/winui3/index.md) (a UI framework) ships with the [Windows App SDK](../windows-app-sdk/index.md) (a Windows platform development framework).
 >
-> Generally, WinUI can't be used unless the app is ready to migrate its UI framework entirely. A feature called [XAML islands](/windows/apps/windows-app-sdk/stable-channel#xaml-islands-no-longer-experimental) is in development to host WinUI content in other UI frameworks (WPF, Win32).
+> Generally, WinUI can't be used unless the app is ready to migrate its UI framework entirely. A feature called [XAML Islands](../desktop/modernize/xaml-islands/xaml-islands.md) enables hosting WinUI content in other UI frameworks (WPF, Win32). See [XAML Islands documentation](../desktop/modernize/xaml-islands/xaml-islands.md) for more info.
 >
 > Elements of the Windows App SDK can often be used in desktop apps, depending on how the existing app was built. UWP apps are not supported by Windows App SDK.
 >
@@ -221,7 +221,7 @@ Topics covered include:
 
 <details><summary>Where can I find WinUI samples?</summary>
 
-> See [Sample and resources](./samples.md). Some notable repositories:
+> See [Samples and resources](./samples.md). Some notable repositories:
 > 
 > - [WindowsAppSDK-Samples](https://github.com/microsoft/WindowsAppSDK-Samples): Demonstrates how to use specific Windows App SDK API sets.
 > - [Windows topic-specific samples](https://github.com/MicrosoftDocs/windows-topic-specific-samples/tree/winui-3/tutorials/winui-notes): Contains a WinUI notes sample used in the [Create a WinUI app](/windows/apps/tutorials/winui-notes/) tutorial.
@@ -389,7 +389,7 @@ Topics covered include:
 > - What languages or skills do you already have — .NET, JavaScript, something else?
 > - Do you need access to Windows-specific APIs?
 > - Which framework’s capabilities best match your app’s requirements?
-> - See [this table](/windows/apps/get-started/#app-development-framework-feature-comparison) for additional comparison factors.
+> - See [this table](/windows/apps/get-started/) for additional comparison factors.
 > 
 > For many business apps, teams often choose based on existing skills and what the team is most comfortable using.
 

--- a/hub/apps/get-started/windows-developer-glossary.md
+++ b/hub/apps/get-started/windows-developer-glossary.md
@@ -15,7 +15,7 @@ This glossary promotes a common vocabulary among Windows developers.
 
 #### App lifecycle management (ALM)
 
-Manage an application's execution state: not running, running in the background, running in the foreground, or suspended. See [UWP app lifecycle](/windows/uwp/launch-resume/app-lifecycle).
+Manage an application's execution state: not running, running in the background, running in the foreground, or suspended. See [UWP app lifecycle](/windows/uwp/launch-resume/app-lifecycle) and [Windows App SDK app lifecycle](../windows-app-sdk/applifecycle/applifecycle.md).
 
 #### Application model
 
@@ -23,7 +23,7 @@ Often referred to as "app model." The application model combines deployment, iso
 
 #### Application packaging
 
-Describes the way in which your app is packaged before being deployed and installed by users. An app can be packaged, unpackaged, or packaged with external location (see the [Windows developer FAQ](/windows/apps/get-started/windows-developer-faq#what-s-the-difference-between-apps-that-are-packaged--unpackaged--and-packaged-with-external-location)).
+Describes the way in which your app is packaged before being deployed and installed by users. An app can be packaged, unpackaged, or packaged with external location (see the [Windows developer FAQ](/windows/apps/get-started/windows-developer-faq)).
 
 
 #### Bootstrapper
@@ -96,7 +96,7 @@ Traditionally, "native" refers to applications built without using the .NET runt
 
 #### Neural Processing Unit (NPU)
 
-A dedicated on‑device AI accelerator optimized for transformer operations and other ML workloads. Windows apps can target NPUs via APIs included as part of [Foundry Local](/windows/ai/foundry-local/get-started).
+A dedicated on‑device AI accelerator optimized for transformer operations and other ML workloads. Windows apps can target NPUs via [Windows AI APIs](/windows/ai/apis/), [Foundry Local](/windows/ai/foundry-local/get-started), or [Windows ML execution providers](/windows/ai/new-windows-ml/supported-execution-providers).
 
 #### ONNX Runtime (ORT)
 
@@ -163,11 +163,11 @@ Lets you create, package, and deploy Visual Studio extensions. [Get started with
 
 #### WebView2
 
-A control that allows app developers to embed web content (HTML/CSS/JS) in their native apps using the Microsoft Edge (Chromium) rendering engine. You can use WebView2 in WinUI, Win32 C++, WPF, and WinForms, and it offers a developer preview for WinUI for UWP support. See [Introduction to Microsoft Edge WebView2](/microsoft-edge/webview2/).
+A control that allows app developers to embed web content (HTML/CSS/JS) in their native apps using the Microsoft Edge (Chromium) rendering engine. You can use WebView2 in WinUI, Win32 C++, WPF, and WinForms. See [Introduction to Microsoft Edge WebView2](/microsoft-edge/webview2/).
 
 #### Microsoft Foundry on Windows
 
-Microsoft Foundry on Windows offers AI-backed features and APIs on Windows 11 PCs. These features are in active development. See [Windows AI APIs overview](/windows/ai/overview).
+Microsoft Foundry on Windows offers AI-backed features and APIs on Windows 10 and later PCs. Some features like Phi Silica require Copilot+ PC hardware. See [Windows AI APIs overview](/windows/ai/overview).
 
 #### Windows API
 
@@ -203,7 +203,7 @@ XAML Islands lets you host WinRT XAML controls in non-UWP desktop (Win32, WinFor
 
 #### Windows ML
 
-Windows APIs for running ONNX models locally in Windows apps, with hardware acceleration via DirectML where it's available. See [Windows ML](/windows/ai/new-windows-ml/overview).
+Windows APIs for running ONNX models locally in Windows apps, with automatic execution provider management across CPUs, GPUs, and NPUs. See [Windows ML](/windows/ai/new-windows-ml/overview).
 
 ## Related content
 


### PR DESCRIPTION
## Summary
Updates glossary definitions, FAQ answers, and best practices links to reflect current product status.

## Changes

### Glossary (windows-developer-glossary.md)
- Fix broken anchor link in Application Packaging FAQ reference
- Update Microsoft Foundry description: Windows 10 and later (not Windows 11 only), clarify Copilot+ PC requirement for Phi Silica
- Update NPU entry: mention all three access pathways (Windows AI APIs, Foundry Local, Windows ML EPs)
- Update Windows ML description: automatic execution provider management across CPUs/GPUs/NPUs
- Remove outdated WebView2 UWP developer preview mention
- Add Windows App SDK lifecycle reference alongside UWP lifecycle link in ALM definition

### FAQ (windows-developer-faq.md)
- Fix XAML Islands: broken anchor link, update from 'is in development' to 'enables hosting' with correct doc link
- Fix broken anchor in feature comparison table link
- Fix typo: 'Sample and resources' to 'Samples and resources'

### Best practices (best-practices.md)
- Fix broken Windows ML link (old path to new path)

cc @jwmsft