### PR TITLE
Migrate controls docs from UWP to WinUI 3

### DIFF
--- a/hub/apps/develop/ui/controls/auto-suggest-box.md
+++ b/hub/apps/develop/ui/controls/auto-suggest-box.md
@@ -144,5 +144,5 @@ Here's an AutoSuggestBox with a 'find' icon.
 - [Text controls](../../../design/controls/text-controls.md)
 - [Spell checking](../../../design/controls/text-controls.md)
 - [TextBox class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.textbox)
-- [Windows.UI.Xaml.Controls PasswordBox class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.passwordbox)
+- [Microsoft.UI.Xaml.Controls.PasswordBox class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.passwordbox)
 - [String.Length property](/dotnet/api/system.string.length)

--- a/hub/apps/develop/ui/controls/commanding.md
+++ b/hub/apps/develop/ui/controls/commanding.md
@@ -16,7 +16,7 @@ In this topic, we describe commanding in Windows applications. Specifically, we 
 
 ## Important APIs
 
-- [Windows.UI.Xaml.Input.ICommand](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.input.icommand) and [System.Windows.Input.ICommand](/dotnet/api/system.windows.input.icommand)
+- [Microsoft.UI.Xaml.Input.ICommand](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.input.icommand) and [System.Windows.Input.ICommand](/dotnet/api/system.windows.input.icommand)
 - [XamlUICommand](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.input.xamluicommand)
 - [StandardUICommand](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.input.standarduicommand)
 
@@ -70,16 +70,16 @@ To provide rich and comprehensive user experiences across command surfaces effic
 
 To bind a control to a shared command resource, you can implement the ICommand interfaces yourself, or you can build your command from either the [XamlUICommand](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.input.xamluicommand) base class or one of the platform commands defined by the [StandardUICommand](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.input.standarduicommand) derived class.
 
-- The ICommand interface ([Windows.UI.Xaml.Input.ICommand](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.input.icommand) or [System.Windows.Input.ICommand](/dotnet/api/system.windows.input.icommand)) lets you create fully customized, reusable commands across your app.
+- The ICommand interface ([Microsoft.UI.Xaml.Input.ICommand](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.input.icommand) or [System.Windows.Input.ICommand](/dotnet/api/system.windows.input.icommand)) lets you create fully customized, reusable commands across your app.
 - [XamlUICommand](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.input.xamluicommand) also provides this capability but simplifies development by exposing a set of built-in command properties such as the command behavior, keyboard shortcuts (access key and accelerator key), icon, label, and description.
 - [StandardUICommand](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.input.standarduicommand) simplifies things further by letting you choose from a set of standard platform commands with predefined properties.
 
 > [!Important]
-> In WinUI applications, commands are implementations of either the [Windows.UI.Xaml.Input.ICommand](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.input.icommand) (C++) or the [System.Windows.Input.ICommand](/dotnet/api/system.windows.input.icommand) (C#) interface, depending on your chosen language framework.
+> In WinUI applications, commands are implementations of either the [Microsoft.UI.Xaml.Input.ICommand](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.input.icommand) (C++) or the [System.Windows.Input.ICommand](/dotnet/api/system.windows.input.icommand) (C#) interface, depending on your chosen language framework.
 
 ## Command experiences using the StandardUICommand class
 
-Derived from [XamlUICommand](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.input.xamluicommand) (derived from [Windows.UI.Xaml.Input.ICommand](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.input.icommand) for C++ or  [System.Windows.Input.ICommand](/dotnet/api/system.windows.input.icommand) for C#), the [StandardUICommand](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.input.standarduicommand) class exposes a set of standard platform commands with pre-defined properties such as icon, keyboard accelerator, and description.
+Derived from [XamlUICommand](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.input.xamluicommand) (derived from [Microsoft.UI.Xaml.Input.ICommand](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.input.icommand) for C++ or  [System.Windows.Input.ICommand](/dotnet/api/system.windows.input.icommand) for C#), the [StandardUICommand](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.input.standarduicommand) class exposes a set of standard platform commands with pre-defined properties such as icon, keyboard accelerator, and description.
 
 A [StandardUICommand](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.input.standarduicommand) provides a quick and consistent way to define common commands such as `Save` or `Delete`. All you have to do is provide the execute and canExecute functions.
 
@@ -91,7 +91,7 @@ A [StandardUICommand](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.input
 
 | Download the code for this example |
 | -------------------- |
-| [Commanding sample (StandardUICommand)](https://github.com/MicrosoftDocs/windows-topic-specific-samples/archive/uwp-commanding-standarduicommand.zip) |
+| [StandardUICommandPage (WinUI Gallery)](https://github.com/microsoft/WinUI-Gallery/blob/main/WinUIGallery/Samples/ControlPages/StandardUICommandPage.xaml.cs) |
 
 In this example, we show how to enhance a basic [ListView](../../../design/controls/listview-and-gridview.md) with a Delete item command implemented through the [StandardUICommand](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.input.standarduicommand) class, while optimizing the user experience for a variety of input types using a [MenuBar](../../../design/controls/menus.md), [Swipe](../../../design/controls/swipe.md) control, hover buttons, and [context menu](../../../design/controls/menus.md).
 
@@ -371,10 +371,10 @@ If you need to create a command that isn't defined by the [StandardUICommand](/w
 
 | Download the code for this example |
 | -------------------- |
-| [WinUI commanding sample (XamlUICommand)](https://github.com/MicrosoftDocs/windows-topic-specific-samples/archive/uwp-commanding-xamluicommand.zip) |
+| [XamlUICommandPage (WinUI Gallery)](https://github.com/microsoft/WinUI-Gallery/blob/main/WinUIGallery/Samples/ControlPages/XamlUICommandPage.xaml.cs) |
 | Download the code for this example |
 | -------------------- |
-| [Commanding sample (XamlUICommand)](https://github.com/MicrosoftDocs/windows-topic-specific-samples/archive/uwp-commanding-xamluicommand.zip) |
+| [XamlUICommandPage (WinUI Gallery)](https://github.com/microsoft/WinUI-Gallery/blob/main/WinUIGallery/Samples/ControlPages/XamlUICommandPage.xaml.cs) |
 Many platform controls use the XamlUICommand properties under the covers, just like our StandardUICommand example in the previous section. 
 
 **Xaml:**
@@ -605,7 +605,7 @@ private void ListViewSwipeContainer_PointerExited(object sender, PointerRoutedEv
 
 Standard WinUI controls (button, list, selection, calendar, predictive text) provide the basis for many common command experiences. For a complete list of control types, see [Controls and patterns for Windows apps](../../../design/controls/index.md).
 
-The most basic way to support a structured commanding experience is to define an implementation of the ICommand interface ([Windows.UI.Xaml.Input.ICommand](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.input.icommand) for C++ or  [System.Windows.Input.ICommand](/dotnet/api/system.windows.input.icommand) for C#).  This ICommand instance can then be bound to controls such as buttons.
+The most basic way to support a structured commanding experience is to define an implementation of the ICommand interface ([Microsoft.UI.Xaml.Input.ICommand](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.input.icommand) for C++ or  [System.Windows.Input.ICommand](/dotnet/api/system.windows.input.icommand) for C#).  This ICommand instance can then be bound to controls such as buttons.
 
 > [!NOTE]
 > In some cases, it might be just as efficient to bind a method to the Click event and a property to the IsEnabled property.
@@ -618,13 +618,13 @@ Standard WinUI controls (button, list, selection, calendar, predictive text) pro
 
 | Download the code for this example |
 | -------------------- |
-| [Commanding sample (ICommand)](https://github.com/MicrosoftDocs/windows-topic-specific-samples/archive/uwp-commanding-icommand.zip) |
+| [CommandBarPage (WinUI Gallery)](https://github.com/microsoft/WinUI-Gallery/blob/main/WinUIGallery/Samples/ControlPages/CommandBarPage.xaml.cs) |
 
 In this basic example, we demonstrate how a single command can be invoked with a button click, a keyboard accelerator, and rotating a mouse wheel.
 
 | Download the code for this example |
 | -------------------- |
-| [Commanding sample (ICommand)](https://github.com/MicrosoftDocs/windows-topic-specific-samples/archive/uwp-commanding-icommand.zip) |
+| [CommandBarPage (WinUI Gallery)](https://github.com/microsoft/WinUI-Gallery/blob/main/WinUIGallery/Samples/ControlPages/CommandBarPage.xaml.cs) |
 
 ```xaml
 <Page
@@ -739,12 +739,12 @@ In this basic example, we demonstrate how a single command can be invoked with a
 In code-behind, we connect to our view model that contains our command code. In addition, we define a handler for input from the mouse wheel, which also connects our command code.
 
 ```csharp
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Controls;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Controls;
 using UICommand1.ViewModel;
 using Windows.System;
-using Windows.UI.Core;
+using Microsoft.UI.Input;
 
 namespace UICommand1.View
 {
@@ -805,8 +805,8 @@ Our view model is where we define the execution details for the two commands in 
 using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
-using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Data;
 
 namespace UICommand1.ViewModel
 {
@@ -1096,12 +1096,6 @@ WinUI provides a robust and flexible commanding system that lets you build apps 
 
 ### Samples
 
-#### Topic samples
-
-- [Commanding sample (StandardUICommand)](https://github.com/MicrosoftDocs/windows-topic-specific-samples/archive/uwp-commanding-standarduicommand.zip)
-- [Commanding sample (XamlUICommand)](https://github.com/MicrosoftDocs/windows-topic-specific-samples/archive/uwp-commanding-xamluicommand.zip)
-- [Commanding sample (ICommand)](https://github.com/MicrosoftDocs/windows-topic-specific-samples/archive/uwp-commanding-icommand.zip)
-
-#### Other samples
-
-- [Universal Windows Platform samples (C# and C++)](https://github.com/Microsoft/Windows-universal-samples/tree/b78d95134ce2d57c848e0a8dc339fc362748fb9c/Samples/RadialController)
+- [StandardUICommandPage (WinUI Gallery)](https://github.com/microsoft/WinUI-Gallery/blob/main/WinUIGallery/Samples/ControlPages/StandardUICommandPage.xaml.cs)
+- [XamlUICommandPage (WinUI Gallery)](https://github.com/microsoft/WinUI-Gallery/blob/main/WinUIGallery/Samples/ControlPages/XamlUICommandPage.xaml.cs)
+- [CommandBarPage (WinUI Gallery)](https://github.com/microsoft/WinUI-Gallery/blob/main/WinUIGallery/Samples/ControlPages/CommandBarPage.xaml.cs)

--- a/hub/apps/develop/ui/controls/controls-and-events-intro.md
+++ b/hub/apps/develop/ui/controls/controls-and-events-intro.md
@@ -153,7 +153,7 @@ Button1().Click({ this, &MainPage::Button1_Click });
 ## Related topics
 
 - [Index of controls by function](../../../design/controls/index.md)
-- [Windows.UI.Xaml.Controls namespace](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls)
+- [Microsoft.UI.Xaml.Controls namespace](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls)
 - [Layout](../../../design/layout/index.md)
 - [Style](../../../design/style/index.md)
 - [Usability](../../../design/usability/index.md)

--- a/hub/apps/develop/ui/controls/custom-transport-controls.md
+++ b/hub/apps/develop/ui/controls/custom-transport-controls.md
@@ -4,9 +4,9 @@ title: Create custom media transport controls
 ms.assetid: 6643A108-A6EB-42BC-B800-22EABD7B731B
 label: Create custom media transport controls
 template: detail.hbs
-ms.date: 09/24/2020
+ms.date: 04/22/2026
 ms.topic: how-to
-keywords: windows 10, uwp
+keywords: windows 11, winui 3, windows app sdk
 ms.localizationpriority: medium
 ---
 # Create custom transport controls
@@ -15,16 +15,16 @@ ms.localizationpriority: medium
 
 MediaPlayerElement has customizable XAML transport controls to manage control of audio and video content within a Windows app. Here, we demonstrate how to customize the MediaTransportControls template. We'll show you how to work with the overflow menu, add a custom button and modify the slider.
 
-> **Important APIs**: [MediaPlayerElement](/uwp/api/windows.ui.xaml.controls.mediaplayerelement), [MediaPlayerElement.AreTransportControlsEnabled](/uwp/api/windows.ui.xaml.controls.mediaplayerelement.aretransportcontrolsenabled), [MediaTransportControls](/uwp/api/Windows.Media.SystemMediaTransportControls)
+> **Important APIs**: [MediaPlayerElement](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.mediaplayerelement), [MediaPlayerElement.AreTransportControlsEnabled](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.mediaplayerelement.aretransportcontrolsenabled), [MediaTransportControls](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.mediatransportcontrols)
 
 Before starting, you should be familiar with the MediaPlayerElement and the MediaTransportControls classes. For more info, see the MediaPlayerElement control guide.
 
 > [!TIP]
-> The examples in this topic are based on the [Media Transport Controls sample](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/XamlCustomMediaTransportControls). You can download the sample to view and run the completed code.
+> The examples in this topic are based on the [Media Transport Controls sample](https://github.com/microsoft/WinUI-Gallery/blob/main/WinUIGallery/Samples/ControlPages/MediaPlayerElementPage.xaml.cs). You can download the sample to view and run the completed code.
 
 ## When should you customize the template?
 
-**MediaPlayerElement** has built-in transport controls that are designed to work well without modification in most video and audio playback apps. They're provided by the [**MediaTransportControls**](/uwp/api/Windows.UI.Xaml.Controls.MediaTransportControls) class and include buttons to play, stop, and navigate media, adjust volume, toggle full screen, cast to a second device, enable captions, switch audio tracks, and adjust the playback rate. MediaTransportControls has properties that let you control whether each button is shown and enabled. You can also set the [**IsCompact**](/uwp/api/windows.ui.xaml.controls.mediatransportcontrols.iscompact) property to specify whether the controls are shown in one row or two.
+**MediaPlayerElement** has built-in transport controls that are designed to work well without modification in most video and audio playback apps. They're provided by the [**MediaTransportControls**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.MediaTransportControls) class and include buttons to play, stop, and navigate media, adjust volume, toggle full screen, cast to a second device, enable captions, switch audio tracks, and adjust the playback rate. MediaTransportControls has properties that let you control whether each button is shown and enabled. You can also set the [**IsCompact**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.mediatransportcontrols.iscompact) property to specify whether the controls are shown in one row or two.
 
 However, there may be scenarios where you need to further customize the look of the control or change its behavior. Here are some examples:
 - Change the icons, slider behavior, and colors.
@@ -42,17 +42,17 @@ You can customize the appearance of the control by modifying the default templat
 
 ## Template structure
 
-The [**ControlTemplate**](/uwp/api/Windows.UI.Xaml.Controls.ControlTemplate) is part of the default style. You can copy this default style into your project to modify it. The ControlTemplate is divided into sections similar to other XAML control templates.
-- The first section of the template contains the [**Style**](/uwp/api/Windows.UI.Xaml.Style) definitions for the various components of the MediaTransportControls.
+The [**ControlTemplate**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.ControlTemplate) is part of the default style. You can copy this default style into your project to modify it. The ControlTemplate is divided into sections similar to other XAML control templates.
+- The first section of the template contains the [**Style**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.Style) definitions for the various components of the MediaTransportControls.
 - The second section defines the various visual states that are used by the MediaTransportControls.
-- The third section contains the [**Grid**](/uwp/api/Windows.UI.Xaml.Controls.Grid) that holds that various MediaTransportControls elements together and defines how the components are laid out.
+- The third section contains the [**Grid**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.Grid) that holds that various MediaTransportControls elements together and defines how the components are laid out.
 
 > [!NOTE]
-> For more info about modifying templates, see [Control templates](../../platform/xaml/xaml-control-templates.md). You can use a text editor or similar editors in your IDE to open the XAML files in \(*Program Files*)\Windows Kits\10\DesignTime\CommonConfiguration\Neutral\UAP\\(*SDK version*)\Generic. The default style and template for each control is defined in the **generic.xaml** file. You can find the MediaTransportControls template in generic.xaml by searching for "MediaTransportControls".
+> For more info about modifying templates, see [Control templates](../../platform/xaml/xaml-control-templates.md). In WinUI 3, you can extract the default control template using Visual Studio: right-click the control in the XAML designer and select **Edit Template > Edit a Copy**. This creates a local copy of the MediaTransportControls style and template that you can customize.
 
 In the following sections, you learn how to customize several of the main elements of the transport controls:
-- [**Slider**](/uwp/api/Windows.UI.Xaml.Controls.Slider): allows a user to scrub through their media and also displays progress
-- [**CommandBar**](/uwp/api/Windows.UI.Xaml.Controls.CommandBar): contains all of the buttons.
+- [**Slider**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.Slider): allows a user to scrub through their media and also displays progress
+- [**CommandBar**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.CommandBar): contains all of the buttons.
 For more info, see the Anatomy section of the MediaTransportControls reference topic.
 
 ## Customize the transport controls
@@ -86,7 +86,7 @@ For more info about modifying styles and templates, see [Styling controls](../..
 
 ### Create a derived control
 
-To add to or modify the functionality of the transport controls, you must create a new class that's derived from MediaTransportControls. A derived class called `CustomMediaTransportControls` is shown in the [Media Transport Controls sample](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/XamlCustomMediaTransportControls) and the remaining examples on this page.
+To add to or modify the functionality of the transport controls, you must create a new class that's derived from MediaTransportControls. A derived class called `CustomMediaTransportControls` is shown in the [Media Transport Controls sample](https://github.com/microsoft/WinUI-Gallery/blob/main/WinUIGallery/Samples/ControlPages/MediaPlayerElementPage.xaml.cs) and the remaining examples on this page.
 
 **To create a new class derived from MediaTransportControls**
 1. Add a new class file to your project.
@@ -100,9 +100,9 @@ public sealed class CustomMediaTransportControls : MediaTransportControls
 }
 ```
 
-3. Copy the default style for [**MediaTransportControls**](/uwp/api/Windows.UI.Xaml.Controls.MediaTransportControls) into a [ResourceDictionary](/uwp/api/Windows.UI.Xaml.ResourceDictionary) in your project. This is the style and template you modify.
+3. Copy the default style for [**MediaTransportControls**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.MediaTransportControls) into a [ResourceDictionary](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.ResourceDictionary) in your project. This is the style and template you modify.
 (In the Media Transport Controls sample, a new folder called "Themes" is created, and a ResourceDictionary file called generic.xaml is added to it.)
-4. Change the [**TargetType**](/uwp/api/windows.ui.xaml.style.targettype) of the style to the new custom control type. (In the sample, the TargetType is changed to `local:CustomMediaTransportControls`.)
+4. Change the [**TargetType**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.style.targettype) of the style to the new custom control type. (In the sample, the TargetType is changed to `local:CustomMediaTransportControls`.)
 
 ```xaml
 xmlns:local="using:CustomMediaTransportControls">
@@ -110,7 +110,7 @@ xmlns:local="using:CustomMediaTransportControls">
 <Style TargetType="local:CustomMediaTransportControls">
 ```
 
-5. Set the [**DefaultStyleKey**](/uwp/api/windows.ui.xaml.controls.control.defaultstylekey) of your custom class. This tells your custom class to use a Style with a TargetType of `local:CustomMediaTransportControls`.
+5. Set the [**DefaultStyleKey**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.control.defaultstylekey) of your custom class. This tells your custom class to use a Style with a TargetType of `local:CustomMediaTransportControls`.
 
 ```csharp
 public sealed class CustomMediaTransportControls : MediaTransportControls
@@ -122,7 +122,7 @@ public sealed class CustomMediaTransportControls : MediaTransportControls
 }
 ```
 
-6. Add a [**MediaPlayerElement**](/uwp/api/windows.ui.xaml.controls.mediaplayerelement) to your XAML markup and add the custom transport controls to it. One thing to note is that the APIs to hide, show, disable, and enable the default buttons still work with a customized template.
+6. Add a [**MediaPlayerElement**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.mediaplayerelement) to your XAML markup and add the custom transport controls to it. One thing to note is that the APIs to hide, show, disable, and enable the default buttons still work with a customized template.
 
 ```xaml
 <MediaPlayerElement Name="MediaPlayerElement1" AreTransportControlsEnabled="True" Source="video.mp4">
@@ -146,13 +146,13 @@ You can now modify the control style and template to update the look of your cus
 
 You can move MediaTransportControls command buttons into an overflow menu, so that less commonly used commands are hidden until the user needs them.
 
-In the MediaTransportControls template, the command buttons are contained in a [**CommandBar**](/uwp/api/Windows.UI.Xaml.Controls.CommandBar) element. The command bar has the concept of primary and secondary commands. The primary commands are the buttons that appear in the control by default and are always visible (unless you disable the button, hide the button or there is not enough room). The secondary commands are shown in an overflow menu that appears when a user clicks the ellipsis (…) button. For more info, see the [App bars and command bars](../../../design/controls/command-bar.md) article.
+In the MediaTransportControls template, the command buttons are contained in a [**CommandBar**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.CommandBar) element. The command bar has the concept of primary and secondary commands. The primary commands are the buttons that appear in the control by default and are always visible (unless you disable the button, hide the button or there is not enough room). The secondary commands are shown in an overflow menu that appears when a user clicks the ellipsis (…) button. For more info, see the [App bars and command bars](../../../design/controls/command-bar.md) article.
 
 To move an element from the command bar primary commands to the overflow menu, you need to edit the XAML control template.
 
 **To move a command to the overflow menu:**
 1. In the control template, find the CommandBar element named `MediaControlsCommandBar`.
-2. Add a [**SecondaryCommands**](/uwp/api/windows.ui.xaml.controls.commandbar.secondarycommands) section to the XAML for the CommandBar. Put it after the closing tag for the [**PrimaryCommands**](/uwp/api/windows.ui.xaml.controls.commandbar.primarycommands).
+2. Add a [**SecondaryCommands**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.commandbar.secondarycommands) section to the XAML for the CommandBar. Put it after the closing tag for the [**PrimaryCommands**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.commandbar.primarycommands).
 
 ```xaml
 <CommandBar x:Name="MediaControlsCommandBar" ... >  
@@ -175,7 +175,7 @@ To move an element from the command bar primary commands to the overflow menu, y
 </CommandBar>
 ```
 
-3. To populate the menu with commands, cut and paste the XAML for the desired [**AppBarButton**](/uwp/api/Windows.UI.Xaml.Controls.AppBarButton) objects from the PrimaryCommands to the SecondaryCommands. In this example, we move the `PlaybackRateButton` to the overflow menu.
+3. To populate the menu with commands, cut and paste the XAML for the desired [**AppBarButton**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.AppBarButton) objects from the PrimaryCommands to the SecondaryCommands. In this example, we move the `PlaybackRateButton` to the overflow menu.
 
 4. Add a label to the button and remove the styling information, as shown here.
 Because the overflow menu is comprised of text buttons, you must add a text label to the button and also remove the style that sets the height and width of the button. Otherwise, it won't appear correctly in the overflow menu.
@@ -193,7 +193,7 @@ Because the overflow menu is comprised of text buttons, you must add a text labe
 
 ### Adding a custom button
 
-One reason you might want to customize MediaTransportControls is to add a custom command to the control. Whether you add it as a primary command or a secondary command, the procedure for creating the command button and modifying its behavior is the same. In the [Media Transport Controls sample](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/XamlCustomMediaTransportControls), a "rating" button is added to the primary commands.
+One reason you might want to customize MediaTransportControls is to add a custom command to the control. Whether you add it as a primary command or a secondary command, the procedure for creating the command button and modifying its behavior is the same. In the [Media Transport Controls sample](https://github.com/microsoft/WinUI-Gallery/blob/main/WinUIGallery/Samples/ControlPages/MediaPlayerElementPage.xaml.cs), a "rating" button is added to the primary commands.
 
 **To add a custom command button**
 1. Create an AppBarButton object and add it to the CommandBar in the control template.
@@ -208,10 +208,10 @@ One reason you might want to customize MediaTransportControls is to add a custom
 
 You must add it to the CommandBar in the appropriate location. (For more information, see the Working with the overflow menu section.) How it's positioned in the UI is determined by where the button is in the markup. For example, if you want this button to appear as the last element in the primary commands, add it at the very end of the primary commands list.
 
-You can also customize the icon for the button. For more information, see the <a href="/uwp/api/Windows.UI.Xaml.Controls.AppBarButton"><b>AppBarButton</b></a> reference.
+You can also customize the icon for the button. For more information, see the <a href="/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.AppBarButton"><b>AppBarButton</b></a> reference.
     
 
-2. In the [**OnApplyTemplate**](/uwp/api/windows.ui.xaml.frameworkelement.onapplytemplate) override, get the button from the template and register a handler for its [**Click**](/uwp/api/windows.ui.xaml.controls.primitives.buttonbase.click) event. This code goes in the `CustomMediaTransportControls` class.
+2. In the [**OnApplyTemplate**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.frameworkelement.onapplytemplate) override, get the button from the template and register a handler for its [**Click**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.primitives.buttonbase.click) event. This code goes in the `CustomMediaTransportControls` class.
 
 ```csharp
 public sealed class CustomMediaTransportControls :  MediaTransportControls
@@ -265,9 +265,9 @@ public sealed class CustomMediaTransportControls : MediaTransportControls
 
 ### Modifying the slider
 
-The "seek" control of the MediaTransportControls is provided by a [**Slider**](/uwp/api/Windows.UI.Xaml.Controls.Slider) element. One way you can customize it is to change the granularity of the seek behavior.
+The "seek" control of the MediaTransportControls is provided by a [**Slider**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.Slider) element. One way you can customize it is to change the granularity of the seek behavior.
 
-The default seek slider is divided into 100 parts, so the seek behavior is limited to that many sections. You can change the granularity of the seek slider by getting the Slider from the XAML visual tree in your [**MediaOpened**](/uwp/api/windows.media.playback.mediaplayer.mediaopened) event handler on [**MediaPlayerElement.MediaPlayer**](/uwp/api/windows.ui.xaml.controls.mediaplayerelement). This example shows how to use [**VisualTreeHelper**](/uwp/api/Windows.UI.Xaml.Media.VisualTreeHelper) to get a reference to the Slider, then change the default step frequency of the slider from 1% to 0.1% (1000 steps) if the media is longer than 120 minutes. The MediaPlayerElement is named `MediaPlayerElement1`.
+The default seek slider is divided into 100 parts, so the seek behavior is limited to that many sections. You can change the granularity of the seek slider by getting the Slider from the XAML visual tree in your [**MediaOpened**](/uwp/api/windows.media.playback.mediaplayer.mediaopened) event handler on [**MediaPlayerElement.MediaPlayer**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.mediaplayerelement). This example shows how to use [**VisualTreeHelper**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.media.VisualTreeHelper) to get a reference to the Slider, then change the default step frequency of the slider from 1% to 0.1% (1000 steps) if the media is longer than 120 minutes. The MediaPlayerElement is named `MediaPlayerElement1`.
 
 ```csharp
 protected override void OnNavigatedTo(NavigationEventArgs e)

--- a/hub/apps/develop/ui/controls/date-and-time.md
+++ b/hub/apps/develop/ui/controls/date-and-time.md
@@ -186,9 +186,7 @@ A related concept is the Calendar class, which influences how dates are interpre
 
 ## Get the sample code
 
-- [WinUI 3 Gallery sample](https://github.com/Microsoft/WinUI-Gallery)
-- [Calendar sample](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/Calendar)
-- [Date and time formatting sample](https://github.com/microsoft/Windows-universal-samples/tree/master/Samples/DateTimeFormatting)
+- [WinUI 3 Gallery sample](https://github.com/Microsoft/WinUI-Gallery) - See CalendarViewPage, CalendarDatePickerPage, DatePickerPage, TimePickerPage
 
 ## Related topics
 

--- a/hub/apps/develop/ui/controls/inverted-lists.md
+++ b/hub/apps/develop/ui/controls/inverted-lists.md
@@ -50,4 +50,4 @@ This example shows how to align the list view’s items to the bottom and indica
 
 ## Get the sample code
 
-- [XAML Bottom-up list sample](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/XamlBottomUpList)
+- [WinUI Gallery - ListViewPage](https://github.com/microsoft/WinUI-Gallery/blob/main/WinUIGallery/Samples/ControlPages/ListViewPage.xaml.cs)

--- a/hub/apps/develop/ui/controls/item-containers-templates.md
+++ b/hub/apps/develop/ui/controls/item-containers-templates.md
@@ -96,8 +96,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Windows.UI;
-using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
 
 namespace ColorsListApp
 {

--- a/hub/apps/develop/ui/controls/item-templates-gridview.md
+++ b/hub/apps/develop/ui/controls/item-templates-gridview.md
@@ -13,7 +13,7 @@ This section contains item templates that you can use with a [**GridView**](/win
 To demonstrate data binding, these templates bind **GridViewItems** to the example Recording class from the [data binding overview](/windows/uwp/data-binding/data-binding-quickstart).
 
 > [!NOTE] 
-> Currently, when a **DataTemplate** contains multiple controls (for example, more than a single **TextBlock**), the default accessible name for screenreaders comes from .ToString() on the item. As a convenience you can instead set the [**AutomationProperties.Name**](/uwp/api/windows.ui.xaml.automation.automationproperties) on the root element of the **DataTemplate**. For more on accessibility, see [Accessibility overview](../../../design/accessibility/accessibility-overview.md).
+> Currently, when a **DataTemplate** contains multiple controls (for example, more than a single **TextBlock**), the default accessible name for screenreaders comes from .ToString() on the item. As a convenience you can instead set the [**AutomationProperties.Name**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.automation.automationproperties) on the root element of the **DataTemplate**. For more on accessibility, see [Accessibility overview](../../../design/accessibility/accessibility-overview.md).
 
 ## Icon and text
 Use these templates to display a collection of apps in a grid with an icon and text.
@@ -153,5 +153,5 @@ Use this template to display a media collection with text overlay.
 - [GridView class](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Controls.GridView)
 - [Data binding overview](/windows/uwp/data-binding/data-binding-quickstart)
 - [Accessibility overview](../../../design/accessibility/accessibility-overview.md)
-- [ListView and GridView sample](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/XamlListView)
+- [WinUI Gallery - GridViewPage](https://github.com/microsoft/WinUI-Gallery/blob/main/WinUIGallery/Samples/ControlPages/GridViewPage.xaml.cs)
 - [Thumbnail images](/windows/uwp/files/thumbnails)

--- a/hub/apps/develop/ui/controls/item-templates-listview.md
+++ b/hub/apps/develop/ui/controls/item-templates-listview.md
@@ -13,7 +13,7 @@ This section contains item templates that you can use with a [**ListView**](/win
 To demonstrate data binding, these templates bind **ListViewItems** to the example Recording class from the [data binding overview](/windows/uwp/data-binding/data-binding-quickstart).
 
 > [!NOTE] 
-> Currently, when a **DataTemplate** contains multiple controls (for example, more than a single **TextBlock**), the default accessible name for screenreaders comes from .ToString() on the item. As a convenience you can instead set the [**AutomationProperties.Name**](/uwp/api/windows.ui.xaml.automation.automationproperties) on the root element of the **DataTemplate**. For more on accessibility, see [Accessibility overview](../../../design/accessibility/accessibility-overview.md).
+> Currently, when a **DataTemplate** contains multiple controls (for example, more than a single **TextBlock**), the default accessible name for screenreaders comes from .ToString() on the item. As a convenience you can instead set the [**AutomationProperties.Name**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.automation.automationproperties) on the root element of the **DataTemplate**. For more on accessibility, see [Accessibility overview](../../../design/accessibility/accessibility-overview.md).
 
 ## Single line list item
 Use this template to display a list of items with an image and a single line of text.
@@ -126,5 +126,5 @@ Use this template to display a list of items with text in defined columns.
 - [ListView class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.listview)
 - [Data binding overview](/windows/uwp/data-binding/data-binding-quickstart)
 - [Accessibility overview](../../../design/accessibility/accessibility-overview.md)
-- [ListView and GridView sample](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/XamlListView)
+- [WinUI Gallery - ListViewPage](https://github.com/microsoft/WinUI-Gallery/blob/main/WinUIGallery/Samples/ControlPages/ListViewPage.xaml.cs)
 - [Thumbnail images](/windows/uwp/files/thumbnails)

--- a/hub/apps/develop/ui/controls/items-repeater.md
+++ b/hub/apps/develop/ui/controls/items-repeater.md
@@ -56,7 +56,7 @@ ItemsRepeater itemsRepeater1 = new ItemsRepeater();
 itemsRepeater1.ItemsSource = Items;
 ```
 
-You can also bind the **ItemsSource** property to a collection in XAML. For more info about data binding, see [Data binding overview](/windows/uwp/data-binding/data-binding-quickstart).
+You can also bind the **ItemsSource** property to a collection in XAML. For more info about data binding, see [Data binding overview](/windows/apps/develop/data-binding/data-binding-overview).
 
 ```xaml
 <ItemsRepeater ItemsSource="{x:Bind Items}"/>
@@ -209,14 +209,14 @@ private async void ScrollViewer_ViewChanged(object sender, ScrollViewerViewChang
 
         // trigger if within 2 viewports of the end
         if (distanceToEnd <= 2.0 * scroller.ViewportHeight
-                && MyItemsSource.HasMore && !itemsSource.Busy)
+                && MyItemsSource.HasMore && !MyItemsSource.Busy)
         {
             // show an indeterminate progress UI
             myLoadingIndicator.Visibility = Visibility.Visible;
 
             await MyItemsSource.LoadMoreItemsAsync(/*DataFetchSize*/);
 
-            loadingIndicator.Visibility = Visibility.Collapsed;
+            myLoadingIndicator.Visibility = Visibility.Collapsed;
         }
     }
 }
@@ -237,12 +237,11 @@ You can set the [Spacing](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.c
 This example shows how to set the ItemsRepeater.Layout property to a StackLayout with horizontal orientation and spacing of 8 pixels.
 
 ```xaml
-<!-- xmlns:muxc="using:Microsoft.UI.Xaml.Controls" -->
-<muxc:ItemsRepeater ItemsSource="{x:Bind Items}" ItemTemplate="{StaticResource MyTemplate}">
-    <muxc:ItemsRepeater.Layout>
-        <muxc:StackLayout Orientation="Horizontal" Spacing="8"/>
-    </muxc:ItemsRepeater.Layout>
-</muxc:ItemsRepeater>
+<ItemsRepeater ItemsSource="{x:Bind Items}" ItemTemplate="{StaticResource MyTemplate}">
+    <ItemsRepeater.Layout>
+        <StackLayout Orientation="Horizontal" Spacing="8"/>
+    </ItemsRepeater.Layout>
+</ItemsRepeater>
 ```
 
 ### UniformGridLayout
@@ -295,15 +294,14 @@ This image shows the effect of the **ItemsStretch** values in a vertical layout 
 This example shows how to set the **ItemsRepeater.Layout** property to a **UniformGridLayout**.
 
 ```xaml
-<!-- xmlns:muxc="using:Microsoft.UI.Xaml.Controls" -->
-<muxc:ItemsRepeater ItemsSource="{x:Bind Items}"
+<ItemsRepeater ItemsSource="{x:Bind Items}"
                     ItemTemplate="{StaticResource MyTemplate}">
-    <muxc:ItemsRepeater.Layout>
-        <muxc:UniformGridLayout MinItemWidth="200"
+    <ItemsRepeater.Layout>
+        <UniformGridLayout MinItemWidth="200"
                                 MinColumnSpacing="28"
                                 ItemsJustification="SpaceAround"/>
-    </muxc:ItemsRepeater.Layout>
-</muxc:ItemsRepeater>
+    </ItemsRepeater.Layout>
+</ItemsRepeater>
 ```
 
 ## Lifecycle events
@@ -322,16 +320,15 @@ In a virtualizing control, you cannot rely on Loaded/Unloaded events because the
 This example shows how you could use these events to attach a custom selection service to track item selection in a custom control that uses ItemsRepeater to display items.
 
 ```xaml
-<!-- xmlns:muxc="using:Microsoft.UI.Xaml.Controls" -->
 <UserControl ...>
     ...
     <ScrollViewer>
-        <muxc:ItemsRepeater ItemsSource="{x:Bind Items}"
+        <ItemsRepeater ItemsSource="{x:Bind Items}"
                             ItemTemplate="{StaticResource MyTemplate}"
                             ElementPrepared="OnElementPrepared"
                             ElementIndexChanged="OnElementIndexChanged"
                             ElementClearing="OnElementClearing">
-        </muxc:ItemsRepeater>
+        </ItemsRepeater>
     </ScrollViewer>
     ...
 </UserControl>
@@ -537,7 +534,6 @@ You can use the [ItemsRepeater](/windows/windows-app-sdk/api/winrt/microsoft.ui.
 This example shows how to place an [ItemsRepeater](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.itemsrepeater) in the template of a custom control named _MediaCollectionView_ and expose its properties.
 
 ```xaml
-<!-- xmlns:muxc="using:Microsoft.UI.Xaml.Controls" -->
 <Style TargetType="local:MediaCollectionView">
     <Setter Property="Template">
         <Setter.Value>
@@ -547,7 +543,7 @@ This example shows how to place an [ItemsRepeater](/windows/windows-app-sdk/api/
                     BorderBrush="{TemplateBinding BorderBrush}"
                     BorderThickness="{TemplateBinding BorderThickness}">
                     <ScrollViewer x:Name="ScrollViewer">
-                        <muxc:ItemsRepeater x:Name="ItemsRepeater"
+                        <ItemsRepeater x:Name="ItemsRepeater"
                                             ItemsSource="{TemplateBinding ItemsSource}"
                                             ItemTemplate="{TemplateBinding ItemTemplate}"
                                             Layout="{TemplateBinding Layout}"
@@ -607,32 +603,31 @@ You can nest an [ItemsRepeater](/windows/windows-app-sdk/api/winrt/microsoft.ui.
 This example shows how you can display a list of grouped items in a vertical stack. The outer ItemsRepeater generates each group. In the template for each group, another ItemsRepeater generates the items.
 
 ```xaml
-<!-- xmlns:muxc="using:Microsoft.UI.Xaml.Controls" -->
 
 <Page.Resources>
-    <muxc:StackLayout x:Key="MyGroupLayout"/>
-    <muxc:StackLayout x:Key="MyItemLayout" Orientation="Horizontal"/>
+    <StackLayout x:Key="MyGroupLayout"/>
+    <StackLayout x:Key="MyItemLayout" Orientation="Horizontal"/>
 </Page.Resources>
 
 <ScrollViewer>
-  <muxc:ItemsRepeater ItemsSource="{x:Bind AppNotifications}"
+  <ItemsRepeater ItemsSource="{x:Bind AppNotifications}"
                       Layout="{StaticResource MyGroupLayout}">
-    <muxc:ItemsRepeater.ItemTemplate>
+    <ItemsRepeater.ItemTemplate>
       <DataTemplate x:DataType="ExampleApp:AppNotifications">
         <!-- Group -->
         <StackPanel>
           <!-- Header -->
           <TextBlock Text="{x:Bind AppTitle}"/>
           <!-- Items -->
-          <muxc:ItemsRepeater ItemsSource="{x:Bind Notifications}"
+          <ItemsRepeater ItemsSource="{x:Bind Notifications}"
                               Layout="{StaticResource MyItemLayout}"
                               ItemTemplate="{StaticResource MyTemplate}"/>
           <!-- Footer -->
           <Button Content="{x:Bind FooterText}"/>
         </StackPanel>
       </DataTemplate>
-    </muxc:ItemsRepeater.ItemTemplate>
-  </muxc:ItemsRepeater>
+    </ItemsRepeater.ItemTemplate>
+  </ItemsRepeater>
 </ScrollViewer>
 ```
 The image below shows the basic layout that's created using the above sample as a guideline.
@@ -642,22 +637,19 @@ The image below shows the basic layout that's created using the above sample as 
 This next example shows a layout for an app that has various categories that can change with user preference and are presented as horizontally scrolling lists. The layout of this example is also represented by the image above.
 
 ```xaml
-<!-- xmlns:muxc="using:Microsoft.UI.Xaml.Controls" -->
-<!-- Include the <muxc:ItemsRepeaterScrollHost> if targeting Windows 10 versions earlier than 1809. -->
 <ScrollViewer>
-  <muxc:ItemsRepeater ItemsSource="{x:Bind Categories}"
+  <ItemsRepeater ItemsSource="{x:Bind Categories}"
                       Background="LightGreen">
-    <muxc:ItemsRepeater.ItemTemplate>
+    <ItemsRepeater.ItemTemplate>
       <DataTemplate x:DataType="local:Category">
         <StackPanel Margin="12,0">
           <TextBlock Text="{x:Bind Name}" Style="{ThemeResource TitleTextBlockStyle}"/>
-          <!-- Include the <muxc:ItemsRepeaterScrollHost> if targeting Windows 10 versions earlier than 1809. -->
           <ScrollViewer HorizontalScrollMode="Enabled"
                                           VerticalScrollMode="Disabled"
                                           HorizontalScrollBarVisibility="Auto" >
-            <muxc:ItemsRepeater ItemsSource="{x:Bind Items}"
+            <ItemsRepeater ItemsSource="{x:Bind Items}"
                                 Background="Orange">
-              <muxc:ItemsRepeater.ItemTemplate>
+              <ItemsRepeater.ItemTemplate>
                 <DataTemplate x:DataType="local:CategoryItem">
                   <Grid Margin="10"
                         Height="60" Width="120"
@@ -667,16 +659,16 @@ This next example shows a layout for an app that has various categories that can
                                Margin="4"/>
                   </Grid>
                 </DataTemplate>
-              </muxc:ItemsRepeater.ItemTemplate>
-              <muxc:ItemsRepeater.Layout>
-                <muxc:StackLayout Orientation="Horizontal"/>
-              </muxc:ItemsRepeater.Layout>
-            </muxc:ItemsRepeater>
+              </ItemsRepeater.ItemTemplate>
+              <ItemsRepeater.Layout>
+                <StackLayout Orientation="Horizontal"/>
+              </ItemsRepeater.Layout>
+            </ItemsRepeater>
           </ScrollViewer>
         </StackPanel>
       </DataTemplate>
-    </muxc:ItemsRepeater.ItemTemplate>
-  </muxc:ItemsRepeater>
+    </ItemsRepeater.ItemTemplate>
+  </ItemsRepeater>
 </ScrollViewer>
 ```
 
@@ -741,7 +733,7 @@ public class MyPage : Page
 ### Keyboarding
 The minimal keyboarding support for focus movement that ItemsRepeater provides is based on XAML's [2D Directional Navigation for Keyboarding](../../../design/input/focus-navigation.md#2d-directional-navigation-for-keyboard).
 
-![Direction Navigation](/windows/uwp/design/input/images/keyboard/directional-navigation.png)
+![Direction Navigation](../../input/images/keyboard/directional-navigation.png)
 
 The ItemsRepeater's [XYFocusKeyboardNavigation mode](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.input.xyfocuskeyboardnavigationmode) is _Enabled_ by default. Depending on the intended experience, consider adding support for common [Keyboard Interactions](../../../design/input/keyboard-interactions.md) such as Home, End, PageUp, and PageDown.
 

--- a/hub/apps/develop/ui/controls/list-details.md
+++ b/hub/apps/develop/ui/controls/list-details.md
@@ -87,8 +87,7 @@ To create an adaptive layout, define different [**VisualStates**](/windows/windo
 ## Get the sample code
 
 The following samples implement the list/details pattern with adaptive layouts and demonstrate data binding to static, database, and online resources: 
-- [Master/detail sample](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/XamlMasterDetail) 
-- [ListView and GridView sample](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/XamlListView)
+- [WinUI Gallery - ListDetailsViewPage](https://github.com/microsoft/WinUI-Gallery/blob/main/WinUIGallery/Samples/ControlPages/ListDetailsViewPage.xaml.cs)
 - [Customer orders database sample](https://github.com/Microsoft/Windows-appsample-customers-orders-database)
 - [RSS Reader sample](https://github.com/Microsoft/Windows-appsample-rssreader)
 

--- a/hub/apps/develop/ui/controls/navigationview.md
+++ b/hub/apps/develop/ui/controls/navigationview.md
@@ -403,7 +403,7 @@ You can hide or disable the back button by setting these properties:
 
 This example shows how you can use NavigationView with both a top navigation pane on large window sizes and a left navigation pane on small window sizes. It can be adapted to left-only navigation by removing the *top* navigation settings in the VisualStateManager.
 
-The example demonstrates a common way to set up navigation data that will work for many scenarios. In this example, you first store (in the tag of the [NavigationViewItem](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewitem)) the full type name of the page to which you want to navigate. In the event handler, you unbox that value, turn it into a [Type]()(C#) or  [**Windows::UI::Xaml::Interop::TypeName**](/uwp/api/windows.ui.xaml.interop.typename)(C++/WinRT) object, and use that to navigate to the destination page. This lets you create unit tests to confirm that the values inside your tags are of a valid type. (Also see [Boxing and unboxing values to IInspectable with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/boxing)). It also demonstrates how to implement backwards navigation with NavigationView's back button.
+The example demonstrates a common way to set up navigation data that will work for many scenarios. In this example, you first store (in the tag of the [NavigationViewItem](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewitem)) the full type name of the page to which you want to navigate. In the event handler, you unbox that value, turn it into a [Type]()(C#) or  [**Microsoft::UI::Xaml::Interop::TypeName**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.interop.typename)(C++/WinRT) object, and use that to navigate to the destination page. This lets you create unit tests to confirm that the values inside your tags are of a valid type. (Also see [Boxing and unboxing values to IInspectable with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/boxing)). It also demonstrates how to implement backwards navigation with NavigationView's back button.
 
 This code assumes that your app contains pages with the following names to navigate to: *HomePage*, *AppsPage*, *GamesPage*, *MusicPage*, *MyContentPage*, and *SettingsPage*. Code for these pages is not shown.
 
@@ -597,7 +597,7 @@ runtimeclass MainPage : Microsoft.UI.Xaml.Controls.Page
 
 // pch.h
 ...
-#include <winrt/Windows.UI.Xaml.Interop.h>
+#include <winrt/Microsoft.UI.Xaml.Interop.h>
 #include <winrt/Microsoft.UI.Xaml.Media.Animation.h>
 
 
@@ -1068,7 +1068,7 @@ import "Category.idl";
 namespace HierarchicalNavigationViewDataBinding
 {
     [default_interface]
-    runtimeclass MainPage : Windows.UI.Xaml.Controls.Page
+    runtimeclass MainPage : Microsoft.UI.Xaml.Controls.Page
     {
         MainPage();
         Windows.Foundation.Collections.IObservableVector<Category> Categories{ get; };

--- a/hub/apps/develop/ui/controls/person-picture.md
+++ b/hub/apps/develop/ui/controls/person-picture.md
@@ -80,13 +80,13 @@ using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Data;
-using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml.Navigation;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
 using Windows.ApplicationModel.Contacts;
 
 namespace SampleApp
@@ -157,4 +157,4 @@ If there isn't an image, the control displays the contact's name or initials; if
 ## Related articles
 
 * [Contacts and calendar](/windows/uwp/contacts-and-calendar/index)
-* [Contact cards sample](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/ContactCards)
+* [PersonPicturePage (WinUI Gallery)](https://github.com/microsoft/WinUI-Gallery/blob/main/WinUIGallery/Samples/ControlPages/PersonPicturePage.xaml.cs)

--- a/hub/apps/develop/ui/controls/radio-button.md
+++ b/hub/apps/develop/ui/controls/radio-button.md
@@ -235,7 +235,7 @@ The following table describes how Narrator handles a `RadioButtons` group and wh
 |Focus moves to an unselected item<br> *(If navigating with Ctrl-arrow keys or Xbox gamepad,<br>which indicates selection is not following focus.)* | "_name_, RadioButton, non-selected, _x_ of _N_"  |
 
 > [!NOTE]
-> The _**name**_ that Narrator announces for each item is the value of the [AutomationProperties.Name](/uwp/api/windows.ui.xaml.automation.automationproperties.nameproperty) attached property if it is available for the item; otherwise, it is the value returned by the item's [ToString](/dotnet/api/system.object.tostring?view=dotnet-uwp-10.0&preserve-view=true) method.
+> The _**name**_ that Narrator announces for each item is the value of the [AutomationProperties.Name](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.automation.automationproperties.nameproperty) attached property if it is available for the item; otherwise, it is the value returned by the item's [ToString](/dotnet/api/system.object.tostring?view=dotnet-uwp-10.0&preserve-view=true) method.
 >
 > _**x**_ is the number of the current item. _**N**_ is the total number of items in the group.
 

--- a/hub/apps/develop/ui/controls/text-controls.md
+++ b/hub/apps/develop/ui/controls/text-controls.md
@@ -178,5 +178,5 @@ For TextBox and RichEditBox controls, spell checking is turned on by default. Yo
 
 **For developers (XAML)**
 - [TextBox class](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Controls.TextBox)
-- [Windows.UI.Xaml.Controls PasswordBox class](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Controls.PasswordBox)
+- [Microsoft.UI.Xaml.Controls.PasswordBox class](/windows/windows-app-sdk/api/winrt/microsoft.UI.Xaml.Controls.PasswordBox)
 - [String.Length property](/dotnet/api/system.string.length)

--- a/hub/apps/develop/ui/controls/tree-view.md
+++ b/hub/apps/develop/ui/controls/tree-view.md
@@ -546,8 +546,8 @@ This example shows how to create a simple tree view structure in XAML. The tree 
 ```
 
 ```csharp
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 using muxc = Microsoft.UI.Xaml.Controls;
 
 namespace TreeViewTest
@@ -664,8 +664,8 @@ This example shows how to create the same tree view as the previous example. How
 
 ```csharp
 using System.Collections.ObjectModel;
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 using muxc = Microsoft.UI.Xaml.Controls;
 
 namespace TreeViewTest
@@ -897,8 +897,8 @@ A custom item template is used to display the data items, which are of type [ISt
 using System;
 using System.Collections.Generic;
 using Windows.Storage;
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 using muxc = Microsoft.UI.Xaml.Controls;
 
 namespace TreeViewTest
@@ -1227,8 +1227,8 @@ The following example demonstrates how to create two tree views whose items can 
 ```csharp
 using System;
 using Windows.ApplicationModel.DataTransfer;
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 
 namespace TreeViewTest
 {


### PR DESCRIPTION
- Update code namespaces: Windows.UI.Xaml -> Microsoft.UI.Xaml
- Update API links: /uwp/api/ -> /windows/windows-app-sdk/api/winrt/
- Replace dead UWP sample zip links with WinUI Gallery references
- Update C++/WinRT includes and IDL base classes

Files updated: 15 files in hub/apps/develop/ui/controls/