### PR TITLE
Add ms-store-badge CSS styling documentation

### DIFF
--- a/hub/apps/publish/faq/leverage-developer-tools.md
+++ b/hub/apps/publish/faq/leverage-developer-tools.md
@@ -211,8 +211,17 @@ Customers clicking this link are taken to the web-based Store listing, where the
 
 - **Using the Microsoft Store badge:**  
 You can create a branded Microsoft Store badge that links directly to your app. To generate your custom badge:
-1. Go to the [Microsoft Store badges](https://developer.microsoft.com/store/badges) page.
+1. Go to the [Microsoft Store badge creator](https://apps.microsoft.com/badge) page.
 2. Provide your app’s 12-character Store ID (found in your Partner Center under the Product Identity section).
+
+The badge is a [web component](https://developer.mozilla.org/en-US/docs/Web/API/Web_components) that automatically detects the user’s language and theme. It won’t inherit CSS styles from your page, but you can customize its size using a [CSS part selector](https://developer.mozilla.org/en-US/docs/Web/CSS/::part):
+
+```css
+/* Adjust the badge size to match other buttons on your page. */
+ms-store-badge::part(img) {
+    max-width: 200px;
+}
+```
 
 This badge clearly indicates your app is available on the Microsoft Store and can help increase customer trust and downloads.
 


### PR DESCRIPTION
Applies the changes from community PR #5418 (by @JudahGabriel, the author of the [ms-store-badge web component](https://github.com/microsoft/app-store-badge)) to the current file location.

## Background

PR #5418 was filed against `hub/apps/publish/microsoft-store-app-badge.md`, but that file was removed and its content was reorganized into `hub/apps/publish/faq/leverage-developer-tools.md` in a squash merge on June 25, 2025. This caused an unresolvable merge conflict on the original PR.

## Changes

- Adds a note that the badge is a web component (won't inherit page CSS)
- Adds CSS `::part(img)` selector example for customizing badge size
- Updates badge creator URL to `apps.microsoft.com/badge`

Closes #5418