### PR TITLE
[develop] Fix: UWP→WinUI migration — input & devices (kbridge)

### DIFF
--- a/hub/apps/design/accessibility/accessible-text-requirements.md
+++ b/hub/apps/design/accessibility/accessible-text-requirements.md
@@ -143,7 +143,7 @@ Avoid disabling text scaling broadly. Consistent cross-app text scaling is an im
 WinUI text controls support the full text scaling experience without any customization or templating. For other WinRT-based apps, you can monitor [**TextScaleFactorChanged**](/uwp/api/windows.ui.viewmanagement.uisettings.textscalefactorchanged) and get the [**TextScaleFactor**](/uwp/api/windows.ui.viewmanagement.uisettings.textscalefactor) to react to system text size changes:
 
 ```csharp
-private readonly Windows.UI.ViewManagement.UISettings _uiSettings = new();
+private readonly Microsoft.UI.Windowing.UISettings _uiSettings = new();
 
 public MainWindow()
 {
@@ -151,7 +151,7 @@ public MainWindow()
     _uiSettings.TextScaleFactorChanged += UISettings_TextScaleFactorChanged;
 }
 
-private void UISettings_TextScaleFactorChanged(Windows.UI.ViewManagement.UISettings sender, object args)
+private void UISettings_TextScaleFactorChanged(Microsoft.UI.Windowing.UISettings sender, object args)
 {
     // Marshal to the UI thread before applying layout or visual updates.
     DispatcherQueue.TryEnqueue(() =>

--- a/hub/apps/design/accessibility/system-button-narration.md
+++ b/hub/apps/design/accessibility/system-button-narration.md
@@ -13,14 +13,14 @@ ms.localizationpriority: medium
 
 Screen-readers, such as [Narrator](https://support.microsoft.com/en-us/windows/complete-guide-to-narrator-e4397a0d-ef4f-b386-d8ae-c172f109bdb1), must be able to recognize and handle hardware system button events and communicate their state to users. In some cases, the screen reader might need to handle these hardware button events exclusively and not let them bubble up to other handlers.
 
-To listen for and handle the **Fn** hardware system button events in the same way as other hardware buttons, use [SystemButtonEventController](/uwp/api/windows.ui.input.systembuttoneventcontroller) in the [Windows.UI.Input](/uwp/api/windows.ui.input) namespace of the Windows SDK.
+To listen for and handle the **Fn** hardware system button events in the same way as other hardware buttons, use [SystemButtonEventController](/uwp/api/windows.ui.input.systembuttoneventcontroller) in the [Windows.UI.Input](/windows/windows-app-sdk/api/winrt/microsoft.ui.input) namespace of the Windows SDK.
 
 For WinUI 3 / Windows App SDK apps, this API is still consumed from the Windows namespace (`winrt::Windows::UI::Input`) rather than `Microsoft.UI.*`.
 
 > [!NOTE]
 > Fn button support is OEM-specific and can include features such as the ability to toggle/lock on or off (vs. a press-and-hold key combination), along with a corresponding lock indicator light (which might not be helpful to users who are blind or have a vision impairment).
 
-Fn button events are exposed through [SystemButtonEventController](/uwp/api/windows.ui.input.systembuttoneventcontroller) in the [Windows.UI.Input](/uwp/api/windows.ui.input) namespace. The SystemButtonEventController object supports the following events:
+Fn button events are exposed through [SystemButtonEventController](/uwp/api/windows.ui.input.systembuttoneventcontroller) in the [Windows.UI.Input](/windows/windows-app-sdk/api/winrt/microsoft.ui.input) namespace. The SystemButtonEventController object supports the following events:
 
 - [SystemFunctionButtonPressed](/uwp/api/windows.ui.input.systembuttoneventcontroller.systemfunctionbuttonpressed)
 - [SystemFunctionButtonReleased](/uwp/api/windows.ui.input.systembuttoneventcontroller.systemfunctionbuttonreleased)

--- a/hub/apps/design/globalizing/adjust-layout-and-fonts--and-support-rtl.md
+++ b/hub/apps/design/globalizing/adjust-layout-and-fonts--and-support-rtl.md
@@ -42,7 +42,7 @@ If your app has images that must be mirrored (that is, the same image can be fli
 If your app requires a different image to flip the image correctly, then you can use the resource management system with the `LayoutDirection` qualifier (see the LayoutDirection section of [Tailor your resources for language, scale, and other qualifiers](/windows/apps/windows-app-sdk/mrtcore/tailor-resources-lang-scale-contrast#layoutdirection)). The system chooses an image named `file.layoutdir-rtl.png` when the app runtime language (see [Understand user profile languages and app manifest languages](manage-language-and-region.md)) is set to an RTL language. This approach may be necessary when some part of the image is flipped, but another part isn't.
 
 ## Handling right-to-left (RTL) languages
-When your app is localized for right-to-left (RTL) languages, use the [**FrameworkElement.FlowDirection**](/uwp/api/Windows.UI.Xaml.FrameworkElement.FlowDirection) property, and set symmetrical padding and margins. Layout panels such as [**Grid**](/uwp/api/Windows.UI.Xaml.Controls.Grid?branch=live) scale and flip automatically with the value of **FlowDirection** that you set.
+When your app is localized for right-to-left (RTL) languages, use the [**FrameworkElement.FlowDirection**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.FrameworkElement.FlowDirection) property, and set symmetrical padding and margins. Layout panels such as [**Grid**](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.Controls.Grid?branch=live) scale and flip automatically with the value of **FlowDirection** that you set.
 
 Set **FlowDirection** on the root layout panel (or frame) of your Page, or on the Page itself. This causes all of the controls contained within to inherit that property.
 
@@ -59,11 +59,11 @@ this.languageTag = Windows.Globalization.ApplicationLanguages.Languages[0];
 var flowDirectionSetting = Windows.ApplicationModel.Resources.Core.ResourceContext.GetForCurrentView().QualifierValues["LayoutDirection"];
 if (flowDirectionSetting == "LTR")
 {
-    this.layoutRoot.FlowDirection = Windows.UI.Xaml.FlowDirection.LeftToRight;
+    this.layoutRoot.FlowDirection = Microsoft.UI.Xaml.FlowDirection.LeftToRight;
 }
 else
 {
-    this.layoutRoot.FlowDirection = Windows.UI.Xaml.FlowDirection.RightToLeft;
+    this.layoutRoot.FlowDirection = Microsoft.UI.Xaml.FlowDirection.RightToLeft;
 }
 ```
 
@@ -79,11 +79,11 @@ m_languageTag = Windows::Globalization::ApplicationLanguages::Languages().GetAt(
 auto flowDirectionSetting = Windows::ApplicationModel::Resources::Core::ResourceContext::GetForCurrentView().QualifierValues().Lookup(L"LayoutDirection");
 if (flowDirectionSetting == L"LTR")
 {
-    layoutRoot().FlowDirection(Windows::UI::Xaml::FlowDirection::LeftToRight);
+    layoutRoot().FlowDirection(Microsoft::UI::Xaml::FlowDirection::LeftToRight);
 }
 else
 {
-    layoutRoot().FlowDirection(Windows::UI::Xaml::FlowDirection::RightToLeft);
+    layoutRoot().FlowDirection(Microsoft::UI::Xaml::FlowDirection::RightToLeft);
 }
 ```
 
@@ -95,11 +95,11 @@ this->languageTag = Windows::Globalization::ApplicationLanguages::Languages->Get
 auto flowDirectionSetting = Windows::ApplicationModel::Resources::Core::ResourceContext::GetForCurrentView()->QualifierValues->Lookup("LayoutDirection");
 if (flowDirectionSetting == "LTR")
 {
-    this->layoutRoot->FlowDirection = Windows::UI::Xaml::FlowDirection::LeftToRight;
+    this->layoutRoot->FlowDirection = Microsoft::UI::Xaml::FlowDirection::LeftToRight;
 }
 else
 {
-    this->layoutRoot->FlowDirection = Windows::UI::Xaml::FlowDirection::RightToLeft;
+    this->layoutRoot->FlowDirection = Microsoft::UI::Xaml::FlowDirection::RightToLeft;
 }
 ```
 

--- a/hub/apps/develop/devices-sensors/scan-from-your-app.md
+++ b/hub/apps/develop/devices-sensors/scan-from-your-app.md
@@ -50,29 +50,25 @@ Windows does not detect scanners automatically. You must perform this step in or
 3.  Create an event handler for when a scanner is added.
 
 ```csharp
-    private async void OnScannerAdded(DeviceWatcher sender,  DeviceInformation deviceInfo)
+    private void OnScannerAdded(DeviceWatcher sender,  DeviceInformation deviceInfo)
     {
-       await
-       MainPage.Current.Dispatcher.RunAsync(
-             Windows.UI.Core.CoreDispatcherPriority.Normal,
-             () =>
-             {
-                MainPage.Current.NotifyUser(String.Format("Scanner with device id {0} has been added", deviceInfo.Id), NotifyType.StatusMessage);
+       MainPage.Current.DispatcherQueue.TryEnqueue(() =>
+       {
+          MainPage.Current.NotifyUser(String.Format("Scanner with device id {0} has been added", deviceInfo.Id), NotifyType.StatusMessage);
 
-                // search the device list for a device with a matching device id
-                ScannerDataItem match = FindInList(deviceInfo.Id);
+          // search the device list for a device with a matching device id
+          ScannerDataItem match = FindInList(deviceInfo.Id);
 
-                // If we found a match then mark it as verified and return
-                if (match != null)
-                {
-                   match.Matched = true;
-                   return;
-                }
+          // If we found a match then mark it as verified and return
+          if (match != null)
+          {
+             match.Matched = true;
+             return;
+          }
 
-                // Add the new element to the end of the list of devices
-                AppendToList(deviceInfo);
-             }
-       );
+          // Add the new element to the end of the list of devices
+          AppendToList(deviceInfo);
+       });
     }
 ```
 

--- a/hub/apps/windows-app-sdk/mrtcore/tailor-resources-lang-scale-contrast.md
+++ b/hub/apps/windows-app-sdk/mrtcore/tailor-resources-lang-scale-contrast.md
@@ -166,7 +166,7 @@ See [Localize your UI strings](localize-strings.md) for more information on maki
 
 ## LayoutDirection
 
-A `layoutdirection` qualifier corresponds to the layout direction of the display language setting. For example, an image may need to be mirrored for a right-to-left language such as Arabic or Hebrew. Layout panels and images in your UI will respond to layout direction appropriately if you set their [FlowDirection](/uwp/api/Windows.UI.Xaml.FrameworkElement.FlowDirection) property (see [Adjust layout and fonts, and support RTL](/windows/apps/design/globalizing/adjust-layout-and-fonts--and-support-rtl)). However, the `layoutdirection` qualifier is for cases where simple flipping isn't adequate, and it allows you to respond to the directionality of specific reading order and text alignment in more general ways.
+A `layoutdirection` qualifier corresponds to the layout direction of the display language setting. For example, an image may need to be mirrored for a right-to-left language such as Arabic or Hebrew. Layout panels and images in your UI will respond to layout direction appropriately if you set their [FlowDirection](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.FrameworkElement.FlowDirection) property (see [Adjust layout and fonts, and support RTL](/windows/apps/design/globalizing/adjust-layout-and-fonts--and-support-rtl)). However, the `layoutdirection` qualifier is for cases where simple flipping isn't adequate, and it allows you to respond to the directionality of specific reading order and text alignment in more general ways.
 
 ## Scale
 

--- a/hub/apps/winui/winui3/xaml-templated-controls-winui-3.md
+++ b/hub/apps/winui/winui3/xaml-templated-controls-winui-3.md
@@ -75,7 +75,7 @@ public BgLabelControl()
 }
 ```
 
-Our templated control will have a text label that can be set programmatically in code, in XAML, or via data binding. In order for the system to keep the text of our control's label up to date, it needs to be implemented as a [DependencyPropety](/uwp/api/Windows.UI.Xaml.DependencyProperty). To do this, first we declare a string property and call it **Label**. Instead of using a backing variable, we set and get the value of our dependency property by calling [GetValue](/uwp/api/windows.ui.xaml.dependencyobject.getvalue) and [SetValue](/uwp/api/windows.ui.xaml.dependencyobject.setvalue). These methods are provided by the [DependencyObject](/uwp/api/windows.ui.xaml.dependencyobject), which **Microsoft.UI.Xaml.Controls.Control** inherits.
+Our templated control will have a text label that can be set programmatically in code, in XAML, or via data binding. In order for the system to keep the text of our control's label up to date, it needs to be implemented as a [DependencyPropety](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.DependencyProperty). To do this, first we declare a string property and call it **Label**. Instead of using a backing variable, we set and get the value of our dependency property by calling [GetValue](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.dependencyobject.getvalue) and [SetValue](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.dependencyobject.setvalue). These methods are provided by the [DependencyObject](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.dependencyobject), which **Microsoft.UI.Xaml.Controls.Control** inherits.
 
 ```csharp
 public string Label
@@ -84,7 +84,7 @@ public string Label
     set => SetValue(LabelProperty, value);
 }
 ```
-Next, declare the dependency property and register it with the system by calling [DependencyProperty.Register](/uwp/api/windows.ui.xaml.dependencyproperty.register). This method specifies the name and type of our **Label** property, the type of the owner of the property, our **BgLabelControl** class, and the default value for the property.
+Next, declare the dependency property and register it with the system by calling [DependencyProperty.Register](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.dependencyproperty.register). This method specifies the name and type of our **Label** property, the type of the owner of the property, our **BgLabelControl** class, and the default value for the property.
 
 ```csharp
 DependencyProperty LabelProperty = DependencyProperty.Register(
@@ -218,12 +218,12 @@ namespace winrt::BgLabelControlApp::implementation
 
 This walkthrough won't use the **OnLabelChanged** callback, but it's provided so that you can see how to register a dependency property with a property-changed callback. The implementation of **OnLabelChanged** also shows how to obtain a derived projected type from a base projected type (the base projected type is DependencyObject, in this case). And it shows how to then obtain a pointer to the type that implements the projected type. That second operation will naturally only be possible in the project that implements the projected type (that is, the project that implements the runtime class).
 
-The [xaml_typename](/uwp/cpp-ref-for-winrt/xaml-typename) function is provided by the Windows.UI.Xaml.Interop namespace that is not included by default in the WinUI project template. Add a line to the precompiled header file for your project, `pch.h`, to include the header file associated with this namespace.
+The [xaml_typename](/uwp/cpp-ref-for-winrt/xaml-typename) function is provided by the Microsoft.UI.Xaml.Interop namespace that is not included by default in the WinUI project template. Add a line to the precompiled header file for your project, `pch.h`, to include the header file associated with this namespace.
 
 ```cppwinrt
 // pch.h
 ...
-#include <winrt/Windows.UI.Xaml.Interop.h>
+#include <winrt/Microsoft.UI.Xaml.Interop.h>
 ...
 ```
 


### PR DESCRIPTION
## Summary
Fixes UWP→WinUI 3 migration issues for kbridge-owned input and device docs.
Verified all pages in `fix-uwp-migration-kbridge-input-devices-1.md`; applied only the documented namespace, API-pattern, and link fixes whose replacement targets were reachable.

## Owner
**kbridge** (resolved via: docfx_file_metadata)

## Root Causes
1. **UWP→WinUI 3 namespace and reference migration**: updated WinUI/XAML namespace references, WinUI API links, and the scanner dispatcher pattern.

## Changes
- 6 files modified across 6 pages
- Fix types: namespace replacement, link replacement, API pattern update

## Affected pages
| Page | Status |
|---|---|
| https://learn.microsoft.com/en-us/windows/apps/design/accessibility/accessible-text-requirements | Updated `UISettings` namespace references; skipped replacement of unreachable `TextScaleFactor*` links |
| https://learn.microsoft.com/en-us/windows/apps/design/globalizing/adjust-layout-and-fonts--and-support-rtl | Updated FlowDirection links and WinUI namespace references |
| https://learn.microsoft.com/en-us/windows/apps/design/accessibility/custom-automation-peers | No change needed after source verification |
| https://learn.microsoft.com/en-us/windows/apps/design/accessibility/system-button-narration | Updated reachable namespace link; kept unreachable `SystemButtonEventController*` replacements unchanged |
| https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/mrtcore/tailor-resources-lang-scale-contrast | Updated FlowDirection link |
| https://learn.microsoft.com/en-us/windows/apps/winui/winui3/xaml-templated-controls-winui-3 | Updated WinUI dependency-property links and interop namespace/header references |
| https://learn.microsoft.com/en-us/windows/apps/design/globalizing/manage-language-and-region | No change; replacement `ResourceContext.*` links returned 404 |
| https://learn.microsoft.com/en-us/windows/apps/develop/devices-sensors/scan-from-your-app | Replaced `Dispatcher.RunAsync` pattern with `DispatcherQueue.TryEnqueue` |

## Cross-owner Dependencies
None

## Link validation
Validated every modified link in the diff with HTTP HEAD. Skipped fix-file replacements whose specified destination links returned 404.

## Note
Requested labels `auto-fix` and `documentation` are not defined in `MicrosoftDocs/windows-dev-docs`, so labels were not applied.

## Source
Generated by page-analyzer pipeline from `fix-uwp-migration-kbridge-input-devices-1.md`