### PR TITLE
Clarify that there is no XAML markup extension for .resw string resources

### DIFF
--- a/uwp/app-resources/localize-strings-ui-manifest.md
+++ b/uwp/app-resources/localize-strings-ui-manifest.md
@@ -70,6 +70,9 @@ Instead of setting **Width** from a Resources File, you'll probably want to allo
 Greeting.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name
 ```
 
+> [!NOTE]
+> Unlike XAML resource references such as `{StaticResource}` or `{ThemeResource}`, there is no XAML markup extension for directly assigning a `.resw` string resource to a property in markup—for example, `<TextBlock Text="{ms-resource:Farewell}"/>` is not valid syntax. **x:Uid** is the XAML-only approach. To explicitly set a localized string to a specific property, add the corresponding property identifier to your `.resw` file (for example, `Farewell.Text`) and set `x:Uid="Farewell"` on the element. If you need to assign a resource string to a property in code (for example, when the identifier naming convention that **x:Uid** requires doesn't fit your scenario), use `ResourceLoader.GetString()` as described in [Refer to a string resource identifier from code](#refer-to-a-string-resource-identifier-from-code).
+
 ## Refer to a string resource identifier from code
 
 You can explicitly load a string resource based on a simple string resource identifier.


### PR DESCRIPTION
## Problem

Issue #4724 asks how to write `<TextBlock Text="{WHAT DO I PUT HERE TO GET RESOURCE STRING}" />` — i.e. whether there is a XAML markup extension syntax for directly binding a `.resw` string resource to a property.

A previous Copilot-generated PR (#5620) attempted to address this by suggesting `Text="ms-resource:///Resources/Farewell"` as valid XAML syntax. **That is incorrect**: assigning an `ms-resource:` URI directly to a plain string property in XAML markup does not trigger resource lookup at runtime — the literal URI string would be displayed as text. That PR was closed without merging.

## Change

Adds a `[!NOTE]` callout at the end of the **"Refer to a string resource identifier from XAML"** section that:

- Explicitly states there is no XAML markup extension (like `{StaticResource}`) for `.resw` string resources
- Shows `<TextBlock Text="{ms-resource:Farewell}"/>` as an example of what does **not** work (directly answering the question in the issue)
- Confirms `x:Uid` is the XAML-only approach
- Points to `ResourceLoader.GetString()` for cases where code-behind is needed

Fixes #4724