### PR TITLE
Fix: Remove duplicate column tag in What's New page

### DIFF
--- a/hub/apps/whats-new/whats-new-for-developers.md
+++ b/hub/apps/whats-new/whats-new-for-developers.md
@@ -26,7 +26,6 @@ Find the latest downloads, release notes, and updates for the Windows SDK, Windo
         [View downloads](../windows-app-sdk/downloads.md)
     :::column-end:::
     :::column:::
-        :::column:::
         ![Windows SDK icon](images/wsdk-hero.png)<br>
         **Windows SDK**<br>
         Discover what's new<br>


### PR DESCRIPTION
## Summary
Fixes a broken column layout in the What's New for developers page.

## Changes
- **whats-new-for-developers.md**: Remove duplicate `:::column:::` opener that caused nested column layout. The Windows SDK column had an extra `:::column:::` tag inside itself, creating malformed Learn layout.

### Fixes not applied (files not in this repo)
- ai-build.md, ai-setup.md, ai-for-windows-developers.md: These files don't exist in this repository
- community.md: 'filling' typo not found (may already be fixed)

cc @GrantMeStrength