### PR TITLE
[develop] Fix: UWP→WinAppSDK migration — desktop & applifecycle

### DIFF
--- a/hub/apps/desktop/modernize/ui/apply-mica-win32.md
+++ b/hub/apps/desktop/modernize/ui/apply-mica-win32.md
@@ -33,7 +33,7 @@ The MicaController reacts to the system Light and Dark themes by default. To ove
 > [!TIP]
 > The code in this section is taken from the [Windows App SDK Win32 Mica sample on GitHub](https://github.com/microsoft/WindowsAppSDK-Samples/tree/main/Samples/Mica/cpp-win32). See the GitHub repo for the full code. These examples use [C++/WinRT](/windows/uwp/cpp-and-winrt-apis/).
 
-To enable Mica, you need a reference to the Windows App SDK, a [Compositor](/uwp/api/windows.ui.composition.compositor), and a [DispatcherQueue](/uwp/api/windows.system.dispatcherqueue).
+To enable Mica, you need a reference to the Windows App SDK, a [Compositor](/windows/windows-app-sdk/api/winrt/microsoft.ui.composition.compositor), and a [DispatcherQueue](/uwp/api/windows.system.dispatcherqueue).
 
 This example shows how to do the following to set up an unpackaged app:
 

--- a/hub/apps/windows-app-sdk/applifecycle/focus-session.md
+++ b/hub/apps/windows-app-sdk/applifecycle/focus-session.md
@@ -97,12 +97,12 @@ private void Manager_IsFocusActiveChanged(Windows.UI.Shell.FocusSessionManager s
 ```cpp
 // pch.h
 ...
-#include <winrt/Windows.UI.Shell.h
-#include <winrt/Windows.UI.Xaml.Navigation.h>
+#include <winrt/Windows.UI.Shell.h>
+#include <winrt/Microsoft.UI.Xaml.Navigation.h>
 
 // MainWindow.xaml.h
 ...
-void OnNavigatedTo(Windows::UI::Xaml::Navigation::NavigationEventArgs const&);
+void OnNavigatedTo(Microsoft::UI::Xaml::Navigation::NavigationEventArgs const&);
 
 Windows::UI::Shell::FocusSessionManager m_focusSessionManager = Windows::UI::Shell::FocusSessionManager::GetDefault();
 winrt::event_token m_focusStateChangedToken;
@@ -111,7 +111,7 @@ void OnFocusStateChanged(Windows::UI::Shell::FocusSessionManager const& sender, 
 
 // MainWindow.xaml.cpp
 ...
-void MainWindow::OnNavigatedTo(Windows::UI::Xaml::Navigation::NavigationEventArgs const&)
+void MainWindow::OnNavigatedTo(Microsoft::UI::Xaml::Navigation::NavigationEventArgs const&)
 {
     if (Windows::UI::Shell::FocusSessionManager::IsSupported())
     {


### PR DESCRIPTION
Migrates UWP API links to WinAppSDK equivalents in desktop modernization and app lifecycle pages.