### PR TITLE
Migrate notifications docs from UWP to WinUI 3

### DIFF
--- a/hub/apps/develop/notifications/badges.md
+++ b/hub/apps/develop/notifications/badges.md
@@ -115,7 +115,7 @@ private void clearBadge()
 
 ## Get the sample code
 
-* [Notifications sample](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/Notifications)<br/> Shows how to create live tiles, send badge updates, and display toast notifications. 
+* [Windows App SDK notifications sample](https://github.com/microsoft/WindowsAppSDK-Samples/tree/main/Samples/Notifications)<br/> Shows how to send app notifications and badge updates. 
 
 ## Related articles
 

--- a/hub/apps/develop/notifications/choosing-a-notification-delivery-method.md
+++ b/hub/apps/develop/notifications/choosing-a-notification-delivery-method.md
@@ -106,7 +106,7 @@ For more information, see these topics:
 
 -   [Send a local tile notification](/windows/uwp/launch-resume/sending-a-local-tile-notification)
 -   [Send a local app notification](app-notifications/app-notifications-quickstart.md)
--   [Windows app notifications code samples](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/Notifications)
+-   [Windows App SDK notifications sample](https://github.com/microsoft/WindowsAppSDK-Samples/tree/main/Samples/Notifications)
 
 ## Scheduled notifications
 
@@ -120,7 +120,7 @@ By default, scheduled notifications expire three days from the time they are del
 For more information, see these topics:
 
 -   [Schedule an app notification](app-notifications/app-notifications-scheduled.md)
--   [Windows app notifications code samples](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/Notifications)
+-   [Windows App SDK notifications sample](https://github.com/microsoft/WindowsAppSDK-Samples/tree/main/Samples/Notifications)
 
 ## Periodic notifications
 
@@ -134,7 +134,7 @@ By default, periodic notifications expire three days from the time polling occur
 For more information, see these topics:
 
 -   [Periodic notification overview](periodic-notification-overview.md)
--   [Windows app notifications code samples](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/Notifications)
+-   [Windows App SDK notifications sample](https://github.com/microsoft/WindowsAppSDK-Samples/tree/main/Samples/Notifications)
 
 ## Push notifications
 
@@ -149,7 +149,7 @@ For more information, see:
 
 -   [Windows Push Notification Services (WNS) overview](push-notifications/wns-overview.md)
 -   [Guidelines for push notifications](push-notifications/index.md)
--   [Windows app notifications code samples](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/Notifications)
+-   [Windows App SDK notifications sample](https://github.com/microsoft/WindowsAppSDK-Samples/tree/main/Samples/Notifications)
 
 
 ## Related topics
@@ -161,7 +161,7 @@ For more information, see:
 * [Guidelines for toast notifications](app-notifications/index.md)
 * [Periodic notification overview](periodic-notification-overview.md)
 * [Windows Push Notification Services (WNS) overview](push-notifications/wns-overview.md)
-* [Windows app notifications code samples on GitHub](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/Notifications)
+* [Windows App SDK notifications sample](https://github.com/microsoft/WindowsAppSDK-Samples/tree/main/Samples/Notifications)
  
 
  

--- a/hub/apps/develop/notifications/push-notifications/wns-overview.md
+++ b/hub/apps/develop/notifications/push-notifications/wns-overview.md
@@ -168,9 +168,9 @@ Here's an example of how to check whether battery saver is turned on in WindowsÂ
 
 ```csharp
 using System;
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Navigation;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Navigation;
 using Windows.System;
 using Windows.System.Power;
 ...
@@ -216,16 +216,16 @@ async public void CheckForEnergySaving()
 #include <winrt/Windows.Storage.h>
 #include <winrt/Windows.System.h>
 #include <winrt/Windows.System.Power.h>
-#include <winrt/Windows.UI.Xaml.h>
-#include <winrt/Windows.UI.Xaml.Controls.h>
-#include <winrt/Windows.UI.Xaml.Navigation.h>
+#include <winrt/Microsoft.UI.Xaml.h>
+#include <winrt/Microsoft.UI.Xaml.Controls.h>
+#include <winrt/Microsoft.UI.Xaml.Navigation.h>
 using namespace winrt;
 using namespace winrt::Windows::Foundation;
 using namespace winrt::Windows::Storage;
 using namespace winrt::Windows::System;
 using namespace winrt::Windows::System::Power;
-using namespace winrt::Windows::UI::Xaml;
-using namespace winrt::Windows::UI::Xaml::Controls;
+using namespace winrt::Microsoft::UI::Xaml;
+using namespace winrt::Microsoft::UI::Xaml::Controls;
 using namespace winrt::Windows::UI::Xaml::Navigation;
 ...
 winrt::fire_and_forget CheckForEnergySaving()
@@ -267,7 +267,7 @@ winrt::fire_and_forget CheckForEnergySaving()
 }
 ```
 
-This is the XAML for the [**ContentDialog**](/uwp/api/Windows.UI.Xaml.Controls.ContentDialog) featured in this example.
+This is the XAML for the [**ContentDialog**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.contentdialog) featured in this example.
 
 ```xaml
 <ContentDialog x:Name="saveEnergyDialog"


### PR DESCRIPTION
- Update XAML namespaces: Windows.UI.Xaml -> Microsoft.UI.Xaml (C# and C++)
- Update XAML API links: /uwp/api/Windows.UI.Xaml -> /windows/windows-app-sdk/api/winrt/microsoft.ui.xaml
- Replace UWP sample links with Windows App SDK notifications sample

Files updated:
- wns-overview.md (XAML code samples)
- choosing-a-notification-delivery-method.md (5 sample links)
- badges.md (1 sample link)

Note: Windows.UI.Notifications APIs are Windows SDK (not XAML) and remain as /uwp/api/