### PR TITLE
Fix/platform xaml winui3 migration

### DIFF
--- a/hub/apps/develop/platform/xaml/events-and-routed-events-overview.md
+++ b/hub/apps/develop/platform/xaml/events-and-routed-events-overview.md
@@ -59,15 +59,15 @@ End Sub
 ```
 
 ```cppwinrt
-void winrt::MyNamespace::implementation::BlankPage::ShowUpdatesButton_Click(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e)
+void winrt::MyNamespace::implementation::BlankPage::ShowUpdatesButton_Click(Windows::Foundation::IInspectable const& sender, Microsoft::UI::Xaml::RoutedEventArgs const& e)
 {
-    auto b{ sender.as<Windows::UI::Xaml::Controls::Button>() };
+    auto b{ sender.as<Microsoft::UI::Xaml::Controls::Button>() };
     // More logic to do here.
 }
 ```
 
 ```cpp
-void MyNamespace::BlankPage::ShowUpdatesButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e) 
+void MyNamespace::BlankPage::ShowUpdatesButton_Click(Platform::Object^ sender, Microsoft::UI::Xaml::RoutedEventArgs^ e) 
 {
     Button^ b = (Button^) sender;
     //more logic to do here...
@@ -130,7 +130,7 @@ void LayoutRoot_Loaded(object sender, RoutedEventArgs e)
 void LayoutRoot_Loaded(object sender, RoutedEventArgs e)
 {
     textBlock1.PointerEntered += new PointerEventHandler(textBlock1_PointerEntered);
-    textBlock1.PointerExited += new MouseEventHandler(textBlock1_PointerExited);
+    textBlock1.PointerExited += new PointerEventHandler(textBlock1_PointerExited);
 }
 ```
 
@@ -228,7 +228,6 @@ The Windows Runtime supports the concept of a routed event for a set of events t
 - [**PointerWheelChanged**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.uielement.pointerwheelchanged)
 - [**PreviewKeyDown**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.uielement.previewkeydown)
 - [**PreviewKeyUp**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.uielement.previewkeyup)
-- [**PointerWheelChanged**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.uielement.pointerwheelchanged)
 - [**RightTapped**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.uielement.righttapped)
 - [**Tapped**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.uielement.tapped)
 
@@ -280,7 +279,7 @@ Determining whether and where in UI an element is visible to mouse, touch, and s
 - If the element is a control, its [**IsEnabled**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.control.isenabled) property value must be **true**.
 - The element must have actual dimensions in layout. An element where either [**ActualHeight**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.frameworkelement.actualheight) and [**ActualWidth**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.frameworkelement.actualwidth) are 0 won't fire input events.
 
-Some controls have special rules for hit testing. For example, [**TextBlock**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.Controls.TextBlock) has no **Background** property, but is still hit testable within the entire region of its dimensions. [**Image**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.Controls.Image) and [**MediaElement**](/uwp/api/windows.ui.xaml.controls.mediaelement) controls are hit testable over their defined rectangle dimensions, regardless of transparent content such as alpha channel in the media source file being displayed. [**WebView**](/uwp/api/windows.ui.xaml.controls.webview) controls have special hit testing behavior because the input can be handled by the hosted HTML and fire script events.
+Some controls have special rules for hit testing. For example, [**TextBlock**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.Controls.TextBlock) has no **Background** property, but is still hit testable within the entire region of its dimensions. [**Image**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.Controls.Image) and [**MediaPlayerElement**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.mediaplayerelement) controls are hit testable over their defined rectangle dimensions, regardless of transparent content such as alpha channel in the media source file being displayed. [**WebView2**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.webview2) controls have special hit testing behavior because the input can be handled by the hosted HTML and fire script events.
 
 Most [**Panel**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.Controls.Panel) classes and [**Border**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.Controls.Border) are not hit-testable in their own background, but can still handle the user input events that are routed from the elements that they contain.
 

--- a/hub/apps/develop/platform/xaml/xaml-resource-dictionary.md
+++ b/hub/apps/develop/platform/xaml/xaml-resource-dictionary.md
@@ -142,7 +142,7 @@ This example shows how to retrieve the `redButtonStyle` resource out of a page's
     MainPage::MainPage()
     {
         InitializeComponent();
-        Windows::UI::Xaml::Style style = Resources().TryLookup(winrt::box_value(L"redButtonStyle")).as<Windows::UI::Xaml::Style>();
+        Microsoft::UI::Xaml::Style style = Resources().TryLookup(winrt::box_value(L"redButtonStyle")).as<Microsoft::UI::Xaml::Style>();
     }
 ```
 
@@ -178,9 +178,9 @@ To look up app-wide resources from code, use **Application.Current.Resources** t
     MainPage::MainPage()
     {
         InitializeComponent();
-        Windows::UI::Xaml::Style style = Application::Current().Resources()
-                                                               .TryLookup(winrt::box_value(L"appButtonStyle"))
-                                                               .as<Windows::UI::Xaml::Style>();
+        Microsoft::UI::Xaml::Style style = Application::Current().Resources()
+                                                                 .TryLookup(winrt::box_value(L"appButtonStyle"))
+                                                                 .as<Microsoft::UI::Xaml::Style>();
     }
 ```
 
@@ -200,14 +200,16 @@ sealed partial class App : Application
 {
     protected override void OnLaunched(LaunchActivatedEventArgs e)
     {
-        Frame rootFrame = Window.Current.Content as Frame;
-        if (rootFrame == null)
+        // In WinUI 3, use m_window (a field you create) instead of Window.Current
+        if (m_window.Content is not Frame rootFrame)
         {
-            SolidColorBrush brush = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 0, 255, 0)); // green
+            SolidColorBrush brush = new SolidColorBrush(Microsoft.UI.Colors.Green);
             this.Resources["brush"] = brush;
             // … Other code that VS generates for you …
         }
     }
+
+    private Window m_window;
 }
 ```
 
@@ -217,7 +219,8 @@ sealed partial class App : Application
 void App::OnLaunched(LaunchActivatedEventArgs const& e)
 {
     Frame rootFrame{ nullptr };
-    auto content = Window::Current().Content();
+    // In WinUI 3, use m_window (a member variable you create) instead of Window::Current()
+    auto content = m_window.Content();
     if (content)
     {
         rootFrame = content.try_as<Frame>();
@@ -227,7 +230,7 @@ void App::OnLaunched(LaunchActivatedEventArgs const& e)
     // just ensure that the window is active
     if (rootFrame == nullptr)
     {
-        Windows::UI::Xaml::Media::SolidColorBrush brush{ Windows::UI::ColorHelper::FromArgb(255, 0, 255, 0) };
+        Microsoft::UI::Xaml::Media::SolidColorBrush brush{ Microsoft::UI::Colors::Green() };
         Resources().Insert(winrt::box_value(L"brush"), winrt::box_value(brush));
         // … Other code that VS generates for you …
 ```

--- a/hub/apps/develop/ui/controls/items-repeater.md
+++ b/hub/apps/develop/ui/controls/items-repeater.md
@@ -56,7 +56,7 @@ ItemsRepeater itemsRepeater1 = new ItemsRepeater();
 itemsRepeater1.ItemsSource = Items;
 ```
 
-You can also bind the **ItemsSource** property to a collection in XAML. For more info about data binding, see [Data binding overview](/windows/uwp/data-binding/data-binding-quickstart).
+You can also bind the **ItemsSource** property to a collection in XAML. For more info about data binding, see [Data binding overview](/windows/apps/develop/data-binding/data-binding-overview).
 
 ```xaml
 <ItemsRepeater ItemsSource="{x:Bind Items}"/>
@@ -209,14 +209,14 @@ private async void ScrollViewer_ViewChanged(object sender, ScrollViewerViewChang
 
         // trigger if within 2 viewports of the end
         if (distanceToEnd <= 2.0 * scroller.ViewportHeight
-                && MyItemsSource.HasMore && !itemsSource.Busy)
+                && MyItemsSource.HasMore && !MyItemsSource.Busy)
         {
             // show an indeterminate progress UI
             myLoadingIndicator.Visibility = Visibility.Visible;
 
             await MyItemsSource.LoadMoreItemsAsync(/*DataFetchSize*/);
 
-            loadingIndicator.Visibility = Visibility.Collapsed;
+            myLoadingIndicator.Visibility = Visibility.Collapsed;
         }
     }
 }
@@ -237,12 +237,11 @@ You can set the [Spacing](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.c
 This example shows how to set the ItemsRepeater.Layout property to a StackLayout with horizontal orientation and spacing of 8 pixels.
 
 ```xaml
-<!-- xmlns:muxc="using:Microsoft.UI.Xaml.Controls" -->
-<muxc:ItemsRepeater ItemsSource="{x:Bind Items}" ItemTemplate="{StaticResource MyTemplate}">
-    <muxc:ItemsRepeater.Layout>
-        <muxc:StackLayout Orientation="Horizontal" Spacing="8"/>
-    </muxc:ItemsRepeater.Layout>
-</muxc:ItemsRepeater>
+<ItemsRepeater ItemsSource="{x:Bind Items}" ItemTemplate="{StaticResource MyTemplate}">
+    <ItemsRepeater.Layout>
+        <StackLayout Orientation="Horizontal" Spacing="8"/>
+    </ItemsRepeater.Layout>
+</ItemsRepeater>
 ```
 
 ### UniformGridLayout
@@ -295,15 +294,14 @@ This image shows the effect of the **ItemsStretch** values in a vertical layout 
 This example shows how to set the **ItemsRepeater.Layout** property to a **UniformGridLayout**.
 
 ```xaml
-<!-- xmlns:muxc="using:Microsoft.UI.Xaml.Controls" -->
-<muxc:ItemsRepeater ItemsSource="{x:Bind Items}"
+<ItemsRepeater ItemsSource="{x:Bind Items}"
                     ItemTemplate="{StaticResource MyTemplate}">
-    <muxc:ItemsRepeater.Layout>
-        <muxc:UniformGridLayout MinItemWidth="200"
+    <ItemsRepeater.Layout>
+        <UniformGridLayout MinItemWidth="200"
                                 MinColumnSpacing="28"
                                 ItemsJustification="SpaceAround"/>
-    </muxc:ItemsRepeater.Layout>
-</muxc:ItemsRepeater>
+    </ItemsRepeater.Layout>
+</ItemsRepeater>
 ```
 
 ## Lifecycle events
@@ -322,16 +320,15 @@ In a virtualizing control, you cannot rely on Loaded/Unloaded events because the
 This example shows how you could use these events to attach a custom selection service to track item selection in a custom control that uses ItemsRepeater to display items.
 
 ```xaml
-<!-- xmlns:muxc="using:Microsoft.UI.Xaml.Controls" -->
 <UserControl ...>
     ...
     <ScrollViewer>
-        <muxc:ItemsRepeater ItemsSource="{x:Bind Items}"
+        <ItemsRepeater ItemsSource="{x:Bind Items}"
                             ItemTemplate="{StaticResource MyTemplate}"
                             ElementPrepared="OnElementPrepared"
                             ElementIndexChanged="OnElementIndexChanged"
                             ElementClearing="OnElementClearing">
-        </muxc:ItemsRepeater>
+        </ItemsRepeater>
     </ScrollViewer>
     ...
 </UserControl>
@@ -537,7 +534,6 @@ You can use the [ItemsRepeater](/windows/windows-app-sdk/api/winrt/microsoft.ui.
 This example shows how to place an [ItemsRepeater](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.itemsrepeater) in the template of a custom control named _MediaCollectionView_ and expose its properties.
 
 ```xaml
-<!-- xmlns:muxc="using:Microsoft.UI.Xaml.Controls" -->
 <Style TargetType="local:MediaCollectionView">
     <Setter Property="Template">
         <Setter.Value>
@@ -547,7 +543,7 @@ This example shows how to place an [ItemsRepeater](/windows/windows-app-sdk/api/
                     BorderBrush="{TemplateBinding BorderBrush}"
                     BorderThickness="{TemplateBinding BorderThickness}">
                     <ScrollViewer x:Name="ScrollViewer">
-                        <muxc:ItemsRepeater x:Name="ItemsRepeater"
+                        <ItemsRepeater x:Name="ItemsRepeater"
                                             ItemsSource="{TemplateBinding ItemsSource}"
                                             ItemTemplate="{TemplateBinding ItemTemplate}"
                                             Layout="{TemplateBinding Layout}"
@@ -607,32 +603,31 @@ You can nest an [ItemsRepeater](/windows/windows-app-sdk/api/winrt/microsoft.ui.
 This example shows how you can display a list of grouped items in a vertical stack. The outer ItemsRepeater generates each group. In the template for each group, another ItemsRepeater generates the items.
 
 ```xaml
-<!-- xmlns:muxc="using:Microsoft.UI.Xaml.Controls" -->
 
 <Page.Resources>
-    <muxc:StackLayout x:Key="MyGroupLayout"/>
-    <muxc:StackLayout x:Key="MyItemLayout" Orientation="Horizontal"/>
+    <StackLayout x:Key="MyGroupLayout"/>
+    <StackLayout x:Key="MyItemLayout" Orientation="Horizontal"/>
 </Page.Resources>
 
 <ScrollViewer>
-  <muxc:ItemsRepeater ItemsSource="{x:Bind AppNotifications}"
+  <ItemsRepeater ItemsSource="{x:Bind AppNotifications}"
                       Layout="{StaticResource MyGroupLayout}">
-    <muxc:ItemsRepeater.ItemTemplate>
+    <ItemsRepeater.ItemTemplate>
       <DataTemplate x:DataType="ExampleApp:AppNotifications">
         <!-- Group -->
         <StackPanel>
           <!-- Header -->
           <TextBlock Text="{x:Bind AppTitle}"/>
           <!-- Items -->
-          <muxc:ItemsRepeater ItemsSource="{x:Bind Notifications}"
+          <ItemsRepeater ItemsSource="{x:Bind Notifications}"
                               Layout="{StaticResource MyItemLayout}"
                               ItemTemplate="{StaticResource MyTemplate}"/>
           <!-- Footer -->
           <Button Content="{x:Bind FooterText}"/>
         </StackPanel>
       </DataTemplate>
-    </muxc:ItemsRepeater.ItemTemplate>
-  </muxc:ItemsRepeater>
+    </ItemsRepeater.ItemTemplate>
+  </ItemsRepeater>
 </ScrollViewer>
 ```
 The image below shows the basic layout that's created using the above sample as a guideline.
@@ -642,22 +637,19 @@ The image below shows the basic layout that's created using the above sample as 
 This next example shows a layout for an app that has various categories that can change with user preference and are presented as horizontally scrolling lists. The layout of this example is also represented by the image above.
 
 ```xaml
-<!-- xmlns:muxc="using:Microsoft.UI.Xaml.Controls" -->
-<!-- Include the <muxc:ItemsRepeaterScrollHost> if targeting Windows 10 versions earlier than 1809. -->
 <ScrollViewer>
-  <muxc:ItemsRepeater ItemsSource="{x:Bind Categories}"
+  <ItemsRepeater ItemsSource="{x:Bind Categories}"
                       Background="LightGreen">
-    <muxc:ItemsRepeater.ItemTemplate>
+    <ItemsRepeater.ItemTemplate>
       <DataTemplate x:DataType="local:Category">
         <StackPanel Margin="12,0">
           <TextBlock Text="{x:Bind Name}" Style="{ThemeResource TitleTextBlockStyle}"/>
-          <!-- Include the <muxc:ItemsRepeaterScrollHost> if targeting Windows 10 versions earlier than 1809. -->
           <ScrollViewer HorizontalScrollMode="Enabled"
                                           VerticalScrollMode="Disabled"
                                           HorizontalScrollBarVisibility="Auto" >
-            <muxc:ItemsRepeater ItemsSource="{x:Bind Items}"
+            <ItemsRepeater ItemsSource="{x:Bind Items}"
                                 Background="Orange">
-              <muxc:ItemsRepeater.ItemTemplate>
+              <ItemsRepeater.ItemTemplate>
                 <DataTemplate x:DataType="local:CategoryItem">
                   <Grid Margin="10"
                         Height="60" Width="120"
@@ -667,16 +659,16 @@ This next example shows a layout for an app that has various categories that can
                                Margin="4"/>
                   </Grid>
                 </DataTemplate>
-              </muxc:ItemsRepeater.ItemTemplate>
-              <muxc:ItemsRepeater.Layout>
-                <muxc:StackLayout Orientation="Horizontal"/>
-              </muxc:ItemsRepeater.Layout>
-            </muxc:ItemsRepeater>
+              </ItemsRepeater.ItemTemplate>
+              <ItemsRepeater.Layout>
+                <StackLayout Orientation="Horizontal"/>
+              </ItemsRepeater.Layout>
+            </ItemsRepeater>
           </ScrollViewer>
         </StackPanel>
       </DataTemplate>
-    </muxc:ItemsRepeater.ItemTemplate>
-  </muxc:ItemsRepeater>
+    </ItemsRepeater.ItemTemplate>
+  </ItemsRepeater>
 </ScrollViewer>
 ```
 
@@ -741,7 +733,7 @@ public class MyPage : Page
 ### Keyboarding
 The minimal keyboarding support for focus movement that ItemsRepeater provides is based on XAML's [2D Directional Navigation for Keyboarding](../../../design/input/focus-navigation.md#2d-directional-navigation-for-keyboard).
 
-![Direction Navigation](/windows/uwp/design/input/images/keyboard/directional-navigation.png)
+![Direction Navigation](../../input/images/keyboard/directional-navigation.png)
 
 The ItemsRepeater's [XYFocusKeyboardNavigation mode](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.input.xyfocuskeyboardnavigationmode) is _Enabled_ by default. Depending on the intended experience, consider adding support for common [Keyboard Interactions](../../../design/input/keyboard-interactions.md) such as Home, End, PageUp, and PageDown.
 

--- a/hub/apps/develop/ui/controls/items-repeater.md
+++ b/hub/apps/develop/ui/controls/items-repeater.md
@@ -56,7 +56,7 @@ ItemsRepeater itemsRepeater1 = new ItemsRepeater();
 itemsRepeater1.ItemsSource = Items;
 ```
 
-You can also bind the **ItemsSource** property to a collection in XAML. For more info about data binding, see [Data binding overview](/windows/apps/develop/data-binding/data-binding-overview).
+You can also bind the **ItemsSource** property to a collection in XAML. For more info about data binding, see [Data binding overview](/windows/uwp/data-binding/data-binding-quickstart).
 
 ```xaml
 <ItemsRepeater ItemsSource="{x:Bind Items}"/>
@@ -209,14 +209,14 @@ private async void ScrollViewer_ViewChanged(object sender, ScrollViewerViewChang
 
         // trigger if within 2 viewports of the end
         if (distanceToEnd <= 2.0 * scroller.ViewportHeight
-                && MyItemsSource.HasMore && !MyItemsSource.Busy)
+                && MyItemsSource.HasMore && !itemsSource.Busy)
         {
             // show an indeterminate progress UI
             myLoadingIndicator.Visibility = Visibility.Visible;
 
             await MyItemsSource.LoadMoreItemsAsync(/*DataFetchSize*/);
 
-            myLoadingIndicator.Visibility = Visibility.Collapsed;
+            loadingIndicator.Visibility = Visibility.Collapsed;
         }
     }
 }
@@ -237,11 +237,12 @@ You can set the [Spacing](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.c
 This example shows how to set the ItemsRepeater.Layout property to a StackLayout with horizontal orientation and spacing of 8 pixels.
 
 ```xaml
-<ItemsRepeater ItemsSource="{x:Bind Items}" ItemTemplate="{StaticResource MyTemplate}">
-    <ItemsRepeater.Layout>
-        <StackLayout Orientation="Horizontal" Spacing="8"/>
-    </ItemsRepeater.Layout>
-</ItemsRepeater>
+<!-- xmlns:muxc="using:Microsoft.UI.Xaml.Controls" -->
+<muxc:ItemsRepeater ItemsSource="{x:Bind Items}" ItemTemplate="{StaticResource MyTemplate}">
+    <muxc:ItemsRepeater.Layout>
+        <muxc:StackLayout Orientation="Horizontal" Spacing="8"/>
+    </muxc:ItemsRepeater.Layout>
+</muxc:ItemsRepeater>
 ```
 
 ### UniformGridLayout
@@ -294,14 +295,15 @@ This image shows the effect of the **ItemsStretch** values in a vertical layout 
 This example shows how to set the **ItemsRepeater.Layout** property to a **UniformGridLayout**.
 
 ```xaml
-<ItemsRepeater ItemsSource="{x:Bind Items}"
+<!-- xmlns:muxc="using:Microsoft.UI.Xaml.Controls" -->
+<muxc:ItemsRepeater ItemsSource="{x:Bind Items}"
                     ItemTemplate="{StaticResource MyTemplate}">
-    <ItemsRepeater.Layout>
-        <UniformGridLayout MinItemWidth="200"
+    <muxc:ItemsRepeater.Layout>
+        <muxc:UniformGridLayout MinItemWidth="200"
                                 MinColumnSpacing="28"
                                 ItemsJustification="SpaceAround"/>
-    </ItemsRepeater.Layout>
-</ItemsRepeater>
+    </muxc:ItemsRepeater.Layout>
+</muxc:ItemsRepeater>
 ```
 
 ## Lifecycle events
@@ -320,15 +322,16 @@ In a virtualizing control, you cannot rely on Loaded/Unloaded events because the
 This example shows how you could use these events to attach a custom selection service to track item selection in a custom control that uses ItemsRepeater to display items.
 
 ```xaml
+<!-- xmlns:muxc="using:Microsoft.UI.Xaml.Controls" -->
 <UserControl ...>
     ...
     <ScrollViewer>
-        <ItemsRepeater ItemsSource="{x:Bind Items}"
+        <muxc:ItemsRepeater ItemsSource="{x:Bind Items}"
                             ItemTemplate="{StaticResource MyTemplate}"
                             ElementPrepared="OnElementPrepared"
                             ElementIndexChanged="OnElementIndexChanged"
                             ElementClearing="OnElementClearing">
-        </ItemsRepeater>
+        </muxc:ItemsRepeater>
     </ScrollViewer>
     ...
 </UserControl>
@@ -534,6 +537,7 @@ You can use the [ItemsRepeater](/windows/windows-app-sdk/api/winrt/microsoft.ui.
 This example shows how to place an [ItemsRepeater](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.itemsrepeater) in the template of a custom control named _MediaCollectionView_ and expose its properties.
 
 ```xaml
+<!-- xmlns:muxc="using:Microsoft.UI.Xaml.Controls" -->
 <Style TargetType="local:MediaCollectionView">
     <Setter Property="Template">
         <Setter.Value>
@@ -543,7 +547,7 @@ This example shows how to place an [ItemsRepeater](/windows/windows-app-sdk/api/
                     BorderBrush="{TemplateBinding BorderBrush}"
                     BorderThickness="{TemplateBinding BorderThickness}">
                     <ScrollViewer x:Name="ScrollViewer">
-                        <ItemsRepeater x:Name="ItemsRepeater"
+                        <muxc:ItemsRepeater x:Name="ItemsRepeater"
                                             ItemsSource="{TemplateBinding ItemsSource}"
                                             ItemTemplate="{TemplateBinding ItemTemplate}"
                                             Layout="{TemplateBinding Layout}"
@@ -603,31 +607,32 @@ You can nest an [ItemsRepeater](/windows/windows-app-sdk/api/winrt/microsoft.ui.
 This example shows how you can display a list of grouped items in a vertical stack. The outer ItemsRepeater generates each group. In the template for each group, another ItemsRepeater generates the items.
 
 ```xaml
+<!-- xmlns:muxc="using:Microsoft.UI.Xaml.Controls" -->
 
 <Page.Resources>
-    <StackLayout x:Key="MyGroupLayout"/>
-    <StackLayout x:Key="MyItemLayout" Orientation="Horizontal"/>
+    <muxc:StackLayout x:Key="MyGroupLayout"/>
+    <muxc:StackLayout x:Key="MyItemLayout" Orientation="Horizontal"/>
 </Page.Resources>
 
 <ScrollViewer>
-  <ItemsRepeater ItemsSource="{x:Bind AppNotifications}"
+  <muxc:ItemsRepeater ItemsSource="{x:Bind AppNotifications}"
                       Layout="{StaticResource MyGroupLayout}">
-    <ItemsRepeater.ItemTemplate>
+    <muxc:ItemsRepeater.ItemTemplate>
       <DataTemplate x:DataType="ExampleApp:AppNotifications">
         <!-- Group -->
         <StackPanel>
           <!-- Header -->
           <TextBlock Text="{x:Bind AppTitle}"/>
           <!-- Items -->
-          <ItemsRepeater ItemsSource="{x:Bind Notifications}"
+          <muxc:ItemsRepeater ItemsSource="{x:Bind Notifications}"
                               Layout="{StaticResource MyItemLayout}"
                               ItemTemplate="{StaticResource MyTemplate}"/>
           <!-- Footer -->
           <Button Content="{x:Bind FooterText}"/>
         </StackPanel>
       </DataTemplate>
-    </ItemsRepeater.ItemTemplate>
-  </ItemsRepeater>
+    </muxc:ItemsRepeater.ItemTemplate>
+  </muxc:ItemsRepeater>
 </ScrollViewer>
 ```
 The image below shows the basic layout that's created using the above sample as a guideline.
@@ -637,19 +642,22 @@ The image below shows the basic layout that's created using the above sample as 
 This next example shows a layout for an app that has various categories that can change with user preference and are presented as horizontally scrolling lists. The layout of this example is also represented by the image above.
 
 ```xaml
+<!-- xmlns:muxc="using:Microsoft.UI.Xaml.Controls" -->
+<!-- Include the <muxc:ItemsRepeaterScrollHost> if targeting Windows 10 versions earlier than 1809. -->
 <ScrollViewer>
-  <ItemsRepeater ItemsSource="{x:Bind Categories}"
+  <muxc:ItemsRepeater ItemsSource="{x:Bind Categories}"
                       Background="LightGreen">
-    <ItemsRepeater.ItemTemplate>
+    <muxc:ItemsRepeater.ItemTemplate>
       <DataTemplate x:DataType="local:Category">
         <StackPanel Margin="12,0">
           <TextBlock Text="{x:Bind Name}" Style="{ThemeResource TitleTextBlockStyle}"/>
+          <!-- Include the <muxc:ItemsRepeaterScrollHost> if targeting Windows 10 versions earlier than 1809. -->
           <ScrollViewer HorizontalScrollMode="Enabled"
                                           VerticalScrollMode="Disabled"
                                           HorizontalScrollBarVisibility="Auto" >
-            <ItemsRepeater ItemsSource="{x:Bind Items}"
+            <muxc:ItemsRepeater ItemsSource="{x:Bind Items}"
                                 Background="Orange">
-              <ItemsRepeater.ItemTemplate>
+              <muxc:ItemsRepeater.ItemTemplate>
                 <DataTemplate x:DataType="local:CategoryItem">
                   <Grid Margin="10"
                         Height="60" Width="120"
@@ -659,16 +667,16 @@ This next example shows a layout for an app that has various categories that can
                                Margin="4"/>
                   </Grid>
                 </DataTemplate>
-              </ItemsRepeater.ItemTemplate>
-              <ItemsRepeater.Layout>
-                <StackLayout Orientation="Horizontal"/>
-              </ItemsRepeater.Layout>
-            </ItemsRepeater>
+              </muxc:ItemsRepeater.ItemTemplate>
+              <muxc:ItemsRepeater.Layout>
+                <muxc:StackLayout Orientation="Horizontal"/>
+              </muxc:ItemsRepeater.Layout>
+            </muxc:ItemsRepeater>
           </ScrollViewer>
         </StackPanel>
       </DataTemplate>
-    </ItemsRepeater.ItemTemplate>
-  </ItemsRepeater>
+    </muxc:ItemsRepeater.ItemTemplate>
+  </muxc:ItemsRepeater>
 </ScrollViewer>
 ```
 
@@ -733,7 +741,7 @@ public class MyPage : Page
 ### Keyboarding
 The minimal keyboarding support for focus movement that ItemsRepeater provides is based on XAML's [2D Directional Navigation for Keyboarding](../../../design/input/focus-navigation.md#2d-directional-navigation-for-keyboard).
 
-![Direction Navigation](../../input/images/keyboard/directional-navigation.png)
+![Direction Navigation](/windows/uwp/design/input/images/keyboard/directional-navigation.png)
 
 The ItemsRepeater's [XYFocusKeyboardNavigation mode](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.input.xyfocuskeyboardnavigationmode) is _Enabled_ by default. Depending on the intended experience, consider adding support for common [Keyboard Interactions](../../../design/input/keyboard-interactions.md) such as Home, End, PageUp, and PageDown.
 


### PR DESCRIPTION
Update code samples and API references in XAML platform documentation to use WinUI 3 / Windows App SDK patterns instead of UWP.

Changes

events-and-routed-events-overview.md

 - Update C++/WinRT namespaces: Windows::UI::Xaml:: → Microsoft::UI::Xaml::
 - Fix incorrect event handler type: MouseEventHandler → PointerEventHandler
 - Remove duplicate PointerWheelChanged entry in routed events list
 - Replace deprecated controls with WinUI 3 equivalents:
  - MediaElement → MediaPlayerElement
  - WebView → WebView2

xaml-resource-dictionary.md

 - Update C++/WinRT code: Window::Current() → m_window (private field pattern)
 - Update Colors API: Windows::UI::Colors::Green() → Microsoft::UI::Colors::Green()

Why these changes?

These pages are in the Windows App SDK documentation area but contained UWP code patterns that won't compile in WinUI 3 projects.