### PR TITLE
[develop] Fix: UWP→WinAppSDK migration — security terminology

### DIFF
--- a/hub/apps/develop/security/common-cryptography-tasks.md
+++ b/hub/apps/develop/security/common-cryptography-tasks.md
@@ -1,6 +1,6 @@
 ---
 title: Common cryptography tasks
-description: These articles provide example code for common Universal Windows Platform (UWP) cryptography tasks, such as creating random numbers, comparing buffers, converting between strings and binary data, copying to and from byte arrays, and encoding and decoding data.
+description: These articles provide example code for common WinUI cryptography tasks, such as creating random numbers, comparing buffers, converting between strings and binary data, copying to and from byte arrays, and encoding and decoding data.
 ms.assetid: 2DE094F4-28E2-4C5D-BF8C-617BD90AB119
 ms.date: 02/08/2017
 ms.topic: article
@@ -9,7 +9,7 @@ ms.localizationpriority: medium
 ---
 # Common cryptography tasks
 
-These articles provide example code for common Universal Windows Platform (UWP) cryptography tasks, such as creating random numbers, comparing buffers, converting between strings and binary data, copying to and from byte arrays, and encoding and decoding data.
+These articles provide example code for common WinUI cryptography tasks, such as creating random numbers, comparing buffers, converting between strings and binary data, copying to and from byte arrays, and encoding and decoding data.
 
 | Topic                                                                                 | Description                                                                                            |
 |---------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
Updates UWP terminology to WinUI in cryptography documentation.